### PR TITLE
Update to crates.io version of avr-device

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,7 @@ avr-hal
 `embedded-hal` implementations for AVR microcontrollers.  Based on the register definitions from [`avr-device`](https://github.com/Rahix/avr-device).
 
 ## Quickstart
-You need nightly rust for compiling rust code for AVR.  Install dependencies for [`avr-device`](https://github.com/Rahix/avr-device):
-
-```bash
-rustup component add --toolchain nightly rustfmt
-cargo install form
-cargo install svd2rust
-cargo install atdf2svd
-pip3 install --user pyyaml
-```
-
-Go into `./boards/arduino-leonardo` (or the directory for whatever board you want), and run the following commands:
+You need nightly rust for compiling rust code for AVR.  Go into `./boards/arduino-leonardo` (or the directory for whatever board you want), and run the following commands:
 ```bash
 # Now you are ready to build your first avr blink example!
 cargo +nightly build -Z build-std=core --target avr-atmega32u4.json --example leonardo-blink

--- a/boards/arduino-leonardo/Cargo.toml
+++ b/boards/arduino-leonardo/Cargo.toml
@@ -14,5 +14,5 @@ nb = "0.1.2"
 ufmt = "0.1.0"
 
 [dev-dependencies.avr-device]
-git = "https://github.com/Rahix/avr-device"
-features = ["rt", "atmega32u4"]
+version = "0.1.0"
+features = ["rt"]

--- a/boards/arduino-leonardo/Cargo.toml
+++ b/boards/arduino-leonardo/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Rahix <rahix@rahix.de>"]
 edition = "2018"
 
+[features]
+default = ["rt"]
+rt = ["atmega32u4-hal/rt"]
+
 [dependencies]
 atmega32u4-hal = { path = "../../chips/atmega32u4-hal/" }
 avr-hal-generic = { path = "../../avr-hal-generic/" }
@@ -12,7 +16,4 @@ avr-hal-generic = { path = "../../avr-hal-generic/" }
 panic-halt = "0.2.0"
 nb = "0.1.2"
 ufmt = "0.1.0"
-
-[dev-dependencies.avr-device]
-version = "0.1.0"
-features = ["rt"]
+avr-device = "0.1.0"

--- a/boards/arduino-leonardo/examples/leonardo-blink.rs
+++ b/boards/arduino-leonardo/examples/leonardo-blink.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use arduino_leonardo::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_leonardo::entry]
+fn main() -> ! {
     let dp = arduino_leonardo::Peripherals::take().unwrap();
 
     let mut delay = arduino_leonardo::Delay::new();

--- a/boards/arduino-leonardo/examples/leonardo-i2cdetect.rs
+++ b/boards/arduino-leonardo/examples/leonardo-i2cdetect.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use arduino_leonardo::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_leonardo::entry]
+fn main() -> ! {
     let dp = arduino_leonardo::Peripherals::take().unwrap();
 
     let mut delay = arduino_leonardo::Delay::new();

--- a/boards/arduino-leonardo/examples/leonardo-interrupt.rs
+++ b/boards/arduino-leonardo/examples/leonardo-interrupt.rs
@@ -9,8 +9,8 @@ use arduino_leonardo::prelude::*;
 use arduino_leonardo::hal::port;
 static mut PIN: Option<port::portc::PC7<port::mode::Output>> = None;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_leonardo::entry]
+fn main() -> ! {
     let dp = arduino_leonardo::Peripherals::take().unwrap();
 
     let mut delay = arduino_leonardo::Delay::new();

--- a/boards/arduino-leonardo/examples/leonardo-panic.rs
+++ b/boards/arduino-leonardo/examples/leonardo-panic.rs
@@ -24,8 +24,8 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_leonardo::entry]
+fn main() -> ! {
     let dp = arduino_leonardo::Peripherals::take().unwrap();
 
     let mut pins = arduino_leonardo::Pins::new(

--- a/boards/arduino-leonardo/examples/leonardo-panic.rs
+++ b/boards/arduino-leonardo/examples/leonardo-panic.rs
@@ -1,18 +1,18 @@
 #![no_std]
 #![no_main]
 
-use arduino_leonardo::prelude::*;
+use arduino_leonardo::hal::port::mode;
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
-    let mut serial: arduino_leonardo::Serial<arduino_leonardo::hal::port::mode::Floating> = unsafe {
-        core::mem::uninitialized()
+    let mut serial: arduino_leonardo::Serial<mode::Floating> = unsafe {
+        core::mem::MaybeUninit::uninit().assume_init()
     };
 
-    ufmt::uwriteln!(&mut serial, "Firmware panic!\r");
+    let _ = ufmt::uwriteln!(&mut serial, "Firmware panic!\r");
 
     if let Some(loc) = info.location() {
-        ufmt::uwriteln!(
+        let _ = ufmt::uwriteln!(
             &mut serial,
             "  At {}:{}:{}\r",
             loc.file(),

--- a/boards/arduino-leonardo/examples/leonardo-serial.rs
+++ b/boards/arduino-leonardo/examples/leonardo-serial.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use arduino_leonardo::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_leonardo::entry]
+fn main() -> ! {
     let dp = arduino_leonardo::Peripherals::take().unwrap();
 
     let mut pins = arduino_leonardo::Pins::new(

--- a/boards/arduino-leonardo/examples/leonardo-spi-feedback.rs
+++ b/boards/arduino-leonardo/examples/leonardo-spi-feedback.rs
@@ -15,8 +15,8 @@ use arduino_leonardo::prelude::*;
 use arduino_leonardo::spi;
 use nb::block;
 
-#[no_mangle]
-pub extern "C" fn main() -> ! {
+#[arduino_leonardo::entry]
+fn main() -> ! {
     let dp = arduino_leonardo::Peripherals::take().unwrap();
     let mut delay = arduino_leonardo::Delay::new();
     let mut pins = arduino_leonardo::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);

--- a/boards/arduino-leonardo/src/lib.rs
+++ b/boards/arduino-leonardo/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
 pub extern crate atmega32u4_hal as hal;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use hal::entry;
 
 mod pins;
 

--- a/boards/arduino-uno/Cargo.toml
+++ b/boards/arduino-uno/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Jonah Dahlquist <jonah@jonah.name>"]
 edition = "2018"
 
+[features]
+default = ["rt"]
+rt = ["atmega328p-hal/rt"]
+
 [dependencies]
 atmega328p-hal = { path = "../../chips/atmega328p-hal/" }
 avr-hal-generic = { path = "../../avr-hal-generic/" }

--- a/boards/arduino-uno/examples/uno-adc.rs
+++ b/boards/arduino-uno/examples/uno-adc.rs
@@ -41,6 +41,6 @@ fn main() -> ! {
         let aread: u16 = nb::block!{adc.read(&mut a0)}.unwrap();
 
         // Write it to Serial
-        ufmt::uwriteln!(&mut serial, "read: {}\r", aread);
+        ufmt::uwriteln!(&mut serial, "read: {}\r", aread).unwrap();
     }
 }

--- a/boards/arduino-uno/examples/uno-adc.rs
+++ b/boards/arduino-uno/examples/uno-adc.rs
@@ -9,8 +9,8 @@ use arduino_uno::prelude::*;
 //
 // $ sudo screen /dev/ttyACM0 9600
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_uno::entry]
+fn main() -> ! {
     let dp = arduino_uno::Peripherals::take().unwrap();
 
     let mut pins = arduino_uno::Pins::new(

--- a/boards/arduino-uno/examples/uno-blink.rs
+++ b/boards/arduino-uno/examples/uno-blink.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use arduino_uno::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_uno::entry]
+fn main() -> ! {
     let dp = arduino_uno::Peripherals::take().unwrap();
 
     let mut delay = arduino_uno::Delay::new();

--- a/boards/arduino-uno/examples/uno-i2cdetect.rs
+++ b/boards/arduino-uno/examples/uno-i2cdetect.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use arduino_uno::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_uno::entry]
+fn main() -> ! {
     let dp = arduino_uno::Peripherals::take().unwrap();
 
     let mut delay = arduino_uno::Delay::new();

--- a/boards/arduino-uno/examples/uno-panic.rs
+++ b/boards/arduino-uno/examples/uno-panic.rs
@@ -24,8 +24,8 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_uno::entry]
+fn main() -> ! {
     let dp = arduino_uno::Peripherals::take().unwrap();
 
     let mut pins = arduino_uno::Pins::new(

--- a/boards/arduino-uno/examples/uno-panic.rs
+++ b/boards/arduino-uno/examples/uno-panic.rs
@@ -1,18 +1,16 @@
 #![no_std]
 #![no_main]
 
-use arduino_uno::prelude::*;
-
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     let mut serial: arduino_uno::Serial<arduino_uno::hal::port::mode::Floating> = unsafe {
-        core::mem::uninitialized()
+        core::mem::MaybeUninit::uninit().assume_init()
     };
 
-    ufmt::uwriteln!(&mut serial, "Firmware panic!\r");
+    let _ = ufmt::uwriteln!(&mut serial, "Firmware panic!\r");
 
     if let Some(loc) = info.location() {
-        ufmt::uwriteln!(
+        let _ = ufmt::uwriteln!(
             &mut serial,
             "  At {}:{}:{}\r",
             loc.file(),

--- a/boards/arduino-uno/examples/uno-serial.rs
+++ b/boards/arduino-uno/examples/uno-serial.rs
@@ -9,8 +9,8 @@ use arduino_uno::prelude::*;
 //
 // $ sudo screen /dev/ttyACM0 57600
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[arduino_uno::entry]
+fn main() -> ! {
     let dp = arduino_uno::Peripherals::take().unwrap();
 
     let mut pins = arduino_uno::Pins::new(

--- a/boards/arduino-uno/examples/uno-spi-feedback.rs
+++ b/boards/arduino-uno/examples/uno-spi-feedback.rs
@@ -14,12 +14,14 @@
 
 #![no_std]
 #![no_main]
+
 extern crate panic_halt;
 use arduino_uno::prelude::*;
 use arduino_uno::spi::{Settings, Spi};
 use nb::block;
-#[no_mangle]
-pub extern "C" fn main() -> ! {
+
+#[arduino_uno::entry]
+fn main() -> ! {
     let dp = arduino_uno::Peripherals::take().unwrap();
     let mut delay = arduino_uno::Delay::new();
     let mut pins = arduino_uno::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD);

--- a/boards/arduino-uno/src/lib.rs
+++ b/boards/arduino-uno/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
 pub extern crate atmega328p_hal as hal;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use hal::entry;
 
 mod pins;
 

--- a/boards/bigavr6/Cargo.toml
+++ b/boards/bigavr6/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Gabriel Pickl <gabriel.pickl@posteo.net>"]
 edition = "2018"
 
+[features]
+default = ["rt"]
+rt = ["atmega1280-hal/rt"]
+
 [dependencies]
 atmega1280-hal = { path = "../../chips/atmega1280-hal/" }
 avr-hal-generic = { path = "../../avr-hal-generic/" }

--- a/boards/bigavr6/examples/bigavr6-blink.rs
+++ b/boards/bigavr6/examples/bigavr6-blink.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use bigavr6::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[bigavr6::entry]
+fn main() -> ! {
     let dp = bigavr6::Peripherals::take().unwrap();
 
     let mut delay = bigavr6::Delay::new();

--- a/boards/bigavr6/examples/bigavr6-i2cdetect.rs
+++ b/boards/bigavr6/examples/bigavr6-i2cdetect.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use bigavr6::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[bigavr6::entry]
+fn main() -> ! {
     let dp = bigavr6::Peripherals::take().unwrap();
 
     let mut delay = bigavr6::Delay::new();

--- a/boards/bigavr6/examples/bigavr6-panic.rs
+++ b/boards/bigavr6/examples/bigavr6-panic.rs
@@ -24,8 +24,8 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[bigavr6::entry]
+fn main() -> ! {
     let dp = bigavr6::Peripherals::take().unwrap();
 
     let mut porte = dp.PORTE.split();

--- a/boards/bigavr6/examples/bigavr6-panic.rs
+++ b/boards/bigavr6/examples/bigavr6-panic.rs
@@ -6,13 +6,13 @@ use bigavr6::prelude::*;
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     let mut serial: bigavr6::Serial<bigavr6::hal::port::mode::Floating> = unsafe {
-        core::mem::uninitialized()
+        core::mem::MaybeUninit::uninit().assume_init()
     };
 
     ufmt::uwriteln!(&mut serial, "Firmware panic!\r").unwrap();
 
     if let Some(loc) = info.location() {
-        ufmt::uwriteln!(
+        let _ = ufmt::uwriteln!(
             &mut serial,
             "  At {}:{}:{}\r",
             loc.file(),

--- a/boards/bigavr6/examples/bigavr6-serial.rs
+++ b/boards/bigavr6/examples/bigavr6-serial.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use bigavr6::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[bigavr6::entry]
+fn main() -> ! {
     let dp = bigavr6::Peripherals::take().unwrap();
 
     let mut porte = dp.PORTE.split();

--- a/boards/bigavr6/src/lib.rs
+++ b/boards/bigavr6/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
 pub extern crate atmega1280_hal as hal;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use hal::entry;
 
 pub use atmega1280_hal::atmega1280;
 pub use crate::atmega1280::Peripherals;

--- a/boards/trinket/Cargo.toml
+++ b/boards/trinket/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Rahix <rahix@rahix.de>"]
 edition = "2018"
 
+[features]
+default = ["rt"]
+rt = ["attiny85-hal/rt"]
+
 [dependencies]
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 attiny85-hal = { path = "../../chips/attiny85-hal/" }

--- a/boards/trinket/examples/trinket-blink.rs
+++ b/boards/trinket/examples/trinket-blink.rs
@@ -4,8 +4,8 @@
 extern crate panic_halt;
 use trinket::prelude::*;
 
-#[no_mangle]
-pub extern fn main() -> ! {
+#[trinket::entry]
+fn main() -> ! {
     let dp = trinket::Peripherals::take().unwrap();
 
     let mut delay = trinket::Delay::new();

--- a/boards/trinket/src/lib.rs
+++ b/boards/trinket/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
 pub extern crate attiny85_hal as hal;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use hal::entry;
 
 pub use attiny85_hal::attiny85;
 pub use crate::attiny85::Peripherals;

--- a/chips/atmega1280-hal/Cargo.toml
+++ b/chips/atmega1280-hal/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Gabriel Pickl <peacememories@posteo.net>"]
 edition = "2018"
 
+[features]
+rt = ["avr-device/rt"]
+
 [dependencies]
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 

--- a/chips/atmega1280-hal/Cargo.toml
+++ b/chips/atmega1280-hal/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-git = "https://github.com/Rahix/avr-device"
+version = "0.1.0"
 features = ["atmega1280"]

--- a/chips/atmega1280-hal/src/lib.rs
+++ b/chips/atmega1280-hal/src/lib.rs
@@ -3,6 +3,9 @@
 extern crate avr_hal_generic as avr_hal;
 
 pub use avr_device::atmega1280;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;

--- a/chips/atmega328p-hal/Cargo.toml
+++ b/chips/atmega328p-hal/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-git = "https://github.com/Rahix/avr-device"
+version = "0.1.0"
 features = ["atmega328p"]
 

--- a/chips/atmega328p-hal/Cargo.toml
+++ b/chips/atmega328p-hal/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Jonah Dahlquist <jonah@jonah.name>"]
 edition = "2018"
 
+[features]
+rt = ["avr-device/rt"]
+
 [dependencies]
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 

--- a/chips/atmega328p-hal/src/lib.rs
+++ b/chips/atmega328p-hal/src/lib.rs
@@ -3,6 +3,9 @@
 extern crate avr_hal_generic as avr_hal;
 
 pub use avr_device::atmega328p;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;

--- a/chips/atmega32u4-hal/Cargo.toml
+++ b/chips/atmega32u4-hal/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-git = "https://github.com/Rahix/avr-device"
+version = "0.1.0"
 features = ["atmega32u4"]

--- a/chips/atmega32u4-hal/Cargo.toml
+++ b/chips/atmega32u4-hal/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Rahix <rahix@rahix.de>"]
 edition = "2018"
 
+[features]
+rt = ["avr-device/rt"]
+
 [dependencies]
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 

--- a/chips/atmega32u4-hal/src/lib.rs
+++ b/chips/atmega32u4-hal/src/lib.rs
@@ -3,6 +3,9 @@
 extern crate avr_hal_generic as avr_hal;
 
 pub use avr_device::atmega32u4;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;

--- a/chips/attiny85-hal/Cargo.toml
+++ b/chips/attiny85-hal/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-git = "https://github.com/Rahix/avr-device"
+version = "0.1.0"
 features = ["attiny85"]

--- a/chips/attiny85-hal/Cargo.toml
+++ b/chips/attiny85-hal/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Rahix <rahix@rahix.de>"]
 edition = "2018"
 
+[features]
+rt = ["avr-device/rt"]
+
 [dependencies]
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 

--- a/chips/attiny85-hal/src/lib.rs
+++ b/chips/attiny85-hal/src/lib.rs
@@ -3,6 +3,9 @@
 extern crate avr_hal_generic as avr_hal;
 
 pub use avr_device::attiny85;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;


### PR DESCRIPTION
What this PR does:

1. No more do we require all the build-tools for `avr-device`.  The crate is pre-built on crates.io which makes the build of `avr-hal` much simpler.
2. The new `#[entry]` macro abstracts the entry point and allows upstream to change the runtime without breaking downstream code.  This PR updates all examples to use this new attribute macro.