### PR TITLE
Allow splitting Serial into Reader and Writer

### DIFF
--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 cfg-if = "0.1.7"
 nb = "0.1.2"
 ufmt = "0.1.0"
+paste = "0.1.18"
 
 [dependencies.embedded-hal]
 version = "0.2.3"

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -9,6 +9,8 @@ pub extern crate nb;
 pub extern crate void;
 #[doc(hidden)]
 pub extern crate ufmt;
+#[doc(hidden)]
+pub extern crate paste;
 
 pub mod clock;
 pub mod delay;

--- a/avr-hal-generic/src/serial.rs
+++ b/avr-hal-generic/src/serial.rs
@@ -89,6 +89,32 @@ macro_rules! impl_usart {
                     _clock: ::core::marker::PhantomData,
                 }
             }
+		}
+
+		$crate::paste::item! {
+	        impl<CLOCK, RX_MODE> $Usart<CLOCK, RX_MODE>
+	        where
+	            CLOCK: $crate::clock::Clock,
+	            RX_MODE: $crate::port::mode::InputMode,
+	        {
+	            /// Helper method for splitting this read/write object into two halves.
+	            ///
+	            /// The two halves returned implement the `Read` and `Write` traits, respectively.
+	            pub fn split(self) -> ([<Read $Usart>]<CLOCK, RX_MODE>, [<Write $Usart>]<CLOCK>) {
+	                (
+	                    [<Read $Usart>] {
+	                        p: unsafe { ::core::ptr::read(&self.p) },
+	                        rx: self.rx,
+	                        _clock: self._clock,
+	                    },
+	                    [<Write $Usart>] {
+	                        p: self.p,
+	                        tx: self.tx,
+	                        _clock: self._clock,
+	                    }
+	                )
+	            }
+	        }
         }
 
         impl<CLOCK, RX_MODE> $crate::hal::serial::Write<u8> for $Usart<CLOCK, RX_MODE>
@@ -146,6 +172,115 @@ macro_rules! impl_usart {
 
                 Ok(self.p.$data.read().bits())
             }
+        }
+
+		$crate::paste::item! {
+			/// The readable half of the
+	        $(#[$usart_attr])*
+	        pub struct [<Read $Usart>]<CLOCK, RX_MODE>
+	        where
+	            CLOCK: $crate::clock::Clock,
+	            RX_MODE: $crate::port::mode::InputMode,
+	        {
+	            p: $USART,
+	            rx: $rxmod::$RX<$crate::port::mode::Input<RX_MODE>>,
+	            _clock: ::core::marker::PhantomData<CLOCK>,
+	        }
+
+			/// The writable half of the
+	        $(#[$usart_attr])*
+	        pub struct [<Write $Usart>]<CLOCK>
+	        where
+	            CLOCK: $crate::clock::Clock,
+	        {
+	            p: $USART,
+	            tx: $txmod::$TX<$crate::port::mode::Output>,
+	            _clock: ::core::marker::PhantomData<CLOCK>,
+	        }
+
+	        impl<CLOCK, RX_MODE> [<Read $Usart>]<CLOCK, RX_MODE>
+	        where
+	            CLOCK: $crate::clock::Clock,
+	            RX_MODE: $crate::port::mode::InputMode,
+	        {
+	            /// Puts the two "halves" of a split `Read + Write` back together.
+	            pub fn reunite(self, other: [<Write $Usart>]<CLOCK>) -> $Usart<CLOCK, RX_MODE> {
+	                $Usart {
+	                    p: self.p,
+	                    rx: self.rx,
+	                    tx: other.tx,
+	                    _clock: self._clock,
+	                }
+	            }
+	        }
+
+	        impl<CLOCK> [<Write $Usart>]<CLOCK>
+	        where
+	            CLOCK: $crate::clock::Clock,
+	        {
+	            /// Puts the two "halves" of a split `Read + Write` back together.
+	            pub fn reunite<RX_MODE>(self, other: [<Read $Usart>]<CLOCK, RX_MODE>) -> $Usart<CLOCK, RX_MODE>
+	            where
+	                RX_MODE: $crate::port::mode::InputMode,
+	            {
+	                other.reunite(self)
+	            }
+	        }
+
+	        impl<CLOCK> $crate::hal::serial::Write<u8> for [<Write $Usart>]<CLOCK>
+	        where
+	            CLOCK: $crate::clock::Clock,
+	        {
+	            type Error = $crate::serial::Error;
+
+	            fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
+	                // Call flush to make sure the data-register is empty
+	                self.flush()?;
+
+	                self.p.$data.write(|w| unsafe { w.bits(byte) });
+	                Ok(())
+	            }
+
+	            fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
+	                if self.p.$control_a.read().$dre().bit_is_clear() {
+	                    Err($crate::nb::Error::WouldBlock)
+	                } else {
+	                    Ok(())
+	                }
+	            }
+	        }
+
+	        impl<CLOCK> $crate::ufmt::uWrite for [<Write $Usart>]<CLOCK>
+	        where
+	            CLOCK: $crate::clock::Clock,
+	        {
+	            type Error = $crate::serial::Error;
+
+	            fn write_str(&mut self, s: &str) -> ::core::result::Result<(), Self::Error> {
+	                use $crate::prelude::*;
+
+	                for b in s.as_bytes().iter() {
+	                    $crate::nb::block!(self.write(*b))?;
+	                }
+	                Ok(())
+	            }
+	        }
+
+	        impl<CLOCK, RX_MODE> $crate::hal::serial::Read<u8> for [<Read $Usart>]<CLOCK, RX_MODE>
+	        where
+	            CLOCK: $crate::clock::Clock,
+	            RX_MODE: $crate::port::mode::InputMode,
+	        {
+	            type Error = $crate::serial::Error;
+
+	            fn read(&mut self) -> $crate::nb::Result<u8, Self::Error> {
+	                if self.p.$control_a.read().$rxc().bit_is_clear() {
+	                    return Err($crate::nb::Error::WouldBlock);
+	                }
+
+	                Ok(self.p.$data.read().bits())
+	            }
+	        }
         }
     };
 }

