### PR TITLE
Add Arduino Mega 2560, ATmega2560

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
 
     # The chip definitions
     "chips/atmega1280-hal",
+    "chips/atmega2560-hal",
     "chips/atmega328p-hal",
     "chips/atmega32u4-hal",
     "chips/attiny85-hal",
@@ -24,6 +25,7 @@ members = [
     # The board crates
     "boards/arduino-leonardo",
     "boards/arduino-uno",
+    "boards/arduino-mega2560",
     "boards/bigavr6",
     "boards/trinket",
 ]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The chip-HAL crates currently support the following peripherals:
   - [x] `PORTA`, `PORTB`, `PORTC`, `PORTD`, `PORTE`, `PORTF`, `PORTG`, `PORTH`, `PORTJ`, `PORTK`, `PORTL` as digital IO
   - [x] `USART0`, `USART1`, `USART2`, `USART3` for serial communication
   - [x] I2C using `TWI`
+  - [x] SPI
   - [x] ADC (no differential channels yet)
 * [`atmega328p-hal`](./chips/atmega328p-hal)
   - [x] Spinning Delay

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The chip-HAL crates currently support the following peripherals:
   - [x] `PORTA`, `PORTB`, `PORTC`, `PORTD`, `PORTE`, `PORTF`, `PORTG`, `PORTH`, `PORTJ`, `PORTK`, `PORTL` as digital IO
   - [x] `USART0`, `USART1`, `USART2`, `USART3` for serial communication
   - [x] I2C using `TWI`
