### PR TITLE
Use Void where possible and add build-matrix to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,23 @@ rust:
 cache:
   - cargo
 
+addons:
+  apt:
+    packages:
+      - avr-libc
+      - binutils-avr
+      - gcc-avr
+
+env:
+  matrix:
+    - BOARD=arduino-leonardo
+    - BOARD=arduino-uno
+    - BOARD=bigavr6
+    - BOARD=trinket
+
+install:
+  - rustup component add rust-src
+
 script:
-  - cargo build --verbose --all
+  - echo "Building board \"$BOARD\" ..."
+  - cd "boards/$BOARD" && cargo build --verbose --examples

--- a/avr-hal-generic/src/serial.rs
+++ b/avr-hal-generic/src/serial.rs
@@ -1,9 +1,5 @@
 //! Serial Implementations
 
-/// Serial Error
-#[derive(Debug, Clone, Copy)]
-pub enum Error { }
-
 /// Implement serial traits for a USART peripheral
 #[macro_export]
 macro_rules! impl_usart {
@@ -122,7 +118,7 @@ macro_rules! impl_usart {
             CLOCK: $crate::clock::Clock,
             RX_MODE: $crate::port::mode::InputMode,
         {
-            type Error = $crate::serial::Error;
+            type Error = $crate::void::Void;
 
             fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
                 // Call flush to make sure the data-register is empty
@@ -146,7 +142,7 @@ macro_rules! impl_usart {
             CLOCK: $crate::clock::Clock,
             RX_MODE: $crate::port::mode::InputMode,
         {
-            type Error = $crate::serial::Error;
+            type Error = $crate::void::Void;
 
             fn write_str(&mut self, s: &str) -> ::core::result::Result<(), Self::Error> {
                 use $crate::prelude::*;
@@ -163,7 +159,7 @@ macro_rules! impl_usart {
             CLOCK: $crate::clock::Clock,
             RX_MODE: $crate::port::mode::InputMode,
         {
-            type Error = $crate::serial::Error;
+            type Error = $crate::void::Void;
 
             fn read(&mut self) -> $crate::nb::Result<u8, Self::Error> {
                 if self.p.$control_a.read().$rxc().bit_is_clear() {
@@ -231,7 +227,7 @@ macro_rules! impl_usart {
             where
                 CLOCK: $crate::clock::Clock,
             {
-                type Error = $crate::serial::Error;
+                type Error = $crate::void::Void;
 
                 fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
                     // Call flush to make sure the data-register is empty
@@ -254,7 +250,7 @@ macro_rules! impl_usart {
             where
                 CLOCK: $crate::clock::Clock,
             {
-                type Error = $crate::serial::Error;
+                type Error = $crate::void::Void;
 
                 fn write_str(&mut self, s: &str) -> ::core::result::Result<(), Self::Error> {
                     use $crate::prelude::*;
@@ -271,7 +267,7 @@ macro_rules! impl_usart {
                 CLOCK: $crate::clock::Clock,
                 RX_MODE: $crate::port::mode::InputMode,
             {
-                type Error = $crate::serial::Error;
+                type Error = $crate::void::Void;
 
                 fn read(&mut self) -> $crate::nb::Result<u8, Self::Error> {
                     if self.p.$control_a.read().$rxc().bit_is_clear() {

--- a/boards/arduino-leonardo/examples/leonardo-adc.rs
+++ b/boards/arduino-leonardo/examples/leonardo-adc.rs
@@ -18,19 +18,19 @@ fn main() -> ! {
         57600,
     );
 
-    ufmt::uwriteln!(&mut serial, "Reading analog inputs ...\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Reading analog inputs ...\r").void_unwrap();
 
     let mut adc = arduino_leonardo::adc::Adc::new(dp.ADC, Default::default());
 
     let (vbg, gnd, temp): (u16, u16, u16) = (
-        nb::block!(adc.read(&mut arduino_leonardo::adc::channel::Vbg)).unwrap(),
-        nb::block!(adc.read(&mut arduino_leonardo::adc::channel::Gnd)).unwrap(),
-        nb::block!(adc.read(&mut arduino_leonardo::adc::channel::Temperature)).unwrap(),
+        nb::block!(adc.read(&mut arduino_leonardo::adc::channel::Vbg)).void_unwrap(),
+        nb::block!(adc.read(&mut arduino_leonardo::adc::channel::Gnd)).void_unwrap(),
+        nb::block!(adc.read(&mut arduino_leonardo::adc::channel::Temperature)).void_unwrap(),
     );
 
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}\r", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "GND: {}\r", gnd).unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature Sensor: {}\r", temp).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}\r", vbg).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "GND: {}\r", gnd).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Temperature Sensor: {}\r", temp).void_unwrap();
 
     let portf = dp.PORTF.split();
     let mut a0 = portf.pf7.into_analog_input(&mut adc);
@@ -42,18 +42,18 @@ fn main() -> ! {
 
     loop {
         let values: [u16; 6] = [
-            nb::block!(adc.read(&mut a0)).unwrap(),
-            nb::block!(adc.read(&mut a1)).unwrap(),
-            nb::block!(adc.read(&mut a2)).unwrap(),
-            nb::block!(adc.read(&mut a3)).unwrap(),
-            nb::block!(adc.read(&mut a4)).unwrap(),
-            nb::block!(adc.read(&mut a5)).unwrap(),
+            nb::block!(adc.read(&mut a0)).void_unwrap(),
+            nb::block!(adc.read(&mut a1)).void_unwrap(),
+            nb::block!(adc.read(&mut a2)).void_unwrap(),
+            nb::block!(adc.read(&mut a3)).void_unwrap(),
+            nb::block!(adc.read(&mut a4)).void_unwrap(),
+            nb::block!(adc.read(&mut a5)).void_unwrap(),
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
         }
-        ufmt::uwriteln!(&mut serial, "\r").unwrap();
+        ufmt::uwriteln!(&mut serial, "\r").void_unwrap();
 
         delay.delay_ms(1000);
     }

--- a/boards/arduino-leonardo/examples/leonardo-i2cdetect.rs
+++ b/boards/arduino-leonardo/examples/leonardo-i2cdetect.rs
@@ -9,12 +9,7 @@ fn main() -> ! {
     let dp = arduino_leonardo::Peripherals::take().unwrap();
 
     let mut delay = arduino_leonardo::Delay::new();
-    let mut pins = arduino_leonardo::Pins::new(
-        dp.PORTB,
-        dp.PORTC,
-        dp.PORTD,
-        dp.PORTE,
-    );
+    let mut pins = arduino_leonardo::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
     let mut serial = arduino_leonardo::Serial::new(
         dp.USART1,
         pins.d0,
@@ -28,10 +23,12 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_leonardo::hal::i2c::Direction::Write).unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_leonardo::hal::i2c::Direction::Read).unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_leonardo::hal::i2c::Direction::Write)
+        .void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_leonardo::hal::i2c::Direction::Read)
+        .void_unwrap();
 
     loop {
         delay.delay_ms(1000);

--- a/boards/arduino-leonardo/examples/leonardo-panic.rs
+++ b/boards/arduino-leonardo/examples/leonardo-panic.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_leonardo::prelude::*;
 use arduino_leonardo::hal::port::mode;
 
 #[panic_handler]
@@ -9,16 +10,16 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         core::mem::MaybeUninit::uninit().assume_init()
     };
 
-    let _ = ufmt::uwriteln!(&mut serial, "Firmware panic!\r");
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").void_unwrap();
 
     if let Some(loc) = info.location() {
-        let _ = ufmt::uwriteln!(
+        ufmt::uwriteln!(
             &mut serial,
             "  At {}:{}:{}\r",
             loc.file(),
             loc.line(),
             loc.column(),
-        );
+        ).void_unwrap();
     }
 
     loop {}
@@ -42,7 +43,7 @@ fn main() -> ! {
         57600,
     );
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
     // Panic messages cannot yet be captured because they rely on core::fmt
     // which is way too big for AVR
     panic!();

--- a/boards/arduino-leonardo/examples/leonardo-serial.rs
+++ b/boards/arduino-leonardo/examples/leonardo-serial.rs
@@ -22,13 +22,13 @@ fn main() -> ! {
         57600,
     );
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).void_unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
     }
 }

--- a/boards/arduino-leonardo/examples/leonardo-spi-feedback.rs
+++ b/boards/arduino-leonardo/examples/leonardo-spi-feedback.rs
@@ -41,11 +41,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        block!(spi.send(0b00001111)).unwrap();
+        block!(spi.send(0b00001111)).void_unwrap();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = block!(spi.read()).unwrap();
+        let data = block!(spi.read()).void_unwrap();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
         delay.delay_ms(1000);
     }
 }

--- a/boards/arduino-uno/examples/uno-adc.rs
+++ b/boards/arduino-uno/examples/uno-adc.rs
@@ -34,13 +34,13 @@ fn main() -> ! {
     let mut a0 = pins.a0.into_analog_input(&mut adc);
 
 
-    ufmt::uwriteln!(&mut serial, "Reading Analog Input on PORT a0\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Reading Analog Input on PORT a0\r").void_unwrap();
 
     loop {
         // Read the Analog value
-        let aread: u16 = nb::block!{adc.read(&mut a0)}.unwrap();
+        let aread: u16 = nb::block!{adc.read(&mut a0)}.void_unwrap();
 
         // Write it to Serial
-        ufmt::uwriteln!(&mut serial, "read: {}\r", aread).unwrap();
+        ufmt::uwriteln!(&mut serial, "read: {}\r", aread).void_unwrap();
     }
 }

--- a/boards/arduino-uno/examples/uno-i2cdetect.rs
+++ b/boards/arduino-uno/examples/uno-i2cdetect.rs
@@ -27,10 +27,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_uno::hal::i2c::Direction::Write).unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_uno::hal::i2c::Direction::Read).unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_uno::hal::i2c::Direction::Write).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_uno::hal::i2c::Direction::Read).void_unwrap();
 
     loop {
         delay.delay_ms(1000);

--- a/boards/arduino-uno/examples/uno-panic.rs
+++ b/boards/arduino-uno/examples/uno-panic.rs
@@ -1,22 +1,24 @@
 #![no_std]
 #![no_main]
 
+use arduino_uno::prelude::*;
+
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     let mut serial: arduino_uno::Serial<arduino_uno::hal::port::mode::Floating> = unsafe {
         core::mem::MaybeUninit::uninit().assume_init()
     };
 
-    let _ = ufmt::uwriteln!(&mut serial, "Firmware panic!\r");
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").void_unwrap();
 
     if let Some(loc) = info.location() {
-        let _ = ufmt::uwriteln!(
+        ufmt::uwriteln!(
             &mut serial,
             "  At {}:{}:{}\r",
             loc.file(),
             loc.line(),
             loc.column(),
-        );
+        ).void_unwrap();
     }
 
     loop {}
@@ -39,7 +41,7 @@ fn main() -> ! {
         57600,
     );
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
     // Panic messages cannot yet be captured because they rely on core::fmt
     // which is way too big for AVR
     panic!();

--- a/boards/arduino-uno/examples/uno-serial.rs
+++ b/boards/arduino-uno/examples/uno-serial.rs
@@ -26,13 +26,13 @@ fn main() -> ! {
         57600,
     );
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).void_unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
     }
 }

--- a/boards/arduino-uno/examples/uno-spi-feedback.rs
+++ b/boards/arduino-uno/examples/uno-spi-feedback.rs
@@ -46,11 +46,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        block!(spi.send(0b00001111)).unwrap();
+        block!(spi.send(0b00001111)).void_unwrap();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = block!(spi.read()).unwrap();
+        let data = block!(spi.read()).void_unwrap();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
         delay.delay_ms(1000);
     }
 }

--- a/boards/bigavr6/examples/bigavr6-i2cdetect.rs
+++ b/boards/bigavr6/examples/bigavr6-i2cdetect.rs
@@ -26,10 +26,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, bigavr6::hal::i2c::Direction::Write).unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, bigavr6::hal::i2c::Direction::Read).unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, bigavr6::hal::i2c::Direction::Write).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, bigavr6::hal::i2c::Direction::Read).void_unwrap();
 
     loop {
         delay.delay_ms(1000);

--- a/boards/bigavr6/examples/bigavr6-panic.rs
+++ b/boards/bigavr6/examples/bigavr6-panic.rs
@@ -9,16 +9,16 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         core::mem::MaybeUninit::uninit().assume_init()
     };
 