--- a/avr-hal-generic/src/serial.rs
+++ b/avr-hal-generic/src/serial.rs
@@ -89,32 +89,32 @@ macro_rules! impl_usart {
                     _clock: ::core::marker::PhantomData,
                 }
             }
-		}
+        }
 
-		$crate::paste::item! {
-	        impl<CLOCK, RX_MODE> $Usart<CLOCK, RX_MODE>
-	        where
-	            CLOCK: $crate::clock::Clock,
-	            RX_MODE: $crate::port::mode::InputMode,
-	        {
-	            /// Helper method for splitting this read/write object into two halves.
-	            ///
-	            /// The two halves returned implement the `Read` and `Write` traits, respectively.
-	            pub fn split(self) -> ([<Read $Usart>]<CLOCK, RX_MODE>, [<Write $Usart>]<CLOCK>) {
-	                (
-	                    [<Read $Usart>] {
-	                        p: unsafe { ::core::ptr::read(&self.p) },
-	                        rx: self.rx,
-	                        _clock: self._clock,
-	                    },
-	                    [<Write $Usart>] {
-	                        p: self.p,
-	                        tx: self.tx,
-	                        _clock: self._clock,
-	                    }
-	                )
-	            }
-	        }
+        $crate::paste::item! {
+            impl<CLOCK, RX_MODE> $Usart<CLOCK, RX_MODE>
+            where
+                CLOCK: $crate::clock::Clock,
+                RX_MODE: $crate::port::mode::InputMode,
+            {
+                /// Helper method for splitting this read/write object into two halves.
+                ///
+                /// The two halves returned implement the `Read` and `Write` traits, respectively.
+                pub fn split(self) -> ([<Read $Usart>]<CLOCK, RX_MODE>, [<Write $Usart>]<CLOCK>) {
+                    (
+                        [<Read $Usart>] {
+                            p: unsafe { ::core::ptr::read(&self.p) },
+                            rx: self.rx,
+                            _clock: self._clock,
+                        },
+                        [<Write $Usart>] {
+                            p: self.p,
+                            tx: self.tx,
+                            _clock: self._clock,
+                        }
+                    )
+                }
+            }
         }
 
         impl<CLOCK, RX_MODE> $crate::hal::serial::Write<u8> for $Usart<CLOCK, RX_MODE>
@@ -174,113 +174,113 @@ macro_rules! impl_usart {
             }
         }
 
