### PR TITLE
Re-export interrupt for convenience

### DIFF
--- a/boards/arduino-leonardo/src/lib.rs
+++ b/boards/arduino-leonardo/src/lib.rs
@@ -45,6 +45,9 @@ pub extern crate atmega32u4_hal as hal;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use hal::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use hal::interrupt;
 
 mod pins;
 pub use crate::pins::*;

--- a/boards/arduino-mega2560/src/lib.rs
+++ b/boards/arduino-mega2560/src/lib.rs
@@ -4,6 +4,9 @@ pub extern crate atmega2560_hal as hal;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use hal::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use hal::interrupt;
 
 mod pins;
 

--- a/boards/arduino-uno/src/lib.rs
+++ b/boards/arduino-uno/src/lib.rs
@@ -45,6 +45,9 @@ pub extern crate atmega328p_hal as hal;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use hal::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use hal::interrupt;
 
 mod pins;
 pub use crate::pins::*;

--- a/boards/bigavr6/src/lib.rs
+++ b/boards/bigavr6/src/lib.rs
@@ -4,6 +4,9 @@ pub extern crate atmega1280_hal as hal;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use hal::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use hal::interrupt;
 
 pub use atmega1280_hal::atmega1280;
 pub use crate::atmega1280::Peripherals;

--- a/boards/trinket/src/lib.rs
+++ b/boards/trinket/src/lib.rs
@@ -4,6 +4,9 @@ pub extern crate attiny85_hal as hal;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use hal::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use hal::interrupt;
 
 pub use attiny85_hal::attiny85;
 pub use crate::attiny85::Peripherals;

--- a/chips/atmega1280-hal/src/lib.rs
+++ b/chips/atmega1280-hal/src/lib.rs
@@ -6,6 +6,9 @@ pub use avr_device::atmega1280;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use avr_device::interrupt;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;

--- a/chips/atmega2560-hal/src/lib.rs
+++ b/chips/atmega2560-hal/src/lib.rs
@@ -6,6 +6,9 @@ pub use avr_device::atmega2560;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use avr_device::interrupt;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;

--- a/chips/atmega328p-hal/src/lib.rs
+++ b/chips/atmega328p-hal/src/lib.rs
@@ -6,6 +6,9 @@ pub use avr_device::atmega328p;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use avr_device::interrupt;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;

--- a/chips/atmega32u4-hal/src/lib.rs
+++ b/chips/atmega32u4-hal/src/lib.rs
@@ -6,6 +6,9 @@ pub use avr_device::atmega32u4;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use avr_device::interrupt;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;

--- a/chips/attiny85-hal/src/lib.rs
+++ b/chips/attiny85-hal/src/lib.rs
@@ -6,6 +6,9 @@ pub use avr_device::attiny85;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use avr_device::interrupt;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;

--- a/chips/attiny88-hal/src/lib.rs
+++ b/chips/attiny88-hal/src/lib.rs
@@ -6,6 +6,9 @@ pub use avr_device::attiny88;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
+/// See [`avr_device::interrupt`](https://docs.rs/avr-device/latest/avr_device/attr.interrupt.html).
+#[cfg(feature = "rt")]
+pub use avr_device::interrupt;
 
 pub use avr_hal::clock;
 pub use avr_hal::delay;


### PR DESCRIPTION
Note that this re-exports both the attribute macro (what I was looking for) and the module (probably okay, but not what I had intended).

If you think this is too niche to re-export, feel free to close.