### PR TITLE
Add support for ATtiny88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "chips/atmega328p-hal",
     "chips/atmega32u4-hal",
     "chips/attiny85-hal",
+    "chips/attiny88-hal",
 
     # The board crates
     "boards/arduino-leonardo",

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ The chip-HAL crates currently support the following peripherals:
 * [`attiny85-hal`](./chips/attiny85-hal)
   - [x] Spinning Delay
   - [x] `PORTB` as digital IO (v2)
+* [`attiny88-hal`](./chips/attiny88-hal)
+  - [x] Spinning Delay
+  - [x] `PORTA`, `PORTB`, `PORTC`, `PORTD` as digital IO
 
 ### Supported Hardware
 In `boards/` there are crates for the following hardware.  Please note that this project is in no way affiliated with any of the vendors.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The chip-HAL crates currently support the following peripherals:
 * [`attiny88-hal`](./chips/attiny88-hal)
   - [x] Spinning Delay
   - [x] `PORTA`, `PORTB`, `PORTC`, `PORTD` as digital IO
+  - [x] I2C using `TWI`
+  - [x] SPI
 
 ### Supported Hardware
 In `boards/` there are crates for the following hardware.  Please note that this project is in no way affiliated with any of the vendors.

--- a/chips/attiny88-hal/Cargo.toml
+++ b/chips/attiny88-hal/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "attiny88-hal"
+version = "0.1.0"
+authors = ["Andrew Dona-Couch <avr-hal@couchand.com>"]
+edition = "2018"
+
+[features]
+rt = ["avr-device/rt"]
+
+[dependencies]
+avr-hal-generic = { path = "../../avr-hal-generic/" }
+
+[dependencies.avr-device]
+version = "0.2.0"
+features = ["attiny88"]

--- a/chips/attiny88-hal/avr-attiny88.json
+++ b/chips/attiny88-hal/avr-attiny88.json
@@ -1,0 +1,31 @@
+{
+  "llvm-target": "avr-unknown-unknown",
+  "cpu": "attiny88",
+  "target-endian": "little",
+  "target-pointer-width": "16",
+  "target-c-int-width": "16",
+  "os": "unknown",
+  "target-env": "",
+  "target-vendor": "unknown",
+  "arch": "avr",
+  "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+
+  "executables": true,
+
+  "linker": "avr-gcc",
+  "linker-flavor": "gcc",
+  "pre-link-args": {
+    "gcc": ["-Os", "-mmcu=attiny88"]
+  },
+  "exe-suffix": ".elf",
+  "post-link-args": {
+    "gcc": ["-Wl,--gc-sections"]
+  },
+
+  "singlethread": false,
+  "no-builtins": false,
+
+  "no-default-libraries": false,
+
+  "eh-frame-header": false
+}

--- a/chips/attiny88-hal/src/lib.rs
+++ b/chips/attiny88-hal/src/lib.rs
@@ -12,7 +12,41 @@ pub use avr_hal::delay;
 
 pub mod port;
 
+pub mod spi;
+
 pub mod prelude {
     pub use crate::avr_hal::prelude::*;
     pub use crate::port::PortExt as _;
+}
+
+/// I2C Bus
+pub mod i2c {
+    use crate::port::portc;
+    pub use avr_hal::i2c::*;
+
+    avr_hal::impl_twi_i2c! {
+        /// I2C based on ATtiny88's TWI peripheral
+        pub struct I2c {
+            peripheral: crate::attiny88::TWI,
+            pins: {
+                sda: portc::PC4,
+                scl: portc::PC5,
+            },
+            registers: {
+                control: twcr {
+                    enable: twen,
+                    ack: twea,
+                    int: twint,
+                    start: twsta,
+                    stop: twsto,
+                },
+                status: twsr {
+                    prescaler: twps,
+                    status: tws,
+                },
+                bitrate: twbr,
+                data: twdr,
+            },
+        }
+    }
 }

--- a/chips/attiny88-hal/src/lib.rs
+++ b/chips/attiny88-hal/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+
+extern crate avr_hal_generic as avr_hal;
+
+pub use avr_device::attiny88;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
+
+pub use avr_hal::clock;
+pub use avr_hal::delay;
+
+pub mod port;
+
+pub mod prelude {
+    pub use crate::avr_hal::prelude::*;
+    pub use crate::port::PortExt as _;
+}

