### PR TITLE
Add ADC support for ATmega32U4

### DIFF
--- a/avr-hal-generic/src/adc.rs
+++ b/avr-hal-generic/src/adc.rs
@@ -49,7 +49,10 @@ macro_rules! impl_adc {
         pub struct $Adc:ident {
             type ChannelID = $ID:ty;
             peripheral: $ADC:ty,
-            pins: {$($pxi:ident: ($PXi:ident, $ChannelID:expr, $didr:ident::$didr_method:ident),)+}
+            set_mux: |$periph_var:ident, $id_var:ident| $set_mux:block,
+            pins: {
+                $($pxi:ident: ($PXi:ident, $ChannelID:expr, $didr:ident::$didr_method:ident),)+
+            }
         }
     ) => {
 
@@ -125,7 +128,12 @@ macro_rules! impl_adc {
                     // Start measurement
                     (None, _) => {
                         self.reading_channel = Some(PIN::channel());
-                        self.peripheral.admux.modify(|_, w| w.mux().variant(PIN::channel()));
+                        {
+                            let $periph_var = &mut self.peripheral;
+                            let $id_var = PIN::channel();
+
+                            $set_mux
+                        }
                         self.peripheral.adcsra.modify(|_, w| w.adsc().set_bit());
                         Err(nb::Error::WouldBlock)
                     },

--- a/boards/arduino-leonardo/src/lib.rs
+++ b/boards/arduino-leonardo/src/lib.rs
@@ -11,6 +11,7 @@ pub use atmega32u4_hal::atmega32u4;
 pub use crate::atmega32u4::Peripherals;
 pub use atmega32u4_hal::prelude;
 pub use atmega32u4_hal::spi;
+pub use atmega32u4_hal::adc;
 pub use crate::pins::*;
 
 pub type Delay = hal::delay::Delay<hal::clock::MHz16>;

--- a/chips/atmega328p-hal/src/adc.rs
+++ b/chips/atmega328p-hal/src/adc.rs
@@ -8,6 +8,9 @@ avr_hal::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
         peripheral: crate::atmega328p::ADC,
+        set_mux: |peripheral, id| {
+            peripheral.admux.modify(|_, w| w.mux().variant(id));
+        },
         pins: {
             pc0: (PC0, MUX_A::ADC0, didr0::adc0d),
             pc1: (PC1, MUX_A::ADC1, didr0::adc1d),

--- a/chips/atmega328p-hal/src/adc.rs
+++ b/chips/atmega328p-hal/src/adc.rs
@@ -21,3 +21,32 @@ avr_hal::impl_adc! {
         }
     }
 }
+
+/// Additional channels
+///
+/// This module contains ADC channels, additional to the direct pin channels.
+pub mod channel {
+    use avr_hal::hal::adc::Channel;
+    use crate::atmega328p::adc::admux::MUX_A;
+
+    /// Channel for the _Bandgap Reference Voltage_
+    pub struct Vbg;
+    impl Channel<super::Adc> for Vbg {
+        type ID = MUX_A;
+        fn channel() -> Self::ID { MUX_A::ADC_VBG }
+    }
+
+    /// Channel for _GND_
+    pub struct Gnd;
+    impl Channel<super::Adc> for Gnd {
+        type ID = MUX_A;
+        fn channel() -> Self::ID { MUX_A::ADC_GND }
+    }
+
+    /// Channel for the built-in _Temperature Sensor_
+    pub struct Temperature;
+    impl Channel<super::Adc> for Temperature {
+        type ID = MUX_A;
+        fn channel() -> Self::ID { MUX_A::TEMPSENS }
+    }
+}

--- a/chips/atmega32u4-hal/src/adc.rs
+++ b/chips/atmega32u4-hal/src/adc.rs
@@ -15,12 +15,17 @@ pub enum AdcMux {
     Adc6 = 0b000110,
     Adc7 = 0b000111,
 
+    AdcVbg = 0b011110,
+    AdcGnd = 0b011111,
+
     Adc8 = 0b100000,
     Adc9 = 0b100001,
     Adc10 = 0b100010,
     Adc11 = 0b100011,
     Adc12 = 0b100100,
     Adc13 = 0b100101,
+
+    AdcTemp = 0b100111,
 }
 
 avr_hal::impl_adc! {
@@ -46,5 +51,34 @@ avr_hal::impl_adc! {
             pb5: (PB5, AdcMux::Adc12, didr2::adc12d),
             pb6: (PB6, AdcMux::Adc13, didr2::adc13d),
         }
+    }
+}
+
+/// Additional channels
+///
+/// This module contains ADC channels, additional to the direct pin channels.
+pub mod channel {
+    use avr_hal::hal::adc::Channel;
+    use super::AdcMux;
+
+    /// Channel for the _Bandgap Reference Voltage_
+    pub struct Vbg;
+    impl Channel<super::Adc> for Vbg {
+        type ID = AdcMux;
+        fn channel() -> Self::ID { AdcMux::AdcVbg }
+    }
+
+    /// Channel for _GND_
+    pub struct Gnd;
+    impl Channel<super::Adc> for Gnd {
+        type ID = AdcMux;
+        fn channel() -> Self::ID { AdcMux::AdcGnd }
+    }
+
+    /// Channel for the built-in _Temperature Sensor_
+    pub struct Temperature;
+    impl Channel<super::Adc> for Temperature {
+        type ID = AdcMux;
+        fn channel() -> Self::ID { AdcMux::AdcTemp }
     }
 }

