### PR TITLE
Allow configuring the prescaler for PWM timers

### DIFF
--- a/boards/arduino-leonardo/examples/leonardo-pwm.rs
+++ b/boards/arduino-leonardo/examples/leonardo-pwm.rs
@@ -3,6 +3,7 @@
 
 extern crate panic_halt;
 use arduino_leonardo::prelude::*;
+use arduino_leonardo::pwm;
 
 #[arduino_leonardo::entry]
 fn main() -> ! {
@@ -10,7 +11,7 @@ fn main() -> ! {
 
     let mut pins = arduino_leonardo::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
 
-    let mut timer4 = arduino_leonardo::pwm::Timer4Pwm::new(dp.TC4);
+    let mut timer4 = pwm::Timer4Pwm::new(dp.TC4, pwm::Prescaler::Prescale64);
 
     let mut led = pins.d13.into_output(&mut pins.ddr).into_pwm(&mut timer4);
 

--- a/boards/arduino-leonardo/src/lib.rs
+++ b/boards/arduino-leonardo/src/lib.rs
@@ -144,7 +144,10 @@ pub mod adc {
 /// For a full example, see [`examples/leonardo-pwm.rs`][ex-pwm].  In short:
 /// ```
 /// let mut pins = arduino_leonardo::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
-/// let mut timer1 = Timer1Pwm::new(dp.TC1);
+/// let mut timer1 = arduino_leonardo::pwm::Timer1Pwm::new(
+///     dp.TC1,
+///     arduino_leonardo::pwm::Prescaler::Prescale64,
+/// );
 ///
 /// let mut d3 = pins.d3.into_output(&mut pins.ddr).into_pwm(&mut timer0);
 ///

--- a/boards/arduino-uno/examples/uno-pwm.rs
+++ b/boards/arduino-uno/examples/uno-pwm.rs
@@ -3,6 +3,7 @@
 
 extern crate panic_halt;
 use arduino_uno::prelude::*;
+use arduino_uno::pwm;
 
 #[arduino_uno::entry]
 fn main() -> ! {
@@ -10,7 +11,7 @@ fn main() -> ! {
 
     let mut pins = arduino_uno::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD);
 
-    let mut timer1 = arduino_uno::pwm::Timer1Pwm::new(dp.TC1);
+    let mut timer1 = pwm::Timer1Pwm::new(dp.TC1, pwm::Prescaler::Prescale64);
 
     let mut pin = pins.d9.into_output(&mut pins.ddr).into_pwm(&mut timer1);
 

--- a/boards/arduino-uno/src/lib.rs
+++ b/boards/arduino-uno/src/lib.rs
@@ -135,7 +135,10 @@ pub mod adc {
 /// ```
 /// let mut pins = arduino_uno::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD);
 ///
-/// let mut timer1 = arduino_uno::pwm::Timer1Pwm::new(dp.TC1);
+/// let mut timer1 = arduino_uno::pwm::Timer1Pwm::new(
+///     dp.TC1,
+///     arduino_uno::pwm::Prescaler::Prescale64,
+/// );
 ///
 /// let mut pin = pins.d9.into_output(&mut pins.ddr).into_pwm(&mut timer1);
 ///

--- a/chips/atmega328p-hal/src/pwm.rs
+++ b/chips/atmega328p-hal/src/pwm.rs
@@ -26,6 +26,7 @@
 //! | `PD6` | `.into_pwm(&mut timer0)` |
 
 use crate::port::{portb, portd};
+pub use avr_hal::pwm::*;
 
 avr_hal::impl_pwm! {
     /// Use `TC0` for PWM (pins `PD5`, `PD6`)
@@ -43,9 +44,15 @@ avr_hal::impl_pwm! {
     /// ```
     pub struct Timer0Pwm {
         timer: crate::atmega328p::TC0,
-        init: |tim| {
+        init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
-            tim.tccr0b.modify(|_, w| w.cs0().prescale_64());
+            tim.tccr0b.modify(|_, w| match prescaler {
+                Prescaler::Direct => w.cs0().direct(),
+                Prescaler::Prescale8 => w.cs0().prescale_8(),
+                Prescaler::Prescale64 => w.cs0().prescale_64(),
+                Prescaler::Prescale256 => w.cs0().prescale_256(),
+                Prescaler::Prescale1024 => w.cs0().prescale_1024(),
+            });
         },
         pins: {
             portd::PD6: {
@@ -84,9 +91,18 @@ avr_hal::impl_pwm! {
     /// ```
     pub struct Timer1Pwm {
         timer: crate::atmega328p::TC1,
-        init: |tim| {
+        init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_, w| w.wgm1().bits(0b01).cs1().prescale_64());
+            tim.tccr1b.modify(|_, w| {
+                w.wgm1().bits(0b01);
+                match prescaler {
+                    Prescaler::Direct => w.cs1().direct(),
+                    Prescaler::Prescale8 => w.cs1().prescale_8(),
+                    Prescaler::Prescale64 => w.cs1().prescale_64(),
+                    Prescaler::Prescale256 => w.cs1().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+                }
+            });
         },
         pins: {
             portb::PB1: {
@@ -126,9 +142,15 @@ avr_hal::impl_pwm! {
     /// ```
     pub struct Timer2Pwm {
         timer: crate::atmega328p::TC2,
-        init: |tim| {
+        init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().pwm_fast());
-            tim.tccr2b.modify(|_, w| w.cs2().prescale_64());
+            tim.tccr2b.modify(|_, w| match prescaler {
+                Prescaler::Direct => w.cs2().direct(),
+                Prescaler::Prescale8 => w.cs2().prescale_8(),
+                Prescaler::Prescale64 => w.cs2().prescale_64(),
+                Prescaler::Prescale256 => w.cs2().prescale_256(),
+                Prescaler::Prescale1024 => w.cs2().prescale_1024(),
+            });
         },
         pins: {
             portb::PB3: {

--- a/chips/atmega328p-hal/src/pwm.rs
+++ b/chips/atmega328p-hal/src/pwm.rs
@@ -6,7 +6,7 @@
 //! # Example
 //! ```
 //! let mut portd = dp.PORTD.split();
-//! let mut timer0 = Timer0Pwm::new(dp.TC0);
+//! let mut timer0 = Timer0Pwm::new(dp.TC0, pwm::Prescaler::Prescale64);
 //!
 //! let mut pd5 = portd.pd5.into_output(&mut portd.ddr).into_pwm(&mut timer0);
 //!
@@ -34,7 +34,7 @@ avr_hal::impl_pwm! {
     /// # Example
     /// ```
     /// let mut portd = dp.PORTD.split();
-    /// let mut timer0 = Timer0Pwm::new(dp.TC0);
+    /// let mut timer0 = Timer0Pwm::new(dp.TC0, pwm::Prescaler::Prescale64);
     ///
     /// let mut pd5 = portd.pd5.into_output(&mut portd.ddr).into_pwm(&mut timer0);
     /// let mut pd6 = portd.pd6.into_output(&mut portd.ddr).into_pwm(&mut timer0);
@@ -81,7 +81,7 @@ avr_hal::impl_pwm! {
     /// # Example
     /// ```
     /// let mut portb = dp.PORTB.split();
-    /// let mut timer1 = Timer1Pwm::new(dp.TC1);
+    /// let mut timer1 = Timer1Pwm::new(dp.TC1, pwm::Prescaler::Prescale64);
     ///
     /// let mut pb1 = portb.pb1.into_output(&mut portb.ddr).into_pwm(&mut timer1);
     /// let mut pb2 = portb.pb2.into_output(&mut portb.ddr).into_pwm(&mut timer1);
@@ -132,7 +132,7 @@ avr_hal::impl_pwm! {
     /// ```
     /// let mut portb = dp.PORTB.split();
     /// let mut portd = dp.PORTD.split();
-    /// let mut timer2 = Timer2Pwm::new(dp.TC2);
+    /// let mut timer2 = Timer2Pwm::new(dp.TC2, pwm::Prescaler::Prescale64);
     ///
     /// let mut pb3 = portb.pb3.into_output(&mut portb.ddr).into_pwm(&mut timer2);
     /// let mut pd3 = portd.pd3.into_output(&mut portd.ddr).into_pwm(&mut timer2);

--- a/chips/atmega32u4-hal/src/pwm.rs
+++ b/chips/atmega32u4-hal/src/pwm.rs
@@ -208,7 +208,7 @@ avr_hal::impl_pwm! {
                     Prescaler::Prescale256 => w.cs4().prescale_256(),
                     Prescaler::Prescale1024 => w.cs4().prescale_1024(),
             });
-            tim.tccr4d.modify(|_, w| w.wgm4().pwm_correct());
+            tim.tccr4d.modify(|_, w| w.wgm4().pwm_fast());
         },
         pins: {
             portc::PC7: {

--- a/chips/atmega32u4-hal/src/pwm.rs
+++ b/chips/atmega32u4-hal/src/pwm.rs
@@ -6,7 +6,7 @@
 //! # Example
 //! ```
 //! let mut portb = dp.PORTB.split();
-//! let mut timer1 = Timer1Pwm::new(dp.TC1);
+//! let mut timer1 = Timer1Pwm::new(dp.TC1, pwm::Prescaler::Prescale64);
 //!
 //! let mut pb5 = portb.pb5.into_output(&mut portb.ddr).into_pwm(&mut timer1);
 //!
@@ -36,7 +36,7 @@ avr_hal::impl_pwm! {
     /// ```
     /// let mut portb = dp.PORTB.split();
     /// let mut portd = dp.PORTD.split();
-    /// let mut timer0 = Timer0Pwm::new(dp.TC0);
+    /// let mut timer0 = Timer0Pwm::new(dp.TC0, pwm::Prescaler::Prescale64);
     ///
     /// let mut pb7 = portb.pb7.into_output(&mut portb.ddr).into_pwm(&mut timer0);
     /// let mut pd0 = portd.pd0.into_output(&mut portd.ddr).into_pwm(&mut timer0);
@@ -83,7 +83,7 @@ avr_hal::impl_pwm! {
     /// # Example
     /// ```
     /// let mut portb = dp.PORTB.split();
-    /// let mut timer1 = Timer1Pwm::new(dp.TC1);
+    /// let mut timer1 = Timer1Pwm::new(dp.TC1, pwm::Prescaler::Prescale64);
     ///
     /// let mut pb5 = portb.pb5.into_output(&mut portb.ddr).into_pwm(&mut timer1);
     /// let mut pb6 = portb.pb6.into_output(&mut portb.ddr).into_pwm(&mut timer1);
@@ -144,7 +144,7 @@ avr_hal::impl_pwm! {
     /// # Example
     /// ```
     /// let mut portc = dp.PORTC.split();
-    /// let mut timer3 = Timer3Pwm::new(dp.TC3);
+    /// let mut timer3 = Timer3Pwm::new(dp.TC3, pwm::Prescaler::Prescale64);
     ///
     /// let mut pc6 = portc.pc6.into_output(&mut portc.ddr).into_pwm(&mut timer3);
     ///
@@ -187,7 +187,7 @@ avr_hal::impl_pwm! {
     /// let mut portb = dp.PORTB.split();
     /// let mut portc = dp.PORTC.split();
     /// let mut portd = dp.PORTD.split();
-    /// let mut timer4 = Timer4Pwm::new(dp.TC4);
+    /// let mut timer4 = Timer4Pwm::new(dp.TC4, pwm::Prescaler::Prescale64);
     ///
     /// let pb6 = portb.pb6.into_output(&mut portb.ddr).into_pwm4(&mut timer4);
     /// let pc7 = portc.pc7.into_output(&mut portc.ddr).into_pwm(&mut timer4);

--- a/chips/atmega32u4-hal/src/pwm.rs
+++ b/chips/atmega32u4-hal/src/pwm.rs
@@ -27,6 +27,7 @@
 //! | `PD7` | `.into_pwm(&mut timer4)` | |
 
 use crate::port::{portb, portc, portd};
+pub use avr_hal::pwm::*;
 
 avr_hal::impl_pwm! {
     /// Use `TC0` for PWM (pins `PB7`, `PD0`)
@@ -45,9 +46,15 @@ avr_hal::impl_pwm! {
     /// ```
     pub struct Timer0Pwm {
         timer: crate::atmega32u4::TC0,
-        init: |tim| {
+        init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
-            tim.tccr0b.modify(|_, w| w.cs0().prescale_64());
+            tim.tccr0b.modify(|_, w| match prescaler {
+                Prescaler::Direct => w.cs0().direct(),
+                Prescaler::Prescale8 => w.cs0().prescale_8(),
+                Prescaler::Prescale64 => w.cs0().prescale_64(),
+                Prescaler::Prescale256 => w.cs0().prescale_256(),
+                Prescaler::Prescale1024 => w.cs0().prescale_1024(),
+            });
         },
         pins: {
             portb::PB7: {
@@ -89,9 +96,18 @@ avr_hal::impl_pwm! {
     /// **Note**: For `PB7` the method is called `into_pwm1()`!
     pub struct Timer1Pwm {
         timer: crate::atmega32u4::TC1,
-        init: |tim| {
+        init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_, w| w.wgm1().bits(0b01).cs1().prescale_64());
+            tim.tccr1b.modify(|_, w| {
+                w.wgm1().bits(0b01);
+                match prescaler {
+                    Prescaler::Direct => w.cs1().direct(),
+                    Prescaler::Prescale8 => w.cs1().prescale_8(),
+                    Prescaler::Prescale64 => w.cs1().prescale_64(),
+                    Prescaler::Prescale256 => w.cs1().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+                }
+            });
         },
         pins: {
             portb::PB5: {
@@ -137,9 +153,18 @@ avr_hal::impl_pwm! {
     /// ```
     pub struct Timer3Pwm {
         timer: crate::atmega32u4::TC3,
-        init: |tim| {
+        init: |tim, prescaler| {
             tim.tccr3a.modify(|_, w| w.wgm3().bits(0b01));
-            tim.tccr3b.modify(|_, w| w.wgm3().bits(0b01).cs3().prescale_64());
+            tim.tccr3b.modify(|_, w| {
+                w.wgm3().bits(0b01);
+                match prescaler {
+                    Prescaler::Direct => w.cs3().direct(),
+                    Prescaler::Prescale8 => w.cs3().prescale_8(),
+                    Prescaler::Prescale64 => w.cs3().prescale_64(),
+                    Prescaler::Prescale256 => w.cs3().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs3().prescale_1024(),
+                }
+            });
         },
         pins: {
             portc::PC6: {
@@ -175,8 +200,14 @@ avr_hal::impl_pwm! {
     /// **Note**: For `PB6` the method is called `into_pwm6()`!
     pub struct Timer4Pwm {
         timer: crate::atmega32u4::TC4,
-        init: |tim| {
-            tim.tccr4b.modify(|_, w| w.cs4().prescale_64());
+        init: |tim, prescaler| {
+            tim.tccr4b.modify(|_, w| match prescaler {
+                    Prescaler::Direct => w.cs4().direct(),
+                    Prescaler::Prescale8 => w.cs4().prescale_8(),
+                    Prescaler::Prescale64 => w.cs4().prescale_64(),
+                    Prescaler::Prescale256 => w.cs4().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs4().prescale_1024(),
+            });
             tim.tccr4d.modify(|_, w| w.wgm4().pwm_correct());
         },
         pins: {


### PR DESCRIPTION
To make the PWM abstractions more useful, allow configuring the prescaler that is used, instead of fixing it to ~ 1 kHz.  This makes it possible, to e.g. drive servo-motors using this as they usually require a frequency of about ~ 50 Hz.

Additionally, fix a bug in the `TC4` implementation for `ATmega32U4` where a wrong PWM mode was used.