-		$crate::paste::item! {
-			/// The readable half of the
-	        $(#[$usart_attr])*
-	        pub struct [<Read $Usart>]<CLOCK, RX_MODE>
-	        where
-	            CLOCK: $crate::clock::Clock,
-	            RX_MODE: $crate::port::mode::InputMode,
-	        {
-	            p: $USART,
-	            rx: $rxmod::$RX<$crate::port::mode::Input<RX_MODE>>,
-	            _clock: ::core::marker::PhantomData<CLOCK>,
-	        }
+        $crate::paste::item! {
+            /// The readable half of the
+            $(#[$usart_attr])*
+            pub struct [<Read $Usart>]<CLOCK, RX_MODE>
+            where
+                CLOCK: $crate::clock::Clock,
+                RX_MODE: $crate::port::mode::InputMode,
+            {
+                p: $USART,
+                rx: $rxmod::$RX<$crate::port::mode::Input<RX_MODE>>,
+                _clock: ::core::marker::PhantomData<CLOCK>,
+            }
 
-			/// The writable half of the
-	        $(#[$usart_attr])*
-	        pub struct [<Write $Usart>]<CLOCK>
-	        where
-	            CLOCK: $crate::clock::Clock,
-	        {
-	            p: $USART,
-	            tx: $txmod::$TX<$crate::port::mode::Output>,
-	            _clock: ::core::marker::PhantomData<CLOCK>,
-	        }
+            /// The writable half of the
+            $(#[$usart_attr])*
+            pub struct [<Write $Usart>]<CLOCK>
+            where
+                CLOCK: $crate::clock::Clock,
+            {
+                p: $USART,
+                tx: $txmod::$TX<$crate::port::mode::Output>,
+                _clock: ::core::marker::PhantomData<CLOCK>,
+            }
 
-	        impl<CLOCK, RX_MODE> [<Read $Usart>]<CLOCK, RX_MODE>
-	        where
-	            CLOCK: $crate::clock::Clock,
-	            RX_MODE: $crate::port::mode::InputMode,
-	        {
-	            /// Puts the two "halves" of a split `Read + Write` back together.
-	            pub fn reunite(self, other: [<Write $Usart>]<CLOCK>) -> $Usart<CLOCK, RX_MODE> {
-	                $Usart {
-	                    p: self.p,
-	                    rx: self.rx,
-	                    tx: other.tx,
-	                    _clock: self._clock,
-	                }
-	            }
-	        }
+            impl<CLOCK, RX_MODE> [<Read $Usart>]<CLOCK, RX_MODE>
+            where
+                CLOCK: $crate::clock::Clock,
+                RX_MODE: $crate::port::mode::InputMode,
+            {
+                /// Puts the two "halves" of a split `Read + Write` back together.
+                pub fn reunite(self, other: [<Write $Usart>]<CLOCK>) -> $Usart<CLOCK, RX_MODE> {
+                    $Usart {
+                        p: self.p,
+                        rx: self.rx,
+                        tx: other.tx,
+                        _clock: self._clock,
+                    }
+                }
+            }
 
-	        impl<CLOCK> [<Write $Usart>]<CLOCK>
-	        where
-	            CLOCK: $crate::clock::Clock,
-	        {
-	            /// Puts the two "halves" of a split `Read + Write` back together.
-	            pub fn reunite<RX_MODE>(self, other: [<Read $Usart>]<CLOCK, RX_MODE>) -> $Usart<CLOCK, RX_MODE>
-	            where
-	                RX_MODE: $crate::port::mode::InputMode,
-	            {
-	                other.reunite(self)
-	            }
-	        }
+            impl<CLOCK> [<Write $Usart>]<CLOCK>
+            where
+                CLOCK: $crate::clock::Clock,
+            {
+                /// Puts the two "halves" of a split `Read + Write` back together.
+                pub fn reunite<RX_MODE>(self, other: [<Read $Usart>]<CLOCK, RX_MODE>) -> $Usart<CLOCK, RX_MODE>
+                where
+                    RX_MODE: $crate::port::mode::InputMode,
+                {
+                    other.reunite(self)
+                }
+            }
 
-	        impl<CLOCK> $crate::hal::serial::Write<u8> for [<Write $Usart>]<CLOCK>
-	        where
-	            CLOCK: $crate::clock::Clock,
-	        {
-	            type Error = $crate::serial::Error;
+            impl<CLOCK> $crate::hal::serial::Write<u8> for [<Write $Usart>]<CLOCK>
+            where
+                CLOCK: $crate::clock::Clock,
+            {
+                type Error = $crate::serial::Error;
 
-	            fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
-	                // Call flush to make sure the data-register is empty
-	                self.flush()?;
+                fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
+                    // Call flush to make sure the data-register is empty
+                    self.flush()?;
 
-	                self.p.$data.write(|w| unsafe { w.bits(byte) });
-	                Ok(())
-	            }
+                    self.p.$data.write(|w| unsafe { w.bits(byte) });
+                    Ok(())
+                }
 
-	            fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
-	                if self.p.$control_a.read().$dre().bit_is_clear() {
-	                    Err($crate::nb::Error::WouldBlock)
-	                } else {
-	                    Ok(())
-	                }
-	            }
-	        }
+                fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
+                    if self.p.$control_a.read().$dre().bit_is_clear() {
+                        Err($crate::nb::Error::WouldBlock)
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
 
-	        impl<CLOCK> $crate::ufmt::uWrite for [<Write $Usart>]<CLOCK>
-	        where
-	            CLOCK: $crate::clock::Clock,
-	        {
-	            type Error = $crate::serial::Error;
+            impl<CLOCK> $crate::ufmt::uWrite for [<Write $Usart>]<CLOCK>
+            where
+                CLOCK: $crate::clock::Clock,
+            {
+                type Error = $crate::serial::Error;
 
-	            fn write_str(&mut self, s: &str) -> ::core::result::Result<(), Self::Error> {
-	                use $crate::prelude::*;
+                fn write_str(&mut self, s: &str) -> ::core::result::Result<(), Self::Error> {
+                    use $crate::prelude::*;
 
-	                for b in s.as_bytes().iter() {
-	                    $crate::nb::block!(self.write(*b))?;
-	                }
-	                Ok(())
-	            }
-	        }
+                    for b in s.as_bytes().iter() {
+                        $crate::nb::block!(self.write(*b))?;
+                    }
+                    Ok(())
+                }
+            }
 
-	        impl<CLOCK, RX_MODE> $crate::hal::serial::Read<u8> for [<Read $Usart>]<CLOCK, RX_MODE>
-	        where
-	            CLOCK: $crate::clock::Clock,
-	            RX_MODE: $crate::port::mode::InputMode,
-	        {
-	            type Error = $crate::serial::Error;
+            impl<CLOCK, RX_MODE> $crate::hal::serial::Read<u8> for [<Read $Usart>]<CLOCK, RX_MODE>
+            where
+                CLOCK: $crate::clock::Clock,
+                RX_MODE: $crate::port::mode::InputMode,
+            {
+                type Error = $crate::serial::Error;
 
-	            fn read(&mut self) -> $crate::nb::Result<u8, Self::Error> {
-	                if self.p.$control_a.read().$rxc().bit_is_clear() {
-	                    return Err($crate::nb::Error::WouldBlock);
-	                }
+                fn read(&mut self) -> $crate::nb::Result<u8, Self::Error> {
+                    if self.p.$control_a.read().$rxc().bit_is_clear() {
+                        return Err($crate::nb::Error::WouldBlock);
+                    }
 
-	                Ok(self.p.$data.read().bits())
-	            }
-	        }
+                    Ok(self.p.$data.read().bits())
+                }
+            }
         }
     };
 }


### PR DESCRIPTION
I'm doing some fun stuff with `async`/`await` and came across the need to have one task reading separately from writing without blocking the other.