### PR TITLE
Refactor serial & add methods for enabling interrupts

### DIFF
--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 cfg-if = "0.1.7"
 nb = "0.1.2"
 ufmt = "0.1.0"
-paste = "0.1.18"
+paste = "1.0.0"
 avr-device = "0.2.1"
 
 [dependencies.embedded-hal]

--- a/avr-hal-generic/src/serial.rs
+++ b/avr-hal-generic/src/serial.rs
@@ -11,26 +11,9 @@ macro_rules! impl_usart {
                 rx: $rxmod:ident::$RX:ident,
                 tx: $txmod:ident::$TX:ident,
             },
-            registers: {
-                control_a: $control_a:ident {
-                    data_empty: $dre:ident,
-                    recv_complete: $rxc:ident,
-                },
-                control_b: $control_b:ident {
-                    tx_enable: $txen:ident,
-                    rx_enable: $rxen:ident,
-                },
-                control_c: $control_c:ident {
-                    mode: $umode:ident,
-                    char_size: $csz:ident,
-                    stop_bits: $sbs:ident,
-                    parity: $par:ident,
-                },
-                baud: $baud:ident,
-                data: $data:ident,
-            },
+            register_suffix: $n:expr,
         }
-    ) => {
+    ) => {$crate::paste::paste! {
         $(#[$usart_attr])*
         pub struct $Usart<CLOCK, RX_MODE>
         where
@@ -59,57 +42,53 @@ macro_rules! impl_usart {
                 tx: $txmod::$TX<$crate::port::mode::Output>,
                 baud: u32,
             ) -> $Usart<CLOCK, RX_MODE> {
-                // Calculate BRR value
-                let brr = CLOCK::FREQ / (16 * baud) - 1;
-                // Set baudrate
-                p.$baud.write(|w| unsafe { w.bits(brr as u16) });
-                // Enable receiver and transmitter
-                p.$control_b
-                    .write(|w| w.$txen().set_bit().$rxen().set_bit());
-                // Set frame format (8n1)
-                p.$control_c.write(|w| {
-                    w.$umode()
-                        .usart_async()
-                        .$csz()
-                        .chr8()
-                        .$sbs()
-                        .stop1()
-                        .$par()
-                        .disabled()
-                });
-
-                $Usart {
+                let mut usart = $Usart {
                     p,
                     rx,
                     tx,
                     _clock: ::core::marker::PhantomData,
-                }
+                };
+                usart.initialize(baud);
+                usart
             }
-        }
 
-        $crate::paste::paste! {
-            impl<CLOCK, RX_MODE> $Usart<CLOCK, RX_MODE>
-            where
-                CLOCK: $crate::clock::Clock,
-                RX_MODE: $crate::port::mode::InputMode,
-            {
-                /// Helper method for splitting this read/write object into two halves.
-                ///
-                /// The two halves returned implement the `Read` and `Write` traits, respectively.
-                pub fn split(self) -> ([<Read $Usart>]<CLOCK, RX_MODE>, [<Write $Usart>]<CLOCK>) {
-                    (
-                        [<Read $Usart>] {
-                            p: unsafe { ::core::ptr::read(&self.p) },
-                            rx: self.rx,
-                            _clock: self._clock,
-                        },
-                        [<Write $Usart>] {
-                            p: self.p,
-                            tx: self.tx,
-                            _clock: self._clock,
-                        }
-                    )
-                }
+            fn initialize(&mut self, baud: u32) {
+                // Value for baudrate register must be calculated based on clock frequency.
+                let brr = CLOCK::FREQ / (16 * baud) - 1;
+                self.p.[<ubrr $n>].write(|w| unsafe { w.bits(brr as u16) });
+
+                // Enable receiver and transmitter but leave interrupts disabled.
+                self.p.[<ucsr $n b>].write(|w| w
+                    .[<txen $n>]().set_bit()
+                    .[<rxen $n>]().set_bit()
+                );
+
+                // Set frame format to 8n1 for now.  At some point, this should be made
+                // configurable, similar to what is done in other HALs.
+                self.p.[<ucsr $n c>].write(|w| w
+                    .[<umsel $n>]().usart_async()
+                    .[<ucsz $n>]().chr8()
+                    .[<usbs $n>]().stop1()
+                    .[<upm $n>]().disabled()
+                );
+            }
+
+            /// Helper method for splitting this read/write object into two halves.
+            ///
+            /// The two halves returned implement the `Read` and `Write` traits, respectively.
+            pub fn split(self) -> ([<Read $Usart>]<CLOCK, RX_MODE>, [<Write $Usart>]<CLOCK>) {
+                (
+                    [<Read $Usart>] {
+                        p: unsafe { ::core::ptr::read(&self.p) },
+                        rx: self.rx,
+                        _clock: self._clock,
+                    },
+                    [<Write $Usart>] {
+                        p: self.p,
+                        tx: self.tx,
+                        _clock: self._clock,
+                    }
+                )
             }
         }
 
@@ -124,12 +103,12 @@ macro_rules! impl_usart {
                 // Call flush to make sure the data-register is empty
                 self.flush()?;
 
-                self.p.$data.write(|w| unsafe { w.bits(byte) });
+                self.p.[<udr $n>].write(|w| unsafe { w.bits(byte) });
                 Ok(())
             }
 
             fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
-                if self.p.$control_a.read().$dre().bit_is_clear() {
+                if self.p.[<ucsr $n a>].read().[<udre $n>]().bit_is_clear() {
                     Err($crate::nb::Error::WouldBlock)
                 } else {
                     Ok(())
@@ -162,121 +141,119 @@ macro_rules! impl_usart {
             type Error = $crate::void::Void;
 
             fn read(&mut self) -> $crate::nb::Result<u8, Self::Error> {
-                if self.p.$control_a.read().$rxc().bit_is_clear() {
+                if self.p.[<ucsr $n a>].read().[<rxc $n>]().bit_is_clear() {
                     return Err($crate::nb::Error::WouldBlock);
                 }
 
-                Ok(self.p.$data.read().bits())
+                Ok(self.p.[<udr $n>].read().bits())
             }
         }
 
-        $crate::paste::paste! {
-            /// The readable half of the
-            $(#[$usart_attr])*
-            pub struct [<Read $Usart>]<CLOCK, RX_MODE>
-            where
-                CLOCK: $crate::clock::Clock,
-                RX_MODE: $crate::port::mode::InputMode,
-            {
-                p: $USART,
-                rx: $rxmod::$RX<$crate::port::mode::Input<RX_MODE>>,
-                _clock: ::core::marker::PhantomData<CLOCK>,
-            }
+        /// The readable half of the
+        $(#[$usart_attr])*
+        pub struct [<Read $Usart>]<CLOCK, RX_MODE>
+        where
+            CLOCK: $crate::clock::Clock,
+            RX_MODE: $crate::port::mode::InputMode,
+        {
+            p: $USART,
+            rx: $rxmod::$RX<$crate::port::mode::Input<RX_MODE>>,
+            _clock: ::core::marker::PhantomData<CLOCK>,
+        }
 
-            /// The writable half of the
-            $(#[$usart_attr])*
-            pub struct [<Write $Usart>]<CLOCK>
-            where
-                CLOCK: $crate::clock::Clock,
-            {
-                p: $USART,
-                tx: $txmod::$TX<$crate::port::mode::Output>,
-                _clock: ::core::marker::PhantomData<CLOCK>,
-            }
+        /// The writable half of the
+        $(#[$usart_attr])*
+        pub struct [<Write $Usart>]<CLOCK>
+        where
+            CLOCK: $crate::clock::Clock,
+        {
+            p: $USART,
+            tx: $txmod::$TX<$crate::port::mode::Output>,
+            _clock: ::core::marker::PhantomData<CLOCK>,
+        }
 
-            impl<CLOCK, RX_MODE> [<Read $Usart>]<CLOCK, RX_MODE>
-            where
-                CLOCK: $crate::clock::Clock,
-                RX_MODE: $crate::port::mode::InputMode,
-            {
-                /// Puts the two "halves" of a split `Read + Write` back together.
-                pub fn reunite(self, other: [<Write $Usart>]<CLOCK>) -> $Usart<CLOCK, RX_MODE> {
-                    $Usart {
-                        p: self.p,
-                        rx: self.rx,
-                        tx: other.tx,
-                        _clock: self._clock,
-                    }
-                }
-            }
-
-            impl<CLOCK> [<Write $Usart>]<CLOCK>
-            where
-                CLOCK: $crate::clock::Clock,
-            {
-                /// Puts the two "halves" of a split `Read + Write` back together.
-                pub fn reunite<RX_MODE>(self, other: [<Read $Usart>]<CLOCK, RX_MODE>) -> $Usart<CLOCK, RX_MODE>
-                where
-                    RX_MODE: $crate::port::mode::InputMode,
-                {
-                    other.reunite(self)
-                }
-            }
-
-            impl<CLOCK> $crate::hal::serial::Write<u8> for [<Write $Usart>]<CLOCK>
-            where
-                CLOCK: $crate::clock::Clock,
-            {
-                type Error = $crate::void::Void;
-
-                fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
-                    // Call flush to make sure the data-register is empty
-                    self.flush()?;
-
-                    self.p.$data.write(|w| unsafe { w.bits(byte) });
-                    Ok(())
-                }
-
-                fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
-                    if self.p.$control_a.read().$dre().bit_is_clear() {
-                        Err($crate::nb::Error::WouldBlock)
-                    } else {
-                        Ok(())
-                    }
-                }
-            }
-
-            impl<CLOCK> $crate::ufmt::uWrite for [<Write $Usart>]<CLOCK>
-            where
-                CLOCK: $crate::clock::Clock,
-            {
-                type Error = $crate::void::Void;
-
-                fn write_str(&mut self, s: &str) -> ::core::result::Result<(), Self::Error> {
-                    use $crate::prelude::*;
-
-                    for b in s.as_bytes().iter() {
-                        $crate::nb::block!(self.write(*b))?;
-                    }
-                    Ok(())
-                }
-            }
-
-            impl<CLOCK, RX_MODE> $crate::hal::serial::Read<u8> for [<Read $Usart>]<CLOCK, RX_MODE>
-            where
-                CLOCK: $crate::clock::Clock,
-                RX_MODE: $crate::port::mode::InputMode,
-            {
-                type Error = $crate::void::Void;
-
-                fn read(&mut self) -> $crate::nb::Result<u8, Self::Error> {
-                    if self.p.$control_a.read().$rxc().bit_is_clear() {
-                        return Err($crate::nb::Error::WouldBlock);
-                    }
-
-                    Ok(self.p.$data.read().bits())
+        impl<CLOCK, RX_MODE> [<Read $Usart>]<CLOCK, RX_MODE>
+        where
+            CLOCK: $crate::clock::Clock,
+            RX_MODE: $crate::port::mode::InputMode,
+        {
+            /// Puts the two "halves" of a split `Read + Write` back together.
+            pub fn reunite(self, other: [<Write $Usart>]<CLOCK>) -> $Usart<CLOCK, RX_MODE> {
+                $Usart {
+                    p: self.p,
+                    rx: self.rx,
+                    tx: other.tx,
+                    _clock: self._clock,
                 }
             }
         }
-    };
+
+        impl<CLOCK> [<Write $Usart>]<CLOCK>
+        where
+            CLOCK: $crate::clock::Clock,
+        {
+            /// Puts the two "halves" of a split `Read + Write` back together.
+            pub fn reunite<RX_MODE>(self, other: [<Read $Usart>]<CLOCK, RX_MODE>) -> $Usart<CLOCK, RX_MODE>
+            where
+                RX_MODE: $crate::port::mode::InputMode,
+            {
+                other.reunite(self)
+            }
+        }
+
+        impl<CLOCK> $crate::hal::serial::Write<u8> for [<Write $Usart>]<CLOCK>
+        where
+            CLOCK: $crate::clock::Clock,
+        {
+            type Error = $crate::void::Void;
+
+            fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
+                // Call flush to make sure the data-register is empty
+                self.flush()?;
+
+                self.p.[<udr $n>].write(|w| unsafe { w.bits(byte) });
+                Ok(())
+            }
+
+            fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
+                if self.p.[<ucsr $n a>].read().[<udre $n>]().bit_is_clear() {
+                    Err($crate::nb::Error::WouldBlock)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        impl<CLOCK> $crate::ufmt::uWrite for [<Write $Usart>]<CLOCK>
+        where
+            CLOCK: $crate::clock::Clock,
+        {
+            type Error = $crate::void::Void;
+
+            fn write_str(&mut self, s: &str) -> ::core::result::Result<(), Self::Error> {
+                use $crate::prelude::*;
+
+                for b in s.as_bytes().iter() {
+                    $crate::nb::block!(self.write(*b))?;
+                }
+                Ok(())
+            }
+        }
+
+        impl<CLOCK, RX_MODE> $crate::hal::serial::Read<u8> for [<Read $Usart>]<CLOCK, RX_MODE>
+        where
+            CLOCK: $crate::clock::Clock,
+            RX_MODE: $crate::port::mode::InputMode,
+        {
+            type Error = $crate::void::Void;
+
+            fn read(&mut self) -> $crate::nb::Result<u8, Self::Error> {
+                if self.p.[<ucsr $n a>].read().[<rxc $n>]().bit_is_clear() {
+                    return Err($crate::nb::Error::WouldBlock);
+                }
+
+                Ok(self.p.[<udr $n>].read().bits())
+            }
+        }
+    }}
 }

--- a/avr-hal-generic/src/serial.rs
+++ b/avr-hal-generic/src/serial.rs
@@ -87,7 +87,7 @@ macro_rules! impl_usart {
             }
         }
 
-        $crate::paste::item! {
+        $crate::paste::paste! {
             impl<CLOCK, RX_MODE> $Usart<CLOCK, RX_MODE>
             where
                 CLOCK: $crate::clock::Clock,
@@ -170,7 +170,7 @@ macro_rules! impl_usart {
             }
         }
 
-        $crate::paste::item! {
+        $crate::paste::paste! {
             /// The readable half of the
             $(#[$usart_attr])*
             pub struct [<Read $Usart>]<CLOCK, RX_MODE>

--- a/avr-hal-generic/src/serial.rs
+++ b/avr-hal-generic/src/serial.rs
@@ -73,6 +73,38 @@ macro_rules! impl_usart {
                 );
             }
 
+            /// Enable/disable "RX Complete" interrupt
+            ///
+            /// When this interrupt triggers, new data is available to be read from the
+            /// data-register.  The corresponding ISR is `USARTi_RX` (where `i` is this
+            /// peripheral's number).  For example, for `USART1` on `ATmega32U4`:
+            ///
+            /// ```
+            /// #[avr_device::interrupt(atmega32u4)]
+            /// fn USART1_RX() {
+            ///     // ...
+            /// }
+            /// ```
+            pub fn interrupt_rxc(&mut self, state: bool) {
+                self.p.[<ucsr $n b>].modify(|_, w| w.[<rxcie $n>]().bit(state));
+            }
+
+            /// Enable/disable "USART Data-Register Empty" interrupt
+            ///
+            /// This interrupt signals that new data can be written to the data-register.  The
+            /// corresponding ISR is `USARTi_UDRE` (where `i` is this peripheral's number).  For
+            /// example, for `USART1` on `ATmega32U4`:
+            ///
+            /// ```
+            /// #[avr_device::interrupt(atmega32u4)]
+            /// fn USART1_UDRE() {
+            ///     // ...
+            /// }
+            /// ```
+            pub fn interrupt_udre(&mut self, state: bool) {
+                self.p.[<ucsr $n b>].modify(|_, w| w.[<txcie $n>]().bit(state));
+            }
+
             /// Helper method for splitting this read/write object into two halves.
             ///
             /// The two halves returned implement the `Read` and `Write` traits, respectively.

--- a/chips/atmega1280-hal/src/usart.rs
+++ b/chips/atmega1280-hal/src/usart.rs
@@ -10,24 +10,7 @@ crate::avr_hal::impl_usart! {
             rx: porte::PE0,
             tx: porte::PE1,
         },
-        registers: {
-            control_a: ucsr0a {
-                data_empty: udre0,
-                recv_complete: rxc0,
-            },
-            control_b: ucsr0b {
-                tx_enable: txen0,
-                rx_enable: rxen0,
-            },
-            control_c: ucsr0c {
-                mode: umsel0,
-                char_size: ucsz0,
-                stop_bits: usbs0,
-                parity: upm0,
-            },
-            baud: ubrr0,
-            data: udr0,
-        },
+        register_suffix: 0,
     }
 }
 
@@ -38,24 +21,7 @@ crate::avr_hal::impl_usart! {
             rx: portd::PD2,
             tx: portd::PD3,
         },
-        registers: {
-            control_a: ucsr1a {
-                data_empty: udre1,
-                recv_complete: rxc1,
-            },
-            control_b: ucsr1b {
-                tx_enable: txen1,
-                rx_enable: rxen1,
-            },
-            control_c: ucsr1c {
-                mode: umsel1,
-                char_size: ucsz1,
-                stop_bits: usbs1,
-                parity: upm1,
-            },
-            baud: ubrr1,
-            data: udr1,
-        },
+        register_suffix: 1,
     }
 }
 
@@ -66,24 +32,7 @@ crate::avr_hal::impl_usart! {
             rx: porth::PH0,
             tx: porth::PH1,
         },
-        registers: {
-            control_a: ucsr2a {
-                data_empty: udre2,
-                recv_complete: rxc2,
-            },
-            control_b: ucsr2b {
-                tx_enable: txen2,
-                rx_enable: rxen2,
-            },
-            control_c: ucsr2c {
-                mode: umsel2,
-                char_size: ucsz2,
-                stop_bits: usbs2,
-                parity: upm2,
-            },
-            baud: ubrr2,
-            data: udr2,
-        },
+        register_suffix: 2,
     }
 }
 
@@ -94,24 +43,7 @@ crate::avr_hal::impl_usart! {
             rx: portj::PJ0,
             tx: portj::PJ1,
         },
-        registers: {
-            control_a: ucsr3a {
-                data_empty: udre3,
-                recv_complete: rxc3,
-            },
-            control_b: ucsr3b {
-                tx_enable: txen3,
-                rx_enable: rxen3,
-            },
-            control_c: ucsr3c {
-                mode: umsel3,
-                char_size: ucsz3,
-                stop_bits: usbs3,
-                parity: upm3,
-            },
-            baud: ubrr3,
-            data: udr3,
-        },
+        register_suffix: 3,
     }
 }
 

--- a/chips/atmega2560-hal/src/usart.rs
+++ b/chips/atmega2560-hal/src/usart.rs
@@ -10,24 +10,7 @@ crate::avr_hal::impl_usart! {
             rx: porte::PE0,
             tx: porte::PE1,
         },
-        registers: {
-            control_a: ucsr0a {
-                data_empty: udre0,
-                recv_complete: rxc0,
-            },
-            control_b: ucsr0b {
-                tx_enable: txen0,
-                rx_enable: rxen0,
-            },
-            control_c: ucsr0c {
-                mode: umsel0,
-                char_size: ucsz0,
-                stop_bits: usbs0,
-                parity: upm0,
-            },
-            baud: ubrr0,
-            data: udr0,
-        },
+        register_suffix: 0,
     }
 }
 