--- a/chips/atmega32u4-hal/src/adc.rs
+++ b/chips/atmega32u4-hal/src/adc.rs
@@ -1,0 +1,50 @@
+use crate::port::portb::{PB4, PB5, PB6};
+use crate::port::portd::{PD4, PD6, PD7};
+use crate::port::portf::{PF0, PF1, PF4, PF5, PF6, PF7};
+
+pub use crate::avr_hal::adc::*;
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum AdcMux {
+    Adc0 = 0b000000,
+    Adc1 = 0b000001,
+    Adc4 = 0b000100,
+    Adc5 = 0b000101,
+    Adc6 = 0b000110,
+    Adc7 = 0b000111,
+
+    Adc8 = 0b100000,
+    Adc9 = 0b100001,
+    Adc10 = 0b100010,
+    Adc11 = 0b100011,
+    Adc12 = 0b100100,
+    Adc13 = 0b100101,
+}
+
+avr_hal::impl_adc! {
+    pub struct Adc {
+        type ChannelID = AdcMux;
+        peripheral: crate::atmega32u4::ADC,
+        set_mux: |peripheral, id| {
+            let id = id as u8;
+            peripheral.admux.modify(|_, w| w.mux().bits(id & 0x1f));
+            peripheral.adcsrb.modify(|_, w| w.mux5().bit(id & 0x20 != 0));
+        },
+        pins: {
+            pf0: (PF0, AdcMux::Adc0, didr0::adc0d),
+            pf1: (PF1, AdcMux::Adc1, didr0::adc1d),
+            pf4: (PF4, AdcMux::Adc4, didr0::adc4d),
+            pf5: (PF5, AdcMux::Adc5, didr0::adc5d),
+            pf6: (PF6, AdcMux::Adc6, didr0::adc6d),
+            pf7: (PF7, AdcMux::Adc7, didr0::adc7d),
+            pd4: (PD4, AdcMux::Adc8, didr2::adc8d),
+            pd6: (PD6, AdcMux::Adc9, didr2::adc9d),
+            pd7: (PD7, AdcMux::Adc10, didr2::adc10d),
+            pb4: (PB4, AdcMux::Adc11, didr2::adc11d),
+            pb5: (PB5, AdcMux::Adc12, didr2::adc12d),
+            pb6: (PB6, AdcMux::Adc13, didr2::adc13d),
+        }
+    }
+}

--- a/chips/atmega32u4-hal/src/lib.rs
+++ b/chips/atmega32u4-hal/src/lib.rs
@@ -10,6 +10,7 @@ pub use avr_device::entry;
 pub use avr_hal::clock;
 pub use avr_hal::delay;
 
+pub mod adc;
 pub mod port;
 
 pub mod prelude {


### PR DESCRIPTION
Add support for the ADC peripheral for `ATmega32U4` (i.e. Arduino Leonardo).  This needs a slight change in the `impl_adc!{}` macro, because `ATmega32U4` has slightly different register layouts (the MUX field is split across 2 registers).