-    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").void_unwrap();
 
     if let Some(loc) = info.location() {
-        let _ = ufmt::uwriteln!(
+        ufmt::uwriteln!(
             &mut serial,
             "  At {}:{}:{}\r",
             loc.file(),
             loc.line(),
             loc.column(),
-        );
+        ).void_unwrap();
     }
 
     loop {}
@@ -37,7 +37,7 @@ fn main() -> ! {
         57600,
     );
 
-    ufmt::uwriteln!(&mut serial, "Hello from BIGAVR6!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from BIGAVR6!\r").void_unwrap();
     // Panic messages cannot yet be captured because they rely on core::fmt
     // which is way too big for AVR
     panic!();

--- a/boards/bigavr6/examples/bigavr6-serial.rs
+++ b/boards/bigavr6/examples/bigavr6-serial.rs
@@ -18,15 +18,15 @@ fn main() -> ! {
 
     // The following would also work, but needs +600% more bytes
     // writeln!(serial, "Hello from Arduino!\r").unwrap();
-    serial.write_str("Hello from BIGAVR6!\r\n").unwrap();
+    serial.write_str("Hello from BIGAVR6!\r\n").void_unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).void_unwrap();
 
         // Answer
-        serial.write_str("You pressed ").unwrap();
-        nb::block!(serial.write(b)).unwrap();
-        serial.write_str("!\r\n").unwrap();
+        serial.write_str("You pressed ").void_unwrap();
+        nb::block!(serial.write(b)).void_unwrap();
+        serial.write_str("!\r\n").void_unwrap();
     }
 }

--- a/boards/trinket/.cargo/config.toml
+++ b/boards/trinket/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-target = "avr-atmega1280.json"
+target = "avr-attiny85.json"
 
 [unstable]
 build-std = ["core"]


### PR DESCRIPTION
- Make the error type of the serial peripheral `void::Void`
- Use `.void_unwrap()` in all examples where possible
- Configure build-matrix for CI, building all examples for all boards