@@ -38,24 +21,7 @@ crate::avr_hal::impl_usart! {
             rx: portd::PD2,
             tx: portd::PD3,
         },
-        registers: {
-            control_a: ucsr1a {
-                data_empty: udre1,
-                recv_complete: rxc1,
-            },
-            control_b: ucsr1b {
-                tx_enable: txen1,
-                rx_enable: rxen1,
-            },
-            control_c: ucsr1c {
-                mode: umsel1,
-                char_size: ucsz1,
-                stop_bits: usbs1,
-                parity: upm1,
-            },
-            baud: ubrr1,
-            data: udr1,
-        },
+        register_suffix: 1,
     }
 }
 
@@ -66,24 +32,7 @@ crate::avr_hal::impl_usart! {
             rx: porth::PH0,
             tx: porth::PH1,
         },
-        registers: {
-            control_a: ucsr2a {
-                data_empty: udre2,
-                recv_complete: rxc2,
-            },
-            control_b: ucsr2b {
-                tx_enable: txen2,
-                rx_enable: rxen2,
-            },
-            control_c: ucsr2c {
-                mode: umsel2,
-                char_size: ucsz2,
-                stop_bits: usbs2,
-                parity: upm2,
-            },
-            baud: ubrr2,
-            data: udr2,
-        },
+        register_suffix: 2,
     }
 }
 
