### PR TITLE
generic: port: Support for open-drain mode

### DIFF
--- a/chips/atmega1280-hal/src/port.rs
+++ b/chips/atmega1280-hal/src/port.rs
@@ -14,17 +14,17 @@ pub trait PortExt {
 
 avr_hal::impl_generic_pin! {
     pub enum Pin {
-        A(crate::atmega1280::PORTA, porta, pina),
-        B(crate::atmega1280::PORTB, portb, pinb),
-        C(crate::atmega1280::PORTC, portc, pinc),
-        D(crate::atmega1280::PORTD, portd, pind),
-        E(crate::atmega1280::PORTE, porte, pine),
-        F(crate::atmega1280::PORTF, portf, pinf),
-        G(crate::atmega1280::PORTG, portg, ping),
-        H(crate::atmega1280::PORTH, porth, pinh),
-        J(crate::atmega1280::PORTJ, portj, pinj),
-        K(crate::atmega1280::PORTK, portk, pink),
-        L(crate::atmega1280::PORTL, portl, pinl),
+        A(crate::atmega1280::PORTA, porta, pina, ddra),
+        B(crate::atmega1280::PORTB, portb, pinb, ddrb),
+        C(crate::atmega1280::PORTC, portc, pinc, ddrc),
+        D(crate::atmega1280::PORTD, portd, pind, ddrd),
+        E(crate::atmega1280::PORTE, porte, pine, ddre),
+        F(crate::atmega1280::PORTF, portf, pinf, ddrf),
+        G(crate::atmega1280::PORTG, portg, ping, ddrg),
+        H(crate::atmega1280::PORTH, porth, pinh, ddrh),
+        J(crate::atmega1280::PORTJ, portj, pinj, ddrj),
+        K(crate::atmega1280::PORTK, portk, pink, ddrk),
+        L(crate::atmega1280::PORTL, portl, pinl, ddrl),
     }
 }
 

--- a/chips/atmega2560-hal/src/port.rs
+++ b/chips/atmega2560-hal/src/port.rs
@@ -14,17 +14,17 @@ pub trait PortExt {
 
 avr_hal::impl_generic_pin! {
     pub enum Pin {
-        A(crate::atmega2560::PORTA, porta, pina),
-        B(crate::atmega2560::PORTB, portb, pinb),
-        C(crate::atmega2560::PORTC, portc, pinc),
-        D(crate::atmega2560::PORTD, portd, pind),
-        E(crate::atmega2560::PORTE, porte, pine),
-        F(crate::atmega2560::PORTF, portf, pinf),
-        G(crate::atmega2560::PORTG, portg, ping),
-        H(crate::atmega2560::PORTH, porth, pinh),
-        J(crate::atmega2560::PORTJ, portj, pinj),
-        K(crate::atmega2560::PORTK, portk, pink),
-        L(crate::atmega2560::PORTL, portl, pinl),
+        A(crate::atmega2560::PORTA, porta, pina, ddra),
+        B(crate::atmega2560::PORTB, portb, pinb, ddrb),
+        C(crate::atmega2560::PORTC, portc, pinc, ddrc),
+        D(crate::atmega2560::PORTD, portd, pind, ddrd),
+        E(crate::atmega2560::PORTE, porte, pine, ddre),
+        F(crate::atmega2560::PORTF, portf, pinf, ddrf),
+        G(crate::atmega2560::PORTG, portg, ping, ddrg),
+        H(crate::atmega2560::PORTH, porth, pinh, ddrh),
+        J(crate::atmega2560::PORTJ, portj, pinj, ddrj),
+        K(crate::atmega2560::PORTK, portk, pink, ddrk),
+        L(crate::atmega2560::PORTL, portl, pinl, ddrl),
     }
 }
 

--- a/chips/atmega328p-hal/src/port.rs
+++ b/chips/atmega328p-hal/src/port.rs
@@ -14,9 +14,9 @@ pub trait PortExt {
 
 avr_hal::impl_generic_pin! {
     pub enum Pin {
-        B(crate::atmega328p::PORTB, portb, pinb),
-        C(crate::atmega328p::PORTC, portc, pinc),
-        D(crate::atmega328p::PORTD, portd, pind),
+        B(crate::atmega328p::PORTB, portb, pinb, ddrb),
+        C(crate::atmega328p::PORTC, portc, pinc, ddrc),
+        D(crate::atmega328p::PORTD, portd, pind, ddrd),
     }
 }
 

--- a/chips/atmega32u4-hal/src/port.rs
+++ b/chips/atmega32u4-hal/src/port.rs
@@ -14,11 +14,11 @@ pub trait PortExt {
 
 avr_hal::impl_generic_pin! {
     pub enum Pin {
-        B(crate::atmega32u4::PORTB, portb, pinb),
-        C(crate::atmega32u4::PORTC, portc, pinc),
-        D(crate::atmega32u4::PORTD, portd, pind),
-        E(crate::atmega32u4::PORTE, porte, pine),
-        F(crate::atmega32u4::PORTF, portf, pinf),
+        B(crate::atmega32u4::PORTB, portb, pinb, ddrb),
+        C(crate::atmega32u4::PORTC, portc, pinc, ddrc),
+        D(crate::atmega32u4::PORTD, portd, pind, ddrd),
+        E(crate::atmega32u4::PORTE, porte, pine, ddre),
+        F(crate::atmega32u4::PORTF, portf, pinf, ddrf),
     }
 }
 

--- a/chips/attiny88-hal/src/port.rs
+++ b/chips/attiny88-hal/src/port.rs
@@ -14,10 +14,10 @@ pub trait PortExt {
 
 avr_hal::impl_generic_pin! {
     pub enum Pin {
-        A(crate::attiny88::PORTA, porta, pina),
-        B(crate::attiny88::PORTB, portb, pinb),
-        C(crate::attiny88::PORTC, portc, pinc),
-        D(crate::attiny88::PORTD, portd, pind),
+        A(crate::attiny88::PORTA, porta, pina, ddra),
+        B(crate::attiny88::PORTB, portb, pinb, ddrb),
+        C(crate::attiny88::PORTC, portc, pinc, ddrc),
+        D(crate::attiny88::PORTD, portd, pind, ddrd),
     }
 }
 


### PR DESCRIPTION
Solution for issue #16.

A new port mode (OpenDrain) that Suports open-drain mode with external pull-up.
The solution uses the DDRxn to switch between a high state with the pin
input floating mode where the external pull-up is setting the pin to high state,
and low state by setting the pin in output low to pull the pin low.

Input traits is reading the external electrical state independent of if
the pin is set high or low.

Signed-off-by: Karl Thorén <karl.h.thoren@gmail.com>