--- a/chips/attiny88-hal/src/port.rs
+++ b/chips/attiny88-hal/src/port.rs
@@ -1,0 +1,98 @@
+pub trait PortExt {
+    type Parts;
+
+    fn split(self) -> Self::Parts;
+}
+
+avr_hal::impl_generic_pin! {
+    pub enum Pin {
+        A(crate::attiny88::PORTA, porta, pina),
+        B(crate::attiny88::PORTB, portb, pinb),
+        C(crate::attiny88::PORTC, portc, pinc),
+        D(crate::attiny88::PORTD, portd, pind),
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod porta {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::A;
+
+        impl PortExt for crate::attiny88::PORTA {
+            regs: (pina, ddra, porta),
+            pa0: (PA0, 0),
+            pa1: (PA1, 1),
+            pa2: (PA2, 2),
+            pa3: (PA3, 3),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portb {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::B;
+
+        impl PortExt for crate::attiny88::PORTB {
+            regs: (pinb, ddrb, portb),
+            pb0: (PB0, 0),
+            pb1: (PB1, 1),
+            pb2: (PB2, 2),
+            pb3: (PB3, 3),
+            pb4: (PB4, 4),
+            pb5: (PB5, 5),
+            pb6: (PB6, 6),
+            pb7: (PB7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portc {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::C;
+
+        impl PortExt for crate::attiny88::PORTC {
+            regs: (pinc, ddrc, portc),
+            pc0: (PC0, 0),
+            pc1: (PC1, 1),
+            pc2: (PC2, 2),
+            pc3: (PC3, 3),
+            pc4: (PC4, 4),
+            pc5: (PC5, 5),
+            pc6: (PC6, 6),
+            pc7: (PC7, 7),
+        }
+    }
+}
+
+avr_hal::impl_port! {
+    pub mod portd {
+        #[port_ext]
+        use super::PortExt;
+
+        #[generic_pin]
+        use Pin::D;
+
+        impl PortExt for crate::attiny88::PORTD {
+            regs: (pind, ddrd, portd),
+            pd0: (PD0, 0),
+            pd1: (PD1, 1),
+            pd2: (PD2, 2),
+            pd3: (PD3, 3),
+            pd4: (PD4, 4),
+            pd5: (PD5, 5),
+            pd6: (PD6, 6),
+            pd7: (PD7, 7),
+        }
+    }
+}

--- a/chips/attiny88-hal/src/spi.rs
+++ b/chips/attiny88-hal/src/spi.rs
@@ -1,0 +1,37 @@
+//! Implementation of the Rust Embedded-HAL SPI FullDuplex trait for AVR.
+//!
+//! The interface can be instantiated with the `new` method, and used directly
+//! or passed into a driver.  Example usage:
+//!
+//! ```
+//! portb::PB2.into_output(&mut pins.ddr);// SS must be set to output mode
+//! // create SPI interface
+//! let mut spi = Spi::new(
+//!     dp.SPI,// SPI peripheral
+//!     portb::PB5.into_output(&mut pins.ddr),// SCLK
+//!     portb::PB3.into_output(&mut pins.ddr),// MOSI output pin
+//!     portb::PB4.into_pull_up_input(&mut pins.ddr),// MISO input pin
+//!     Settings::default(),
+//! );
+//!
+//! // Send a byte
+//! let sent = 0b10101010;
+//! spi.send(sent).unwrap();
+//! let response = spi.read().unwrap();
+//! ```
+//! In the example above, all of the settings are left at the default.  You can
+//! also instantiate a Settings object with the other options available.
+
+use crate::port::portb;
+pub use avr_hal::spi::*;
+
+avr_hal::impl_spi! {
+    pub struct Spi {
+        peripheral: crate::attiny88::SPI,
+        pins: {
+            sclk: portb::PB5,
+            mosi: portb::PB3,
+            miso: portb::PB4,
+        }
+    }
+}


### PR DESCRIPTION
This much of the tiny88 was not too hard once I got the `avr-device` patches in place.

Looks like none of the other `chips` have example files, but I'd like to add some here, any objection?

I'm a bit hung up on the ADC support, feel free to take a look at https://github.com/couchand/avr-hal/tree/202008/attiny88 (relevant commit: https://github.com/couchand/avr-hal/commit/8bc9f59bc97c585c9b94dad12c622b7771ad13e6) to see my current attempt.  One thing I really don't like over there is the `ReferenceVoltage` enum having an extra variant that's not relevant to this model.  Maybe I should open a separate PR for that discussion?

Of course this will need an updated version of `avr-device` before it will build.