+  - [x] ADC (no differential channels yet)
 * [`atmega328p-hal`](./chips/atmega328p-hal)
   - [x] Spinning Delay
   - [x] `PORTB`, `PORTC`, `PORTD` as digital IO (v2)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ In `boards/` there are crates for the following hardware.  Please note that this
   - [Website](https://www.arduino.cc/en/Main/Arduino_BoardLeonardo)
 * [Arduino Uno](./boards/arduino-uno)
   - [Website](https://store.arduino.cc/usa/arduino-uno-rev3)
+* [Arduino Mega 2560](./boards/arduino-mega2560)
+  - [Website](http://arduino.cc/en/Main/ArduinoBoardMega2560)
 * [Adafruit Trinket (3V3 or 5V)](./boards/trinket) (**not** PRO!)
   - [Website](https://learn.adafruit.com/introducing-trinket)
 * [BigAVR 6](./boards/bigavr6)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ The following peripherals are supported in `avr-hal-generic`:
 
 ### HAL Status
 The chip-HAL crates currently support the following peripherals:
+* [`atmega2560-hal`](./chips/atmega2560-hal)
+  - [x] Spinning Delay
+  - [x] `PORTA`, `PORTB`, `PORTC`, `PORTD`, `PORTE`, `PORTF`, `PORTG`, `PORTH`, `PORTJ`, `PORTK`, `PORTL` as digital IO
+  - [x] `USART0`, `USART1`, `USART2`, `USART3` for serial communication
+  - [x] I2C using `TWI`
 * [`atmega328p-hal`](./chips/atmega328p-hal)
   - [x] Spinning Delay
   - [x] `PORTB`, `PORTC`, `PORTD` as digital IO (v2)

--- a/boards/arduino-mega2560/.cargo/config.toml
+++ b/boards/arduino-mega2560/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "avr-atmega1280.json"
+
+[unstable]
+build-std = ["core"]

--- a/boards/arduino-mega2560/Cargo.toml
+++ b/boards/arduino-mega2560/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "arduino-mega2560"
+version = "0.1.0"
+authors = ["Andrew Dona-Couch <avr-hal@couchand.com>"]
+edition = "2018"
+
+[features]
+default = ["rt"]
+rt = ["atmega2560-hal/rt"]
+
+[dependencies]
+atmega2560-hal = { path = "../../chips/atmega2560-hal/" }
+avr-hal-generic = { path = "../../avr-hal-generic/" }
+
+[dev-dependencies]
+panic-halt = "0.2.0"
+nb = "0.1.2"
+ufmt = "0.1.0"

--- a/boards/arduino-mega2560/avr-atmega2560.json
+++ b/boards/arduino-mega2560/avr-atmega2560.json
@@ -1,0 +1,1 @@
+../../chips/atmega2560-hal/avr-atmega2560.json

--- a/boards/arduino-mega2560/examples/mega2560-adc.rs
+++ b/boards/arduino-mega2560/examples/mega2560-adc.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use arduino_mega2560::prelude::*;
+
+#[arduino_mega2560::entry]
+fn main() -> ! {
+    let dp = arduino_mega2560::Peripherals::take().unwrap();
+
+    let mut pins = arduino_mega2560::Pins::new(
+        dp.PORTA,
+        dp.PORTB,
+        dp.PORTC,
+        dp.PORTD,
+        dp.PORTE,
+        dp.PORTF,
+        dp.PORTG,
+        dp.PORTH,
+        dp.PORTJ,
+        dp.PORTK,
+        dp.PORTL,
+    );
+    let mut delay = arduino_mega2560::Delay::new();
+
+    let mut serial = arduino_mega2560::Serial::new(
+        dp.USART0,
+        pins.d0,
+        pins.d1.into_output(&mut pins.ddr),
+        57600,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Reading analog inputs ...\r").void_unwrap();
+
+    let mut adc = arduino_mega2560::adc::Adc::new(dp.ADC, Default::default());
+
+    let (vbg, gnd): (u16, u16) = (
+        nb::block!(adc.read(&mut arduino_mega2560::adc::channel::Vbg)).void_unwrap(),
+        nb::block!(adc.read(&mut arduino_mega2560::adc::channel::Gnd)).void_unwrap(),
+    );
+
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}\r", vbg).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "GND: {}\r", gnd).void_unwrap();
+
+    let mut a0 = pins.a0.into_analog_input(&mut adc);
+    let mut a1 = pins.a1.into_analog_input(&mut adc);
+    let mut a2 = pins.a2.into_analog_input(&mut adc);
+    let mut a3 = pins.a3.into_analog_input(&mut adc);
+    let mut a4 = pins.a4.into_analog_input(&mut adc);
+    let mut a5 = pins.a5.into_analog_input(&mut adc);
+    let mut a6 = pins.a6.into_analog_input(&mut adc);
+    let mut a7 = pins.a7.into_analog_input(&mut adc);
+    let mut a8 = pins.a8.into_analog_input(&mut adc);
+    let mut a9 = pins.a9.into_analog_input(&mut adc);
+    let mut a10 = pins.a10.into_analog_input(&mut adc);
+    let mut a11 = pins.a11.into_analog_input(&mut adc);
+    let mut a12 = pins.a12.into_analog_input(&mut adc);
+    let mut a13 = pins.a13.into_analog_input(&mut adc);
+    let mut a14 = pins.a14.into_analog_input(&mut adc);
+    let mut a15 = pins.a15.into_analog_input(&mut adc);
+
+    loop {
+        let values: [u16; 16] = [
+            nb::block!(adc.read(&mut a0)).void_unwrap(),
+            nb::block!(adc.read(&mut a1)).void_unwrap(),
+            nb::block!(adc.read(&mut a2)).void_unwrap(),
+            nb::block!(adc.read(&mut a3)).void_unwrap(),
+            nb::block!(adc.read(&mut a4)).void_unwrap(),
+            nb::block!(adc.read(&mut a5)).void_unwrap(),
+            nb::block!(adc.read(&mut a6)).void_unwrap(),
+            nb::block!(adc.read(&mut a7)).void_unwrap(),
+            nb::block!(adc.read(&mut a8)).void_unwrap(),
+            nb::block!(adc.read(&mut a9)).void_unwrap(),
+            nb::block!(adc.read(&mut a10)).void_unwrap(),
+            nb::block!(adc.read(&mut a11)).void_unwrap(),
+            nb::block!(adc.read(&mut a12)).void_unwrap(),
+            nb::block!(adc.read(&mut a13)).void_unwrap(),
+            nb::block!(adc.read(&mut a14)).void_unwrap(),
+            nb::block!(adc.read(&mut a15)).void_unwrap(),
+        ];
+
+        for (i, v) in values.iter().enumerate() {
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+        }
+        ufmt::uwriteln!(&mut serial, "\r").void_unwrap();
+
+        delay.delay_ms(1000);
+    }
+}

--- a/boards/arduino-mega2560/examples/mega2560-blink.rs
+++ b/boards/arduino-mega2560/examples/mega2560-blink.rs
@@ -9,8 +9,21 @@ fn main() -> ! {
     let dp = arduino_mega2560::Peripherals::take().unwrap();
 
     let mut delay = arduino_mega2560::Delay::new();
-    let mut portb = dp.PORTB.split();
-    let mut led = portb.pb7.into_output(&mut portb.ddr);
+    let mut pins = arduino_mega2560::Pins::new(
+        dp.PORTA,
+        dp.PORTB,
+        dp.PORTC,
+        dp.PORTD,
+        dp.PORTE,
+        dp.PORTF,
+        dp.PORTG,
+        dp.PORTH,
+        dp.PORTJ,
+        dp.PORTK,
+        dp.PORTL,
+    );
+
+    let mut led = pins.d13.into_output(&mut pins.ddr);
 
     loop {
         led.toggle().void_unwrap();

--- a/boards/arduino-mega2560/examples/mega2560-blink.rs
+++ b/boards/arduino-mega2560/examples/mega2560-blink.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use arduino_mega2560::prelude::*;
+
+#[arduino_mega2560::entry]
+fn main() -> ! {
+    let dp = arduino_mega2560::Peripherals::take().unwrap();
+
+    let mut delay = arduino_mega2560::Delay::new();
+    let mut portb = dp.PORTB.split();
+    let mut led = portb.pb7.into_output(&mut portb.ddr);
+
+    loop {
+        led.toggle().void_unwrap();
+        delay.delay_ms(1000);
+    }
+}

--- a/boards/arduino-mega2560/examples/mega2560-i2cdetect.rs
+++ b/boards/arduino-mega2560/examples/mega2560-i2cdetect.rs
@@ -1,0 +1,37 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use arduino_mega2560::prelude::*;
+
+#[arduino_mega2560::entry]
+fn main() -> ! {
+    let dp = arduino_mega2560::Peripherals::take().unwrap();
+
+    let mut delay = arduino_mega2560::Delay::new();
+
+    let mut porte = dp.PORTE.split();
+    let mut portd = dp.PORTD.split();
+
+    let mut serial = arduino_mega2560::Serial::new(
+        dp.USART0,
+        porte.pe0,
+        porte.pe1.into_output(&mut porte.ddr),
+        57600,
+    );
+    let mut i2c = arduino_mega2560::I2c::new(
+        dp.TWI,
+        portd.pd1.into_pull_up_input(&mut portd.ddr),
+        portd.pd0.into_pull_up_input(&mut portd.ddr),
+        50000,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_mega2560::hal::i2c::Direction::Write).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_mega2560::hal::i2c::Direction::Read).void_unwrap();
+
+    loop {
+        delay.delay_ms(1000);
+    }
+}

--- a/boards/arduino-mega2560/examples/mega2560-panic.rs
+++ b/boards/arduino-mega2560/examples/mega2560-panic.rs
@@ -1,0 +1,44 @@
+#![no_std]
+#![no_main]
+
+use arduino_mega2560::prelude::*;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    let mut serial: arduino_mega2560::Serial<arduino_mega2560::hal::port::mode::Floating> = unsafe {
+        core::mem::MaybeUninit::uninit().assume_init()
+    };
+
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").void_unwrap();
+
+    if let Some(loc) = info.location() {
+        ufmt::uwriteln!(
+            &mut serial,
+            "  At {}:{}:{}\r",
+            loc.file(),
+            loc.line(),
+            loc.column(),
+        ).void_unwrap();
+    }
+
+    loop {}
+}
+
+#[arduino_mega2560::entry]
+fn main() -> ! {
+    let dp = arduino_mega2560::Peripherals::take().unwrap();
+
+    let mut porte = dp.PORTE.split();
+
+    let mut serial = arduino_mega2560::Serial::new(
+        dp.USART0,
+        porte.pe0,
+        porte.pe1.into_output(&mut porte.ddr),
+        57600,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Hello from MEGA2560!\r").void_unwrap();
+    // Panic messages cannot yet be captured because they rely on core::fmt
+    // which is way too big for AVR
+    panic!();
+}

--- a/boards/arduino-mega2560/examples/mega2560-serial.rs
+++ b/boards/arduino-mega2560/examples/mega2560-serial.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use arduino_mega2560::prelude::*;
+
+#[arduino_mega2560::entry]
+fn main() -> ! {
+    let dp = arduino_mega2560::Peripherals::take().unwrap();
+
+    let mut porte = dp.PORTE.split();
+    let mut serial = arduino_mega2560::Serial::new(
+        dp.USART0,
+        porte.pe0,
+        porte.pe1.into_output(&mut porte.ddr),
+        57600,
+    );
+
+    // The following would also work, but needs +600% more bytes
+    // writeln!(serial, "Hello from Arduino!\r").unwrap();
+    serial.write_str("Hello from Arduino!\r\n").void_unwrap();
+
+    loop {
+        // Read a byte from the serial connection
+        let b = nb::block!(serial.read()).void_unwrap();
+
+        // Answer
+        serial.write_str("You pressed ").void_unwrap();
+        nb::block!(serial.write(b)).void_unwrap();
+        serial.write_str("!\r\n").void_unwrap();
+    }
+}

--- a/boards/arduino-mega2560/examples/mega2560-serial.rs
+++ b/boards/arduino-mega2560/examples/mega2560-serial.rs
@@ -16,9 +16,7 @@ fn main() -> ! {
         57600,
     );
 
-    // The following would also work, but needs +600% more bytes
-    // writeln!(serial, "Hello from Arduino!\r").unwrap();
-    serial.write_str("Hello from Arduino!\r\n").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
         // Read a byte from the serial connection

--- a/boards/arduino-mega2560/examples/mega2560-spi-feedback.rs
+++ b/boards/arduino-mega2560/examples/mega2560-spi-feedback.rs
@@ -1,0 +1,68 @@
+//! This example demonstrates how to set up a SPI interface and communicate
+//! over it.  The physical hardware configuation consists of connecting a
+//! jumper directly from pin `~50` to pin `~51`.
+//!
+//! Once this program is written to the board, the serial output can be
+//! accessed with
+//!
+//! ```
+//! sudo screen /dev/ttyACM0 57600
+//! ```
+//!
+//! You should see it output the line `data: 15` repeatedly (aka 0b00001111).
+//! If the output you see is `data: 255`, you may need to check your jumper.
+
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use arduino_mega2560::prelude::*;
+use arduino_mega2560::spi::{Settings, Spi};
+use nb::block;
+
+#[arduino_mega2560::entry]
+fn main() -> ! {
+    let dp = arduino_mega2560::Peripherals::take().unwrap();
+    let mut delay = arduino_mega2560::Delay::new();
+    let mut pins = arduino_mega2560::Pins::new(
+        dp.PORTA,
+        dp.PORTB,
+        dp.PORTC,
+        dp.PORTD,
+        dp.PORTE,
+        dp.PORTF,
+        dp.PORTG,
+        dp.PORTH,
+        dp.PORTJ,
+        dp.PORTK,
+        dp.PORTL,
+    );
+    // set up serial interface for text output
+    let mut serial = arduino_mega2560::Serial::new(
+        dp.USART0,
+        pins.d0,
+        pins.d1.into_output(&mut pins.ddr),
+        57600,
+    );
+
+    pins.d53.into_output(&mut pins.ddr); // SS must be set to output mode.
+
+    // Create SPI interface.
+    let mut spi = Spi::new(
+        dp.SPI,
+        pins.d52.into_output(&mut pins.ddr),
+        pins.d51.into_output(&mut pins.ddr),
+        pins.d50.into_pull_up_input(&mut pins.ddr),
+        Settings::default(),
+    );
+
+    loop {
+        // Send a byte
+        block!(spi.send(0b00001111)).void_unwrap();
+        // Because MISO is connected to MOSI, the read data should be the same
+        let data = block!(spi.read()).void_unwrap();
+
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
+        delay.delay_ms(1000);
+    }
+}

--- a/boards/arduino-mega2560/src/lib.rs
+++ b/boards/arduino-mega2560/src/lib.rs
@@ -10,6 +10,7 @@ mod pins;
 pub use atmega2560_hal::atmega2560;
 pub use crate::atmega2560::Peripherals;
 pub use atmega2560_hal::prelude;
+pub use atmega2560_hal::adc;
 pub use crate::pins::*;
 
 pub type Delay = hal::delay::Delay<hal::clock::MHz16>;

--- a/boards/arduino-mega2560/src/lib.rs
+++ b/boards/arduino-mega2560/src/lib.rs
@@ -10,6 +10,7 @@ mod pins;
 pub use atmega2560_hal::atmega2560;
 pub use crate::atmega2560::Peripherals;
 pub use atmega2560_hal::prelude;
+pub use atmega2560_hal::spi;
 pub use atmega2560_hal::adc;
 pub use crate::pins::*;
 

--- a/boards/arduino-mega2560/src/lib.rs
+++ b/boards/arduino-mega2560/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+pub extern crate atmega2560_hal as hal;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use hal::entry;
+
+pub use atmega2560_hal::atmega2560;
+pub use crate::atmega2560::Peripherals;
+pub use atmega2560_hal::prelude;
+
+pub type Delay = hal::delay::Delay<hal::clock::MHz16>;
+pub type Serial<IMODE> = atmega2560_hal::usart::Usart0<hal::clock::MHz16, IMODE>;
+pub type I2c<M> = hal::i2c::I2c<hal::clock::MHz16, M>;

--- a/boards/arduino-mega2560/src/lib.rs
+++ b/boards/arduino-mega2560/src/lib.rs
@@ -5,9 +5,12 @@ pub extern crate atmega2560_hal as hal;
 #[cfg(feature = "rt")]
 pub use hal::entry;
 
+mod pins;
+
 pub use atmega2560_hal::atmega2560;
 pub use crate::atmega2560::Peripherals;
 pub use atmega2560_hal::prelude;
+pub use crate::pins::*;
 
 pub type Delay = hal::delay::Delay<hal::clock::MHz16>;
 pub type Serial<IMODE> = atmega2560_hal::usart::Usart0<hal::clock::MHz16, IMODE>;

--- a/boards/arduino-mega2560/src/pins.rs
+++ b/boards/arduino-mega2560/src/pins.rs
@@ -1,0 +1,346 @@
+use atmega2560_hal::port::PortExt;
+
+avr_hal_generic::impl_board_pins! {
+    #[port_defs]
+    use atmega2560_hal::port;
+
+    /// Generic DDR that works for all ports
+    pub struct DDR {
+        porta: crate::atmega2560::PORTA,
+        portb: crate::atmega2560::PORTB,
+        portc: crate::atmega2560::PORTC,
+        portd: crate::atmega2560::PORTD,
+        porte: crate::atmega2560::PORTE,
+        portf: crate::atmega2560::PORTF,
+        portg: crate::atmega2560::PORTG,
+        porth: crate::atmega2560::PORTH,
+        portj: crate::atmega2560::PORTJ,
+        portk: crate::atmega2560::PORTK,
+        portl: crate::atmega2560::PORTL,
+    }
+
+    /// Reexport of the Mega 2560's pins, with the names they have on the board
+    pub struct Pins {
+        /// `D0` / `RX0`
+        ///
+        /// * `RXD0` (USART0)
+        /// * `PCINT8`: External Interrupt (Pin Change)
+        pub d0: porte::pe0::PE0,
+        /// `D1` / `TX0`
+        ///
+        /// * `TXD0` (USART0)
+        pub d1: porte::pe1::PE1,
+        /// `D2`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer3Pwm]
+        /// * `OC3B`: Output Compare Channel `B` for Timer/Counter3
+        /// * `INT4`: External Interrupt
+        pub d2: porte::pe4::PE4,
+        /// `D3`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer3Pwm]
+        /// * `OC3C`: Output Compare Channel `C` for Timer/Counter3
+        /// * `INT5`: External Interrupt
+        pub d3: porte::pe5::PE5,
+        /// `D4`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer0Pwm]
+        /// * `OC0B`: Output Compare Channel `B` for Timer/Counter0
+        pub d4: portg::pg5::PG5,
+        /// `D5`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer3Pwm]
+        /// * `OC3A`: Output Compare Channel `A` for Timer/Counter3
+        /// * `AIN1`: Analog Comparator Negative Input (Not Implemented)
+        pub d5: porte::pe3::PE3,
+        /// `D6`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer4Pwm]
+        /// * `OC4A`: Output Compare Channel `A` for Timer/Counter4
+        pub d6: porth::ph3::PH3,
+        /// `D7`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer4Pwm]
+        /// * `OC4B`: Output Compare Channel `B` for Timer/Counter4
+        pub d7: porth::ph4::PH4,
+        /// `D8`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer4Pwm]
+        /// * `OC4C`: Output Compare Channel `C` for Timer/Counter4
+        pub d8: porth::ph5::PH5,
+        /// `D9`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer2Pwm]
+        /// * `OC2B`: Output Compare Channel `B` for Timer/Counter2
+        pub d9: porth::ph6::PH6,
+        /// `D10`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer2Pwm]
+        /// * `OC2B`: Output Compare Channel `B` for Timer/Counter2
+        /// * `PCINT4`: External Interrupt (Pin Change)
+        pub d10: portb::pb4::PB4,
+        /// `D11`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer1Pwm]
+        /// * `OC1A`: Output Compare Channel `A` for Timer/Counter1
+        /// * `PCINT5`: External Interrupt (Pin Change)
+        pub d11: portb::pb5::PB5,
+        /// `D12`
+        ///
+        /// * **PWM**: [atmega2560_hal::timer::Timer1Pwm]
+        /// * `OC1B`: Output Compare Channel `B` for Timer/Counter1
+        /// * `PCINT6`: External Interrupt (Pin Change)
+        pub d12: portb::pb6::PB6,
+        /// `D13`
+        ///
+        /// * Onboard LED
+        /// * **PWM**: [atmega2560_hal::timer::Timer0Pwm]
+        /// * **PWM**: [atmega2560_hal::timer::Timer1Pwm]
+        /// * `OC0A`: Output Compare Channel `A` for Timer/Counter0
+        /// * `OC1C`: Output Compare Channel `C` for Timer/Counter1
+        /// * `PCINT7`: External Interrupt (Pin Change)
+        pub d13: portb::pb7::PB7,
+        /// `D14` / `TX3`
+        ///
+        /// * `TXD3` (USART3)
+        /// * `PCINT10`: External Interrupt (Pin Change)
+        pub d14: portj::pj1::PJ1,
+        /// `D15` / `RX3`
+        ///
+        /// * `RXD3` (USART3)
+        /// * `PCINT9`: External Interrupt (Pin Change)
+        pub d15: portj::pj0::PJ0,
+        /// `D16` / `TX2`
+        ///
+        /// * `TXD2` (USART2)
+        pub d16: porth::ph1::PH1,
+        /// `D17` / `RX2`
+        ///
+        /// * `RXD2` (USART2)
+        pub d17: porth::ph0::PH0,
+        /// `D18` / `TX1`
+        ///
+        /// * `TXD1` (USART1)
+        /// * `INT3`: External Interrupt
+        pub d18: portd::pd3::PD3,
+        /// `D19` / `RX1`
+        ///
+        /// * `RXD1` (USART1)
+        /// * `INT2`: External Interrupt
+        pub d19: portd::pd2::PD2,
+        /// `D20` / `SDA`
+        ///
+        /// * `SDA`: i2c/twi data
+        /// * `INT1`: External Interrupt
+        pub d20: portd::pd1::PD1,
+        /// `D21` / `SCL`
+        ///
+        /// * `SCL`: i2c/twi clock
+        /// * `INT0`: External Interrupt
+        pub d21: portd::pd0::PD0,
+        /// `D22`
+        ///
+        /// * `AD0`: External memory interface
+        pub d22: porta::pa0::PA0,
+        /// `D23`
+        ///
+        /// * `AD1`: External memory interface
+        pub d23: porta::pa1::PA1,
+        /// `D24`
+        ///
+        /// * `AD2`: External memory interface
+        pub d24: porta::pa2::PA2,
+        /// `D25`
+        ///
+        /// * `AD3`: External memory interface
+        pub d25: porta::pa3::PA3,
+        /// `D26`
+        ///
+        /// * `AD4`: External memory interface
+        pub d26: porta::pa4::PA4,
+        /// `D27`
+        ///
+        /// * `AD5`: External memory interface
+        pub d27: porta::pa5::PA5,
+        /// `D28`
+        ///
+        /// * `AD6`: External memory interface
+        pub d28: porta::pa6::PA6,
+        /// `D29`
+        ///
+        /// * `AD7`: External memory interface
+        pub d29: porta::pa7::PA7,
+        /// `D30`
+        ///
+        /// * `AD15`: External memory interface
+        pub d30: portc::pc7::PC7,
+        /// `D31`
+        ///
+        /// * `AD14`: External memory interface
+        pub d31: portc::pc6::PC6,
+        /// `D32`
+        ///
+        /// * `AD13`: External memory interface
+        pub d32: portc::pc5::PC5,
+        /// `D33`
+        ///
+        /// * `AD12`: External memory interface
+        pub d33: portc::pc4::PC4,
+        /// `D34`
+        ///
+        /// * `AD11`: External memory interface
+        pub d34: portc::pc3::PC3,
+        /// `D35`
+        ///
+        /// * `AD10`: External memory interface
+        pub d35: portc::pc2::PC2,
+        /// `D36`
+        ///
+        /// * `AD9`: External memory interface
+        pub d36: portc::pc1::PC1,
+        /// `D37`
+        ///
+        /// * `AD8`: External memory interface
+        pub d37: portc::pc0::PC0,
+        /// `D38`
+        ///
+        /// * `T0`: Clock Input for Timer/Counter0
+        pub d38: portd::pd7::PD7,
+        /// `D39`
+        ///
+        /// * `ALE`: External memory Address Latch Enable
+        pub d39: portg::pg2::PG2,
+        /// `D40`
+        ///
+        /// `RD`: External memory Read Strobe
+        pub d40: portg::pg1::PG1,
+        /// `D41`
+        ///
+        /// `WR`: External memory Write Strobe
+        pub d41: portg::pg0::PG0,
+        /// `D42`
+        pub d42: portl::pl7::PL7,
+        /// `D43`
+        pub d43: portl::pl6::PL6,
+        /// `D44`
+        ///
+        /// * `OC5C`: Output Compare Channel `C` for Timer/Counter5
+        pub d44: portl::pl5::PL5,
+        /// `D45`
+        ///
+        /// * `OC5B`: Output Compare Channel `B` for Timer/Counter5
+        pub d45: portl::pl4::PL4,
+        /// `D46`
+        ///
+        /// * `OC5A`: Output Compare Channel `A` for Timer/Counter5
+        pub d46: portl::pl3::PL3,
+        /// `D47`
+        ///
+        /// * `T5`: Clock Input for Timer/Counter5
+        pub d47: portl::pl2::PL2,
+        /// `D48`
+        ///
+        /// * `ICP5`: Input Capture Trigger for Timer/Counter5
+        pub d48: portl::pl1::PL1,
+        /// `D49`
+        ///
+        /// * `ICP4`: Input Capture Trigger for Timer/Counter4
+        pub d49: portl::pl0::PL0,
+        /// `D50`
+        ///
+        /// * `MISO`: SPI bus Master In/Slave Out
+        /// * `PCINT3`: External Interrupt (Pin Change)
+        pub d50: portb::pb3::PB3,
+        /// `D51`
+        ///
+        /// * `MOSI`: SPI bus Master Out/Slave In
+        /// * `PCINT2`: External Interrupt (Pin Change)
+        pub d51: portb::pb2::PB2,
+        /// `D52`
+        ///
+        /// * `SCK`: SPI bus Serial Clock
+        /// * `PCINT1`: External Interrupt (Pin Change)
+        pub d52: portb::pb1::PB1,
+        /// `D53`
+        ///
+        /// * `SS`: SPI bus Slave Select
+        /// * `PCINT0`: External Interrupt (Pin Change)
+        pub d53: portb::pb0::PB0,
+        /// `A0`
+        ///
+        /// * `ADC0`: A/D converter input 0
+        pub a0: portf::pf0::PF0,
+        /// `A1`
+        ///
+        /// * `ADC1`: A/D converter input 1
+        pub a1: portf::pf1::PF1,
+        /// `A2`
+        ///
+        /// * `ADC2`: A/D converter input 2
+        pub a2: portf::pf2::PF2,
+        /// `A3`
+        ///
+        /// * `ADC3`: A/D converter input 3
+        pub a3: portf::pf3::PF3,
+        /// `A4`
+        ///
+        /// * `ADC4`: A/D converter input 4
+        /// * `TCK`: JTAG test clock
+        pub a4: portf::pf4::PF4,
+        /// `A5`
+        ///
+        /// * `ADC5`: A/D converter input 5
+        /// * `TMS`: JTAG test mode select
+        pub a5: portf::pf5::PF5,
+        /// `A6`
+        ///
+        /// * `ADC6`: A/D converter input 6
+        /// * `TDO`: JTAG test data output
+        pub a6: portf::pf6::PF6,
+        /// `A7`
+        ///
+        /// * `ADC7`: A/D converter input 7
+        /// * `TDI`: JTAG test data input
+        pub a7: portf::pf7::PF7,
+        /// `A8`
+        ///
+        /// * `ADC8`: A/D converter input 8
+        /// * `PCINT16`: External Interrupt (Pin Change)
+        pub a8: portk::pk0::PK0,
+        /// `A9`
+        ///
+        /// * `ADC9`: A/D converter input 9
+        /// * `PCINT17`: External Interrupt (Pin Change)
+        pub a9: portk::pk1::PK1,
+        /// `A10`
+        ///
+        /// * `ADC10`: A/D converter input 10
+        /// * `PCINT18`: External Interrupt (Pin Change)
+        pub a10: portk::pk2::PK2,
+        /// `A11`
+        ///
+        /// * `ADC11`: A/D converter input 11
+        /// * `PCINT19`: External Interrupt (Pin Change)
+        pub a11: portk::pk3::PK3,
+        /// `A12`
+        ///
+        /// * `ADC12`: A/D converter input 12
+        /// * `PCINT20`: External Interrupt (Pin Change)
+        pub a12: portk::pk4::PK4,
+        /// `A13`
+        ///
+        /// * `ADC13`: A/D converter input 13
+        /// * `PCINT21`: External Interrupt (Pin Change)
+        pub a13: portk::pk5::PK5,
+        /// `A14`
+        ///
+        /// * `ADC14`: A/D converter input 14
+        /// * `PCINT22`: External Interrupt (Pin Change)
+        pub a14: portk::pk6::PK6,
+        /// `A15`
+        ///
+        /// * `ADC15`: A/D converter input 15
+        /// * `PCINT23`: External Interrupt (Pin Change)
+        pub a15: portk::pk7::PK7,
+    }
+}

--- a/chips/atmega2560-hal/Cargo.toml
+++ b/chips/atmega2560-hal/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "atmega2560-hal"
+version = "0.1.0"
+authors = ["Andrew Dona-Couch <avr-hal@couchand.com>"]
+edition = "2018"
+
+[features]
+rt = ["avr-device/rt"]
+
+[dependencies]
+avr-hal-generic = { path = "../../avr-hal-generic/" }
+
+[dependencies.avr-device]
+version = "0.1.1"
+features = ["atmega2560"]

--- a/chips/atmega2560-hal/avr-atmega2560.json
+++ b/chips/atmega2560-hal/avr-atmega2560.json
@@ -1,0 +1,32 @@
+{
+  "llvm-target": "avr-unknown-unknown",
+  "cpu": "atmega2560",
+  "target-endian": "little",
+  "target-pointer-width": "16",
+  "target-c-int-width": "16",
+  "os": "unknown",
+  "target-env": "",
+  "target-vendor": "unknown",
+  "arch": "avr",
+  "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "executables": true,
+  "linker": "avr-gcc",
+  "linker-flavor": "gcc",
+  "pre-link-args": {
+    "gcc": [
+      "-Os",
+      "-mmcu=atmega2560"
+    ]
+  },
+  "exe-suffix": ".elf",
+  "post-link-args": {
+    "gcc": [
+      "-Wl,--gc-sections"
+    ]
+  },
+  "singlethread": false,
+  "no-builtins": false,
+  "no-default-libraries": false,
+
+  "eh-frame-header": false
+}

--- a/chips/atmega2560-hal/src/adc.rs
+++ b/chips/atmega2560-hal/src/adc.rs
@@ -1,0 +1,56 @@
+extern crate avr_hal_generic as avr_hal;
+
+use crate::port::portf::{PF0, PF1, PF2, PF3, PF4, PF5, PF6, PF7};
+use crate::port::portk::{PK0, PK1, PK2, PK3, PK4, PK5, PK6, PK7};
+
+use crate::atmega2560::adc::admux::MUX_A;
+
+avr_hal::impl_adc! {
+    pub struct Adc {
+        type ChannelID = MUX_A;
+        peripheral: crate::atmega2560::ADC,
+        set_mux: |peripheral, id| {
+            peripheral.admux.modify(|_, w| w.mux().variant(id));
+        },
+        pins: {
+            pf0: (PF0, MUX_A::ADC0, didr0::adc0d),
+            pf1: (PF1, MUX_A::ADC1, didr0::adc1d),
+            pf2: (PF2, MUX_A::ADC2, didr0::adc2d),
+            pf3: (PF3, MUX_A::ADC3, didr0::adc3d),
+            pf4: (PF4, MUX_A::ADC4, didr0::adc4d),
+            pf5: (PF5, MUX_A::ADC5, didr0::adc5d),
+            pf6: (PF6, MUX_A::ADC6, didr0::adc6d),
+            pf7: (PF7, MUX_A::ADC7, didr0::adc7d),
+            pk0: (PK0, MUX_A::ADC8, didr2::adc8d),
+            pk1: (PK1, MUX_A::ADC9, didr2::adc9d),
+            pk2: (PK2, MUX_A::ADC10, didr2::adc10d),
+            pk3: (PK3, MUX_A::ADC11, didr2::adc11d),
+            pk4: (PK4, MUX_A::ADC12, didr2::adc12d),
+            pk5: (PK5, MUX_A::ADC13, didr2::adc13d),
+            pk6: (PK6, MUX_A::ADC14, didr2::adc14d),
+            pk7: (PK7, MUX_A::ADC15, didr2::adc15d),
+        }
+    }
+}
+
+/// Additional channels
+///
+/// This module contains ADC channels, additional to the direct pin channels.
+pub mod channel {
+    use avr_hal::hal::adc::Channel;
+    use crate::atmega2560::adc::admux::MUX_A;
+
+    /// Channel for the _Bandgap Reference Voltage_
+    pub struct Vbg;
+    impl Channel<super::Adc> for Vbg {
+        type ID = MUX_A;
+        fn channel() -> Self::ID { MUX_A::ADC_VBG }
+    }
+
+    /// Channel for _GND_
+    pub struct Gnd;
+    impl Channel<super::Adc> for Gnd {
+        type ID = MUX_A;
+        fn channel() -> Self::ID { MUX_A::ADC_GND }
+    }
+}

--- a/chips/atmega2560-hal/src/adc.rs
+++ b/chips/atmega2560-hal/src/adc.rs
@@ -11,6 +11,8 @@ avr_hal::impl_adc! {
         peripheral: crate::atmega2560::ADC,
         set_mux: |peripheral, id| {
             peripheral.admux.modify(|_, w| w.mux().variant(id));
+            // n.b. the high bit of ADMUX[MUX] is in the ADCSRB register
+            peripheral.adcsrb.modify(|_, w| w.mux5().bit((id as u8) & 0b100000 != 0));
         },
         pins: {
             pf0: (PF0, MUX_A::ADC0, didr0::adc0d),

--- a/chips/atmega2560-hal/src/lib.rs
+++ b/chips/atmega2560-hal/src/lib.rs
@@ -12,6 +12,7 @@ pub use avr_hal::delay;
 
 pub mod adc;
 pub mod port;
+pub mod spi;
 pub mod usart;
 
 pub mod prelude {

--- a/chips/atmega2560-hal/src/lib.rs
+++ b/chips/atmega2560-hal/src/lib.rs
@@ -10,6 +10,7 @@ pub use avr_device::entry;
 pub use avr_hal::clock;
 pub use avr_hal::delay;
 
+pub mod adc;
 pub mod port;
 pub mod usart;
 

--- a/chips/atmega2560-hal/src/lib.rs
+++ b/chips/atmega2560-hal/src/lib.rs
@@ -1,0 +1,49 @@
+#![no_std]
+
+extern crate avr_hal_generic as avr_hal;
+
+pub use avr_device::atmega2560;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
+
+pub use avr_hal::clock;
+pub use avr_hal::delay;
+
+pub mod port;
+pub mod usart;
+
+pub mod prelude {
+    pub use crate::avr_hal::prelude::*;
+    pub use crate::port::PortExt as _;
+}
+
+pub mod i2c {
+    use crate::port::portd;
+    pub use avr_hal::i2c::*;
+
+    avr_hal::impl_twi_i2c! {
+        pub struct I2c {
+            peripheral: crate::atmega2560::TWI,
+            pins: {
+                sda: portd::PD1,
+                scl: portd::PD0,
+            },
+            registers: {
+                control: twcr {
+                    enable: twen,
+                    ack: twea,
+                    int: twint,
+                    start: twsta,
+                    stop: twsto,
+                },
+                status: twsr {
+                    prescaler: twps,
+                    status: tws,
+                },
+                bitrate: twbr,
+                data: twdr,
+            },
+        }
+    }
+}

--- a/chips/atmega2560-hal/src/port.rs
+++ b/chips/atmega2560-hal/src/port.rs
@@ -1,0 +1,263 @@
+pub use avr_hal::port::mode;
+
+pub trait PortExt {
+    type Parts;
+
+    fn split(self) -> Self::Parts;
+}
+
+avr_hal::impl_generic_pin! {
+    pub enum Pin {
+        A(crate::atmega2560::PORTA, porta, pina),
+        B(crate::atmega2560::PORTB, portb, pinb),
+        C(crate::atmega2560::PORTC, portc, pinc),
+        D(crate::atmega2560::PORTD, portd, pind),
+        E(crate::atmega2560::PORTE, porte, pine),
+        F(crate::atmega2560::PORTF, portf, pinf),
+        G(crate::atmega2560::PORTG, portg, ping),
+        H(crate::atmega2560::PORTH, porth, pinh),
+        J(crate::atmega2560::PORTJ, portj, pinj),
+        K(crate::atmega2560::PORTK, portk, pink),
+        L(crate::atmega2560::PORTL, portl, pinl),
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod porta {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::A;
+
+        impl PortExt for crate::atmega2560::PORTA {
+            regs: (pina, ddra, porta),
+            pa0: (PA0, 0),
+            pa1: (PA1, 1),
+            pa2: (PA2, 2),
+            pa3: (PA3, 3),
+            pa4: (PA4, 4),
+            pa5: (PA5, 5),
+            pa6: (PA6, 6),
+            pa7: (PA7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portb {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::B;
+
+        impl PortExt for crate::atmega2560::PORTB {
+            regs: (pinb, ddrb, portb),
+            pb0: (PB0, 0),
+            pb1: (PB1, 1),
+            pb2: (PB2, 2),
+            pb3: (PB3, 3),
+            pb4: (PB4, 4),
+            pb5: (PB5, 5),
+            pb6: (PB6, 6),
+            pb7: (PB7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portc {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::C;
+
+        impl PortExt for crate::atmega2560::PORTC {
+            regs: (pinc, ddrc, portc),
+            pc0: (PC0, 0),
+            pc1: (PC1, 1),
+            pc2: (PC2, 2),
+            pc3: (PC3, 3),
+            pc4: (PC4, 4),
+            pc5: (PC5, 5),
+            pc6: (PC6, 6),
+            pc7: (PC7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portd {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::D;
+
+        impl PortExt for crate::atmega2560::PORTD {
+            regs: (pind, ddrd, portd),
+            pd0: (PD0, 0),
+            pd1: (PD1, 1),
+            pd2: (PD2, 2),
+            pd3: (PD3, 3),
+            pd4: (PD4, 4),
+            pd5: (PD5, 5),
+            pd6: (PD6, 6),
+            pd7: (PD7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod porte {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::E;
+
+        impl PortExt for crate::atmega2560::PORTE {
+            regs: (pine, ddre, porte),
+            pe0: (PE0, 0),
+            pe1: (PE1, 1),
+            pe2: (PE2, 2),
+            pe3: (PE3, 3),
+            pe4: (PE4, 4),
+            pe5: (PE5, 5),
+            pe6: (PE6, 6),
+            pe7: (PE7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portf {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::F;
+
+        impl PortExt for crate::atmega2560::PORTF {
+            regs: (pinf, ddrf, portf),
+            pf0: (PF0, 0),
+            pf1: (PF1, 1),
+            pf2: (PF2, 2),
+            pf3: (PF3, 3),
+            pf4: (PF4, 4),
+            pf5: (PF5, 5),
+            pf6: (PF6, 6),
+            pf7: (PF7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portg {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::G;
+
+        impl PortExt for crate::atmega2560::PORTG {
+            regs: (ping, ddrg, portg),
+            pg0: (PG0, 0),
+            pg1: (PG1, 1),
+            pg2: (PG2, 2),
+            pg3: (PG3, 3),
+            pg4: (PG4, 4),
+            pg5: (PG5, 5),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod porth {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::H;
+
+        impl PortExt for crate::atmega2560::PORTH {
+            regs: (pinh, ddrh, porth),
+            ph0: (PH0, 0),
+            ph1: (PH1, 1),
+            ph2: (PH2, 2),
+            ph3: (PH3, 3),
+            ph4: (PH4, 4),
+            ph5: (PH5, 5),
+            ph6: (PH6, 6),
+            ph7: (PH7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portj {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::J;
+
+        impl PortExt for crate::atmega2560::PORTJ {
+            regs: (pinj, ddrj, portj),
+            pj0: (PJ0, 0),
+            pj1: (PJ1, 1),
+            pj2: (PJ2, 2),
+            pj3: (PJ3, 3),
+            pj4: (PJ4, 4),
+            pj5: (PJ5, 5),
+            pj6: (PJ6, 6),
+            pj7: (PJ7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portk {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::K;
+
+        impl PortExt for crate::atmega2560::PORTK {
+            regs: (pink, ddrk, portk),
+            pk0: (PK0, 0),
+            pk1: (PK1, 1),
+            pk2: (PK2, 2),
+            pk3: (PK3, 3),
+            pk4: (PK4, 4),
+            pk5: (PK5, 5),
+            pk6: (PK6, 6),
+            pk7: (PK7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portl {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::L;
+
+        impl PortExt for crate::atmega2560::PORTL {
+            regs: (pinl, ddrl, portl),
+            pl0: (PL0, 0),
+            pl1: (PL1, 1),
+            pl2: (PL2, 2),
+            pl3: (PL3, 3),
+            pl4: (PL4, 4),
+            pl5: (PL5, 5),
+            pl6: (PL6, 6),
+            pl7: (PL7, 7),
+        }
+    }
+}

--- a/chips/atmega2560-hal/src/spi.rs
+++ b/chips/atmega2560-hal/src/spi.rs
@@ -1,0 +1,40 @@
+//! Implementation of the Rust Embedded-HAL SPI FullDuplex trait for AVR.
+//!
+//! The interface can be instantiated with the `new` method, and used directly
+//! or passed into a driver.  Example usage:
+//!
+//! ```
+//! pins.d53.into_output(&mut pins.ddr);// SS must be set to output mode
+//! // create SPI interface
+//! let mut spi = Spi::new(
+//!     dp.SPI,// SPI peripheral
+//!     pins.d52.into_output(&mut pins.ddr),// SCLK
+//!     pins.d51.into_output(&mut pins.ddr),// MOSI output pin
+//!     pins.d50.into_pull_up_input(&mut pins.ddr),// MISO input pin
+//!     Settings::default(),
+//! );
+//!
+//! // Send a byte
+//! let sent = 0b10101010;
+//! spi.send(sent).unwrap();
+//! let response = spi.read().unwrap();
+//! ```
+//! In the example above, all of the settings are left at the default.  You can
+//! also instantiate a Settings object with the other options available.
+
+extern crate avr_hal_generic as avr_hal;
+
+pub use avr_hal::spi::*;
+use crate::port::portb;
+
+
+avr_hal::impl_spi! {
+    pub struct Spi {
+        peripheral: crate::atmega2560::SPI,
+        pins: {
+            sclk: portb::PB1,
+            mosi: portb::PB2,
+            miso: portb::PB3,
+        }
+    }
+}

--- a/chips/atmega2560-hal/src/usart.rs
+++ b/chips/atmega2560-hal/src/usart.rs
@@ -1,0 +1,117 @@
+use crate::port::porte;
+use crate::port::portd;
+use crate::port::porth;
+use crate::port::portj;
+
+crate::avr_hal::impl_usart! {
+    pub struct Usart0 {
+        peripheral: crate::atmega2560::USART0,
+        pins: {
+            rx: porte::PE0,
+            tx: porte::PE1,
+        },
+        registers: {
+            control_a: ucsr0a {
+                data_empty: udre0,
+                recv_complete: rxc0,
+            },
+            control_b: ucsr0b {
+                tx_enable: txen0,
+                rx_enable: rxen0,
+            },
+            control_c: ucsr0c {
+                mode: umsel0,
+                char_size: ucsz0,
+                stop_bits: usbs0,
+                parity: upm0,
+            },
+            baud: ubrr0,
+            data: udr0,
+        },
+    }
+}
+
+crate::avr_hal::impl_usart! {
+    pub struct Usart1 {
+        peripheral: crate::atmega2560::USART1,
+        pins: {
+            rx: portd::PD2,
+            tx: portd::PD3,
+        },
+        registers: {
+            control_a: ucsr1a {
+                data_empty: udre1,
+                recv_complete: rxc1,
+            },
+            control_b: ucsr1b {
+                tx_enable: txen1,
+                rx_enable: rxen1,
+            },
+            control_c: ucsr1c {
+                mode: umsel1,
+                char_size: ucsz1,
+                stop_bits: usbs1,
+                parity: upm1,
+            },
+            baud: ubrr1,
+            data: udr1,
+        },
+    }
+}
+
+crate::avr_hal::impl_usart! {
+    pub struct Usart2 {
+        peripheral: crate::atmega2560::USART2,
+        pins: {
+            rx: porth::PH0,
+            tx: porth::PH1,
+        },
+        registers: {
+            control_a: ucsr2a {
+                data_empty: udre2,
+                recv_complete: rxc2,
+            },
+            control_b: ucsr2b {
+                tx_enable: txen2,
+                rx_enable: rxen2,
+            },
+            control_c: ucsr2c {
+                mode: umsel2,
+                char_size: ucsz2,
+                stop_bits: usbs2,
+                parity: upm2,
+            },
+            baud: ubrr2,
+            data: udr2,
+        },
+    }
+}
+
+crate::avr_hal::impl_usart! {
+    pub struct Usart3 {
+        peripheral: crate::atmega2560::USART3,
+        pins: {
+            rx: portj::PJ0,
+            tx: portj::PJ1,
+        },
+        registers: {
+            control_a: ucsr3a {
+                data_empty: udre3,
+                recv_complete: rxc3,
+            },
+            control_b: ucsr3b {
+                tx_enable: txen3,
+                rx_enable: rxen3,
+            },
+            control_c: ucsr3c {
+                mode: umsel3,
+                char_size: ucsz3,
+                stop_bits: usbs3,
+                parity: upm3,
+            },
+            baud: ubrr3,
+            data: udr3,
+        },
+    }
+}
+


### PR DESCRIPTION
More or less just copied from the ATmega1280 and BigAVR6 definitions, with the minimal changes needed to get the examples running.

Note that the `avr-device` dep is currently specified using a relative path, this presumably should be updated to use the new version once https://github.com/Rahix/avr-device/pull/32 lands.