### PR TITLE
generic: delay: Account for the modulo 4096 part

### DIFF
--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -218,6 +218,7 @@ where
         for _ in 0..(us >> 12) {
             delay::DelayUs::<u16>::delay_us(self, 0xfff);
         }
+        delay::DelayUs::<u16>::delay_us(self, (us & 0xfff) as u16);
     }
 }
 


### PR DESCRIPTION
This fixes small delays (less than 4096us) and all delays not an exact multiple of 4096 us.