@@ -94,24 +43,7 @@ crate::avr_hal::impl_usart! {
             rx: portj::PJ0,
             tx: portj::PJ1,
         },
-        registers: {
-            control_a: ucsr3a {
-                data_empty: udre3,
-                recv_complete: rxc3,
-            },
-            control_b: ucsr3b {
-                tx_enable: txen3,
-                rx_enable: rxen3,
-            },
-            control_c: ucsr3c {
-                mode: umsel3,
-                char_size: ucsz3,
-                stop_bits: usbs3,
-                parity: upm3,
-            },
-            baud: ubrr3,
-            data: udr3,
-        },
+        register_suffix: 3,
     }
 }
 

--- a/chips/atmega328p-hal/src/lib.rs
+++ b/chips/atmega328p-hal/src/lib.rs
@@ -106,24 +106,7 @@ pub mod usart {
                 rx: portd::PD0,
                 tx: portd::PD1,
             },
-            registers: {
-                control_a: ucsr0a {
-                    data_empty: udre0,
-                    recv_complete: rxc0,
-                },
-                control_b: ucsr0b {
-                    tx_enable: txen0,
-                    rx_enable: rxen0,
-                },
-                control_c: ucsr0c {
-                    mode: umsel0,
-                    char_size: ucsz0,
-                    stop_bits: usbs0,
-                    parity: upm0,
-                },
-                baud: ubrr0,
-                data: udr0,
-            },
+            register_suffix: 0,
         }
     }
 }

--- a/chips/atmega32u4-hal/src/lib.rs
+++ b/chips/atmega32u4-hal/src/lib.rs
@@ -105,24 +105,7 @@ pub mod usart {
                 rx: portd::PD2,
                 tx: portd::PD3,
             },
-            registers: {
-                control_a: ucsr1a {
-                    data_empty: udre1,
-                    recv_complete: rxc1,
-                },
-                control_b: ucsr1b {
-                    tx_enable: txen1,
-                    rx_enable: rxen1,
-                },
-                control_c: ucsr1c {
-                    mode: umsel1,
-                    char_size: ucsz1,
-                    stop_bits: usbs1,
-                    parity: upm1,
-                },
-                baud: ubrr1,
-                data: udr1,
-            },
+            register_suffix: 1,
         }
     }
 }


### PR DESCRIPTION
We are using `paste` anyway, let's do it properly.  This greatly simplifies the macro invocations in all HAL crates.

Additionally, add new methods for enabling/disabling "RX Complete" and "UDR Empty" interrupts.  @lights0123, this might be useful to you.