### PR TITLE
SparkFun Qwiic Pro Micro USB-C Atmega32u4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - BOARD=arduino-uno
     - BOARD=bigavr6
     - BOARD=trinket
+    - BOARD=sparkfun-pro-micro
 
 install:
   - rustup component add rust-src

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "boards/arduino-uno",
     "boards/arduino-mega2560",
     "boards/bigavr6",
+    "boards/sparkfun-pro-micro",
     "boards/trinket",
 ]
 

--- a/boards/sparkfun-pro-micro/.cargo/config.toml
+++ b/boards/sparkfun-pro-micro/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "avr-atmega32u4.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "./pro-micro-runner.sh"
+
+[unstable]
+build-std = ["core"]

--- a/boards/sparkfun-pro-micro/Cargo.toml
+++ b/boards/sparkfun-pro-micro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkfun-pro-micro"
 version = "0.1.0"
-authors = ["Rahix <rahix@rahix.de>"]
+authors = ["Cecile Tonglet <cecile.tonglet@cecton.com>"]
 edition = "2018"
 
 [features]

--- a/boards/sparkfun-pro-micro/Cargo.toml
+++ b/boards/sparkfun-pro-micro/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sparkfun-pro-micro"
+version = "0.1.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
+
+[features]
+default = ["rt"]
+rt = ["atmega32u4-hal/rt"]
+
+[dependencies]
+atmega32u4-hal = { path = "../../chips/atmega32u4-hal/" }
+avr-hal-generic = { path = "../../avr-hal-generic/" }
+
+[dev-dependencies]
+panic-halt = "0.2.0"
+nb = "0.1.2"
+ufmt = "0.1.0"
+avr-device = "0.2.1"

--- a/boards/sparkfun-pro-micro/avr-atmega32u4.json
+++ b/boards/sparkfun-pro-micro/avr-atmega32u4.json
@@ -1,0 +1,1 @@
+../../chips/atmega32u4-hal/avr-atmega32u4.json

--- a/boards/sparkfun-pro-micro/examples/pro-micro-adc.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-adc.rs
@@ -31,13 +31,12 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "GND: {}\r", gnd).void_unwrap();
     ufmt::uwriteln!(&mut serial, "Temperature Sensor: {}\r", temp).void_unwrap();
 
-    let portf = dp.PORTF.split();
-    let mut a0 = portf.pf7.into_analog_input(&mut adc);
-    let mut a1 = portf.pf6.into_analog_input(&mut adc);
-    let mut a2 = portf.pf5.into_analog_input(&mut adc);
-    let mut a3 = portf.pf4.into_analog_input(&mut adc);
-    let mut a4 = portf.pf1.into_analog_input(&mut adc);
-    let mut a5 = portf.pf0.into_analog_input(&mut adc);
+    let mut a0 = pins.a0.into_analog_input(&mut adc);
+    let mut a1 = pins.a1.into_analog_input(&mut adc);
+    let mut a2 = pins.a2.into_analog_input(&mut adc);
+    let mut a3 = pins.a3.into_analog_input(&mut adc);
+    let mut a4 = pins.a4.into_analog_input(&mut adc);
+    let mut a5 = pins.a5.into_analog_input(&mut adc);
 
     loop {
         let values: [u16; 6] = [

--- a/boards/sparkfun-pro-micro/examples/pro-micro-adc.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-adc.rs
@@ -1,0 +1,59 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use sparkfun_pro_micro::prelude::*;
+
+#[sparkfun_pro_micro::entry]
+fn main() -> ! {
+    let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+
+    let mut serial = sparkfun_pro_micro::Serial::new(
+        dp.USART1,
+        pins.d0,
+        pins.d1.into_output(&mut pins.ddr),
+        57600,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Reading analog inputs ...\r").void_unwrap();
+
+    let mut adc = sparkfun_pro_micro::adc::Adc::new(dp.ADC, Default::default());
+
+    let (vbg, gnd, temp): (u16, u16, u16) = (
+        nb::block!(adc.read(&mut sparkfun_pro_micro::adc::channel::Vbg)).void_unwrap(),
+        nb::block!(adc.read(&mut sparkfun_pro_micro::adc::channel::Gnd)).void_unwrap(),
+        nb::block!(adc.read(&mut sparkfun_pro_micro::adc::channel::Temperature)).void_unwrap(),
+    );
+
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}\r", vbg).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "GND: {}\r", gnd).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Temperature Sensor: {}\r", temp).void_unwrap();
+
+    let portf = dp.PORTF.split();
+    let mut a0 = portf.pf7.into_analog_input(&mut adc);
+    let mut a1 = portf.pf6.into_analog_input(&mut adc);
+    let mut a2 = portf.pf5.into_analog_input(&mut adc);
+    let mut a3 = portf.pf4.into_analog_input(&mut adc);
+    let mut a4 = portf.pf1.into_analog_input(&mut adc);
+    let mut a5 = portf.pf0.into_analog_input(&mut adc);
+
+    loop {
+        let values: [u16; 6] = [
+            nb::block!(adc.read(&mut a0)).void_unwrap(),
+            nb::block!(adc.read(&mut a1)).void_unwrap(),
+            nb::block!(adc.read(&mut a2)).void_unwrap(),
+            nb::block!(adc.read(&mut a3)).void_unwrap(),
+            nb::block!(adc.read(&mut a4)).void_unwrap(),
+            nb::block!(adc.read(&mut a5)).void_unwrap(),
+        ];
+
+        for (i, v) in values.iter().enumerate() {
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+        }
+        ufmt::uwriteln!(&mut serial, "\r").void_unwrap();
+
+        sparkfun_pro_micro::delay_ms(1000);
+    }
+}

--- a/boards/sparkfun-pro-micro/examples/pro-micro-adc.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-adc.rs
@@ -8,7 +8,7 @@ use sparkfun_pro_micro::prelude::*;
 fn main() -> ! {
     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 
-    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 
     let mut serial = sparkfun_pro_micro::Serial::new(
         dp.USART1,

--- a/boards/sparkfun-pro-micro/examples/pro-micro-blink.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-blink.rs
@@ -8,12 +8,7 @@ use sparkfun_pro_micro::prelude::*;
 fn main() -> ! {
     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 
-    let mut pins = sparkfun_pro_micro::Pins::new(
-        dp.PORTB,
-        dp.PORTC,
-        dp.PORTD,
-        dp.PORTE,
-    );
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 
     let mut led0 = pins.led_rx.into_output(&mut pins.ddr);
     let mut led1 = pins.led_tx.into_output(&mut pins.ddr);

--- a/boards/sparkfun-pro-micro/examples/pro-micro-blink.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-blink.rs
@@ -1,0 +1,39 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use sparkfun_pro_micro::prelude::*;
+
+#[sparkfun_pro_micro::entry]
+fn main() -> ! {
+    let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+
+    let mut pins = sparkfun_pro_micro::Pins::new(
+        dp.PORTB,
+        dp.PORTC,
+        dp.PORTD,
+        dp.PORTE,
+    );
+
+    let mut led0 = pins.led_rx.into_output(&mut pins.ddr);
+    let mut led1 = pins.led_tx.into_output(&mut pins.ddr);
+    let mut led2 = pins.d13.into_output(&mut pins.ddr);
+
+    led0.set_high().void_unwrap();
+    led1.set_high().void_unwrap();
+    led2.set_high().void_unwrap();
+
+    let mut leds = [
+        led0.downgrade(),
+        led1.downgrade(),
+        led2.downgrade(),
+    ];
+
+    loop {
+        for i in 0..3 {
+            leds[i].toggle().void_unwrap();
+            leds[(i+2)%3].toggle().void_unwrap();
+            sparkfun_pro_micro::delay_ms(200);
+        }
+    }
+}

--- a/boards/sparkfun-pro-micro/examples/pro-micro-blink.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-blink.rs
@@ -12,23 +12,25 @@ fn main() -> ! {
 
     let mut led0 = pins.led_rx.into_output(&mut pins.ddr);
     let mut led1 = pins.led_tx.into_output(&mut pins.ddr);
-    let mut led2 = pins.d13.into_output(&mut pins.ddr);
 
     led0.set_high().void_unwrap();
     led1.set_high().void_unwrap();
-    led2.set_high().void_unwrap();
 
-    let mut leds = [
-        led0.downgrade(),
-        led1.downgrade(),
-        led2.downgrade(),
-    ];
-
+    let mut time: u16 = 0;
     loop {
-        for i in 0..3 {
-            leds[i].toggle().void_unwrap();
-            leds[(i+2)%3].toggle().void_unwrap();
-            sparkfun_pro_micro::delay_ms(200);
+        if time % 2 == 0 {
+            led0.set_low().void_unwrap();
+        } else {
+            led0.set_high().void_unwrap();
         }
+
+        if time % 3 == 0 {
+            led1.set_low().void_unwrap();
+        } else {
+            led1.set_high().void_unwrap();
+        }
+
+        sparkfun_pro_micro::delay_ms(500);
+        time = time.wrapping_add(1);
     }
 }

--- a/boards/sparkfun-pro-micro/examples/pro-micro-i2cdetect.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-i2cdetect.rs
@@ -8,7 +8,7 @@ use sparkfun_pro_micro::prelude::*;
 fn main() -> ! {
     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 
-    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
     let mut serial = sparkfun_pro_micro::Serial::new(
         dp.USART1,
         pins.d0,

--- a/boards/sparkfun-pro-micro/examples/pro-micro-i2cdetect.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-i2cdetect.rs
@@ -1,0 +1,35 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use sparkfun_pro_micro::prelude::*;
+
+#[sparkfun_pro_micro::entry]
+fn main() -> ! {
+    let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+    let mut serial = sparkfun_pro_micro::Serial::new(
+        dp.USART1,
+        pins.d0,
+        pins.d1.into_output(&mut pins.ddr),
+        57600,
+    );
+    let mut i2c = sparkfun_pro_micro::I2c::new(
+        dp.TWI,
+        pins.d2.into_pull_up_input(&mut pins.ddr),
+        pins.d3.into_pull_up_input(&mut pins.ddr),
+        50000,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, sparkfun_pro_micro::hal::i2c::Direction::Write)
+        .void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, sparkfun_pro_micro::hal::i2c::Direction::Read)
+        .void_unwrap();
+
+    loop {
+        sparkfun_pro_micro::delay_ms(1000);
+    }
+}

--- a/boards/sparkfun-pro-micro/examples/pro-micro-interrupt.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-interrupt.rs
@@ -13,12 +13,7 @@ static mut PIN: Option<port::portc::PC7<port::mode::Output>> = None;
 fn main() -> ! {
     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 
-    let mut pins = sparkfun_pro_micro::Pins::new(
-        dp.PORTB,
-        dp.PORTC,
-        dp.PORTD,
-        dp.PORTE,
-    );
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 
     let mut led0 = pins.led_rx.into_output(&mut pins.ddr);
     let mut led1 = pins.led_tx.into_output(&mut pins.ddr);

--- a/boards/sparkfun-pro-micro/examples/pro-micro-interrupt.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-interrupt.rs
@@ -1,0 +1,65 @@
+#![no_std]
+#![no_main]
+#![feature(abi_avr_interrupt)]
+
+extern crate panic_halt;
+use sparkfun_pro_micro::prelude::*;
+
+// This pin will be used from the interrupt handler
+use sparkfun_pro_micro::hal::port;
+static mut PIN: Option<port::portc::PC7<port::mode::Output>> = None;
+
+#[sparkfun_pro_micro::entry]
+fn main() -> ! {
+    let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+
+    let mut pins = sparkfun_pro_micro::Pins::new(
+        dp.PORTB,
+        dp.PORTC,
+        dp.PORTD,
+        dp.PORTE,
+    );
+
+    let mut led0 = pins.led_rx.into_output(&mut pins.ddr);
+    let mut led1 = pins.led_tx.into_output(&mut pins.ddr);
+
+    let mut led = pins.d13.into_output(&mut pins.ddr);
+
+    led0.set_high().void_unwrap();
+    led1.set_low().void_unwrap();
+    led.set_low().void_unwrap();
+
+    unsafe {
+        PIN = Some(led);
+    }
+
+    // In theory this should not be necessary ... But if you previously had
+    // a sketch from Arduino loaded, the USB device will not have been reset.
+    // Because of this we will be spammed with interrupts which will never
+    // stop because they are never handled.
+    dp.USB_DEVICE.usbcon.reset();
+
+    // Initialize INT6
+    // There is not yet a hal implementation, which is why we need to do this
+    // manually
+    let ei = dp.EXINT;
+    // TODO: Patch EXINT so we at least don't need manual values here
+    ei.eicrb.write(|w| w.isc6().bits(0x02));
+    ei.eimsk.write(|w| w.int().bits(0x40));
+
+    // Enable interrupts
+    unsafe {
+        avr_device::interrupt::enable();
+    }
+
+    loop {
+        led0.toggle().void_unwrap();
+        led1.toggle().void_unwrap();
+        sparkfun_pro_micro::delay_ms(300);
+    }
+}
+
+#[avr_device::interrupt(atmega32u4)]
+unsafe fn INT6() {
+    PIN.as_mut().unwrap().toggle().void_unwrap();
+}

--- a/boards/sparkfun-pro-micro/examples/pro-micro-panic.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-panic.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+
+use sparkfun_pro_micro::prelude::*;
+use sparkfun_pro_micro::hal::port::mode;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    let mut serial: sparkfun_pro_micro::Serial<mode::Floating> = unsafe {
+        core::mem::MaybeUninit::uninit().assume_init()
+    };
+
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").void_unwrap();
+
+    if let Some(loc) = info.location() {
+        ufmt::uwriteln!(
+            &mut serial,
+            "  At {}:{}:{}\r",
+            loc.file(),
+            loc.line(),
+            loc.column(),
+        ).void_unwrap();
+    }
+
+    loop {}
+}
+
+#[sparkfun_pro_micro::entry]
+fn main() -> ! {
+    let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+
+    let mut pins = sparkfun_pro_micro::Pins::new(
+        dp.PORTB,
+        dp.PORTC,
+        dp.PORTD,
+        dp.PORTE,
+    );
+
+    let mut serial = sparkfun_pro_micro::Serial::new(
+        dp.USART1,
+        pins.d0,
+        pins.d1.into_output(&mut pins.ddr),
+        57600,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    // Panic messages cannot yet be captured because they rely on core::fmt
+    // which is way too big for AVR
+    panic!();
+}

--- a/boards/sparkfun-pro-micro/examples/pro-micro-panic.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-panic.rs
@@ -29,12 +29,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 fn main() -> ! {
     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 
-    let mut pins = sparkfun_pro_micro::Pins::new(
-        dp.PORTB,
-        dp.PORTC,
-        dp.PORTD,
-        dp.PORTE,
-    );
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 
     let mut serial = sparkfun_pro_micro::Serial::new(
         dp.USART1,

--- a/boards/sparkfun-pro-micro/examples/pro-micro-pwm.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-pwm.rs
@@ -1,8 +1,9 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
 use sparkfun_pro_micro::prelude::*;
+use sparkfun_pro_micro::pwm;
+use panic_halt as _;
 
 #[sparkfun_pro_micro::entry]
 fn main() -> ! {
@@ -10,7 +11,7 @@ fn main() -> ! {
 
     let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 
-    let mut timer4 = sparkfun_pro_micro::pwm::Timer4Pwm::new(dp.TC4);
+    let mut timer4 = pwm::Timer4Pwm::new(dp.TC4, pwm::Prescaler::Prescale64);
 
     let mut led = pins.d13.into_output(&mut pins.ddr).into_pwm(&mut timer4);
 

--- a/boards/sparkfun-pro-micro/examples/pro-micro-pwm.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-pwm.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use sparkfun_pro_micro::prelude::*;
+
+#[sparkfun_pro_micro::entry]
+fn main() -> ! {
+    let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+
+    let mut timer4 = sparkfun_pro_micro::pwm::Timer4Pwm::new(dp.TC4);
+
+    let mut led = pins.d13.into_output(&mut pins.ddr).into_pwm(&mut timer4);
+
+    led.set_duty(128);
+    led.enable();
+
+    loop {
+        for i in 0..=255u16 {
+            let duty: u16 = i * i / 256;
+            led.set_duty(duty as u8);
+            sparkfun_pro_micro::delay_ms(10);
+        }
+    }
+}

--- a/boards/sparkfun-pro-micro/examples/pro-micro-pwm.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-pwm.rs
@@ -8,7 +8,7 @@ use sparkfun_pro_micro::prelude::*;
 fn main() -> ! {
     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 
-    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 
     let mut timer4 = sparkfun_pro_micro::pwm::Timer4Pwm::new(dp.TC4);
 

--- a/boards/sparkfun-pro-micro/examples/pro-micro-serial.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-serial.rs
@@ -8,12 +8,7 @@ use sparkfun_pro_micro::prelude::*;
 fn main() -> ! {
     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 
-    let mut pins = sparkfun_pro_micro::Pins::new(
-        dp.PORTB,
-        dp.PORTC,
-        dp.PORTD,
-        dp.PORTE,
-    );
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 
     let mut serial = sparkfun_pro_micro::Serial::new(
         dp.USART1,

--- a/boards/sparkfun-pro-micro/examples/pro-micro-serial.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-serial.rs
@@ -1,0 +1,34 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use sparkfun_pro_micro::prelude::*;
+
+#[sparkfun_pro_micro::entry]
+fn main() -> ! {
+    let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+
+    let mut pins = sparkfun_pro_micro::Pins::new(
+        dp.PORTB,
+        dp.PORTC,
+        dp.PORTD,
+        dp.PORTE,
+    );
+
+    let mut serial = sparkfun_pro_micro::Serial::new(
+        dp.USART1,
+        pins.d0,
+        pins.d1.into_output(&mut pins.ddr),
+        57600,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+
+    loop {
+        // Read a byte from the serial connection
+        let b = nb::block!(serial.read()).void_unwrap();
+
+        // Answer
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+    }
+}

--- a/boards/sparkfun-pro-micro/examples/pro-micro-spi-feedback.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-spi-feedback.rs
@@ -1,0 +1,51 @@
+//! This example demonstrates how to set up a SPI interface and communicate
+//! over it.  The physical hardware configuation consists of connecting a
+//! jumper directly from ICSP pin 10 to ICSP pin 11.
+//!
+//! Once this program is written to the board, you can use the board's serial
+//! connection to see the output.  You should see it output the line
+//! `data: 15` repeatedly (aka 0b00001111).  If the output you see is
+//! `data: 255`, you may need to check your jumper.
+
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+use sparkfun_pro_micro::prelude::*;
+use sparkfun_pro_micro::spi;
+use nb::block;
+
+#[sparkfun_pro_micro::entry]
+fn main() -> ! {
+    let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+
+    let mut serial = sparkfun_pro_micro::Serial::new(
+        dp.USART1,
+        pins.d0,
+        pins.d1.into_output(&mut pins.ddr),
+        57600,
+    );
+
+    pins.led_rx.into_output(&mut pins.ddr); // SS must be set to output mode.
+
+    // Create SPI interface.
+    let mut spi = spi::Spi::new(
+        dp.SPI,
+        pins.sck.into_output(&mut pins.ddr),
+        pins.mosi.into_output(&mut pins.ddr),
+        pins.miso.into_pull_up_input(&mut pins.ddr),
+        spi::Settings::default(),
+    );
+
+    loop {
+        // Send a byte
+        block!(spi.send(0b00001111)).void_unwrap();
+        // Because MISO is connected to MOSI, the read data should be the same
+        let data = block!(spi.read()).void_unwrap();
+
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
+        sparkfun_pro_micro::delay_ms(1000);
+    }
+}

--- a/boards/sparkfun-pro-micro/examples/pro-micro-spi-feedback.rs
+++ b/boards/sparkfun-pro-micro/examples/pro-micro-spi-feedback.rs
@@ -19,7 +19,7 @@ use nb::block;
 fn main() -> ! {
     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 
-    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+    let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 
     let mut serial = sparkfun_pro_micro::Serial::new(
         dp.USART1,

--- a/boards/sparkfun-pro-micro/pro-micro-runner.sh
+++ b/boards/sparkfun-pro-micro/pro-micro-runner.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+set -e
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    echo "usage: $0 <application.elf>" >&2
+    exit 1
+fi
+
+if [ "$#" -lt 1 ]; then
+    echo "$0: no ELF file given" >&2
+    exit 1
+fi
+
+NAME="$(basename "$1")"
+SIZE_TEXT="$(avr-size "$1" | tail -1 | cut -f1)"
+SIZE_DATA="$(avr-size "$1" | tail -1 | cut -f2)"
+SIZE_BSS="$(avr-size "$1" | tail -1 | cut -f3)"
+
+printf "\n"
+printf "Program:             %s\n" "$NAME"
+printf "Size:\n"
+printf "   .text   %s (exact: %d)\n" "$(numfmt --to=si --padding=9 "$SIZE_TEXT")" "$SIZE_TEXT"
+printf "   .data   %s (exact: %d)\n" "$(numfmt --to=si --padding=9 "$SIZE_DATA")" "$SIZE_DATA"
+printf "   .bss    %s (exact: %d)\n" "$(numfmt --to=si --padding=9 "$SIZE_BSS")" "$SIZE_BSS"
+printf "\n"
+printf "Please bring up the bootloader and press ENTER!\n"
+read -r
+printf "Attempting to flash ...\n"
+printf "\n"
+
+avrdude -qq -C/etc/avrdude.conf -patmega32u4 -cavr109 -P/dev/ttyACM0 -b57600 -D "-Uflash:w:$1:e"

--- a/boards/sparkfun-pro-micro/src/lib.rs
+++ b/boards/sparkfun-pro-micro/src/lib.rs
@@ -85,7 +85,7 @@ pub fn delay_us(us: u16) {
 /// ```no_run
 /// let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 ///
-/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 ///
 /// pins.led_rx.into_output(&mut pins.ddr); // Chip Select must be set to output mode.
 ///
@@ -111,7 +111,7 @@ pub mod spi {
 /// ```no_run
 /// let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 ///
-/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 ///
 /// let mut adc = sparkfun_pro_micro::adc::Adc::new(dp.ADC, Default::default());
 ///
@@ -143,7 +143,7 @@ pub mod adc {
 /// # Example
 /// For a full example, see [`examples/pro-micro-pwm.rs`][ex-pwm].  In short:
 /// ```
-/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 /// let mut timer1 = Timer1Pwm::new(dp.TC1);
 ///
 /// let mut d3 = pins.d3.into_output(&mut pins.ddr).into_pwm(&mut timer0);
@@ -176,7 +176,7 @@ pub mod pwm {
 /// ```no_run
 /// let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 ///
-/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 ///
 /// let mut serial = sparkfun_pro_micro::Serial::new(
 ///     dp.USART1,
@@ -198,7 +198,7 @@ pub type Serial<IMODE> = hal::usart::Usart1<hal::clock::MHz16, IMODE>;
 /// ```no_run
 /// let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
 ///
-/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF);
 ///
 /// let mut i2c = sparkfun_pro_micro::I2c::new(
 ///     dp.TWI,

--- a/boards/sparkfun-pro-micro/src/lib.rs
+++ b/boards/sparkfun-pro-micro/src/lib.rs
@@ -1,0 +1,212 @@
+//! Board Support Crate for _SparkFun Pro Micro_.
+//!
+//! This crate provides abstractions for interfacing with the hardware of SparkFun Pro Micro. It
+//! re-exports functionality from the underlying HAL in ways that make more sense for this
+//! particular board.  For example, the pins are named by what is printed on the PCB instead of the
+//! MCU names.
+//!
+//! # Examples
+//! A number of examples can be found in the [`examples/`][ex] subdirectory of this crate.
+//!
+//! [ex]: https://github.com/Rahix/avr-hal/tree/master/boards/sparkfun-pro-micro/examples
+//!
+//! # Getting Started
+//! Please follow the guide from [`avr-hal`'s README][guide] for steps on how to set up a project
+//! with this board.  A rough skeleton for an application looks like this:
+//!
+//! ```no_run
+//! #![no_std]
+//! #![no_main]
+//!
+//! // Pull in the panic handler from panic-halt
+//! extern crate panic_halt;
+//!
+//! // The prelude just exports all HAL traits anonymously which makes
+//! // all trait methods available.  This is probably something that
+//! // should always be added.
+//! use sparkfun_pro_micro::prelude::*;
+//!
+//! // Define the entry-point for the application.  This can only be
+//! // done once in the entire dependency tree.
+//! #[sparkfun_pro_micro::entry]
+//! fn main() -> ! {
+//!     // Get the peripheral singletons for interacting with them.
+//!     let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+//!
+//!     unimplemented!()
+//! }
+//! ```
+//!
+//! [guide]: https://github.com/Rahix/avr-hal#starting-your-own-project
+
+#![no_std]
+
+pub extern crate atmega32u4_hal as hal;
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use hal::entry;
+
+mod pins;
+pub use crate::pins::*;
+
+pub use atmega32u4_hal::atmega32u4;
+pub use crate::atmega32u4::Peripherals;
+pub use atmega32u4_hal::prelude;
+
+
+/// Busy-Delay
+///
+/// **Note**: For just delaying, using [`sparkfun_pro_micro::delay_ms()`][delay_ms] or
+/// [`sparkfun_pro_micro::delay_us()`][delay_us] is probably the better choice.  This type is more
+/// useful when an `embedded-hal` driver needs a delay implementation.
+///
+/// [delay_ms]: fn.delay_ms.html
+/// [delay_us]: fn.delay_us.html
+pub type Delay = hal::delay::Delay<hal::clock::MHz16>;
+
+/// Wait (busy spin) for `ms` milliseconds
+pub fn delay_ms(ms: u16) {
+    use prelude::*;
+
+    Delay::new().delay_ms(ms)
+}
+
+/// Wait (busy spin) for `us` microseconds
+pub fn delay_us(us: u16) {
+    use prelude::*;
+
+    Delay::new().delay_us(us)
+}
+
+/// Support for the Serial Peripheral Interface
+///
+/// # Example
+/// For a full example, see [`examples/pro-micro-spi-feedback.rs`][ex-spi].  In short:
+/// ```no_run
+/// let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+///
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+///
+/// pins.led_rx.into_output(&mut pins.ddr); // Chip Select must be set to output mode.
+///
+/// // Create SPI interface.
+/// let mut spi = sparkfun_pro_micro::spi::Spi::new(
+///     dp.SPI,
+///     pins.sck.into_output(&mut pins.ddr),
+///     pins.mosi.into_output(&mut pins.ddr),
+///     pins.miso.into_pull_up_input(&mut pins.ddr),
+///     sparkfun_pro_micro::spi::Settings::default(),
+/// );
+/// ```
+///
+/// [ex-spi]: https://github.com/Rahix/avr-hal/blob/master/boards/sparkfun-pro-micro/examples/pro-micro-spi-feedback.rs
+pub mod spi {
+    pub use atmega32u4_hal::spi::*;
+}
+
+/// Support for the Analog to Digital Converter
+///
+/// # Example
+/// For a full example, see [`examples/pro-micro-adc.rs`][ex-adc].  In short:
+/// ```no_run
+/// let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+///
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+///
+/// let mut adc = sparkfun_pro_micro::adc::Adc::new(dp.ADC, Default::default());
+///
+/// let v_bandgap: u16 = nb::block!(
+///     adc.read(&mut sparkfun_pro_micro::adc::channel::Vbg)
+/// ).void_unwrap(),
+///
+/// let portf = dp.PORTF.split();
+/// let mut a0 = portf.pf7.into_analog_input(&mut adc);
+/// let mut a1 = portf.pf6.into_analog_input(&mut adc);
+/// let mut a2 = portf.pf5.into_analog_input(&mut adc);
+/// let mut a3 = portf.pf4.into_analog_input(&mut adc);
+/// let mut a4 = portf.pf1.into_analog_input(&mut adc);
+/// let mut a5 = portf.pf0.into_analog_input(&mut adc);
+///
+/// let v: u16 = nb::block!(adc.read(&mut a0)).void_unwrap(),
+/// ```
+///
+/// [ex-adc]: https://github.com/Rahix/avr-hal/blob/master/boards/sparkfun-pro-micro/examples/pro-micro-adc.rs
+pub mod adc {
+    pub use atmega32u4_hal::adc::*;
+}
+
+/// Support for PWM pins
+///
+/// The 4 timers of ATmega32U4 can be used for PWM on certain pins.
+/// The PWM methods are from `embedded_hal::PwmPin`.
+///
+/// # Example
+/// For a full example, see [`examples/pro-micro-pwm.rs`][ex-pwm].  In short:
+/// ```
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+/// let mut timer1 = Timer1Pwm::new(dp.TC1);
+///
+/// let mut d3 = pins.d3.into_output(&mut pins.ddr).into_pwm(&mut timer0);
+///
+/// d3.set_duty(128);
+/// d3.enable();
+/// ```
+///
+/// [ex-pwm]: https://github.com/Rahix/avr-hal/blob/master/boards/sparkfun-pro-micro/examples/pro-micro-pwm.rs
+///
+/// Here is an overview of pins and which timer they work with:
+///
+/// | Pin | Conversion Method | Alternate Conversion Method |
+/// | --- | --- | --- |
+/// | `pins.d3` | `.into_pwm(&mut timer0)` | |
+/// | `pins.d5` | `.into_pwm(&mut timer3)` | |
+/// | `pins.d6` | `.into_pwm(&mut timer4)` | |
+/// | `pins.d9` | `.into_pwm(&mut timer1)` | |
+/// | `pins.d10` | `.into_pwm(&mut timer1)` | `.into_pwm4(&mut timer4)` |
+/// | `pins.d11` | `.into_pwm(&mut timer0)` | `.into_pwm1(&mut timer1)` |
+/// | `pins.d13` | `.into_pwm(&mut timer4)` | |
+pub mod pwm {
+    pub use atmega32u4_hal::pwm::*;
+}
+
+/// Serial (UART) interface on pins `D0` (RX) and `D1` (TX)
+///
+/// # Example
+/// For a full example, see [`examples/pro-micro-serial.rs`][ex-serial].  In short:
+/// ```no_run
+/// let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+///
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+///
+/// let mut serial = sparkfun_pro_micro::Serial::new(
+///     dp.USART1,
+///     pins.d0,
+///     pins.d1.into_output(&mut pins.ddr),
+///     57600,
+/// );
+///
+/// ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+/// ```
+///
+/// [ex-serial]: https://github.com/Rahix/avr-hal/blob/master/boards/sparkfun-pro-micro/examples/pro-micro-serial.rs
+pub type Serial<IMODE> = hal::usart::Usart1<hal::clock::MHz16, IMODE>;
+
+/// I2C Master on pins `D2` (SDA) and `D3` (SCL)
+///
+/// # Example
+/// For a full example, see [`examples/pro-micro-i2cdetect.rs`][ex-i2c].  In short:
+/// ```no_run
+/// let dp = sparkfun_pro_micro::Peripherals::take().unwrap();
+///
+/// let mut pins = sparkfun_pro_micro::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE);
+///
+/// let mut i2c = sparkfun_pro_micro::I2c::new(
+///     dp.TWI,
+///     pins.d2.into_pull_up_input(&mut pins.ddr),
+///     pins.d3.into_pull_up_input(&mut pins.ddr),
+///     50000,
+/// );
+/// ```
+///
+/// [ex-i2c]: https://github.com/Rahix/avr-hal/blob/master/boards/sparkfun-pro-micro/examples/pro-micro-i2cdetect.rs
+pub type I2c<M> = hal::i2c::I2c<hal::clock::MHz16, M>;

--- a/boards/sparkfun-pro-micro/src/pins.rs
+++ b/boards/sparkfun-pro-micro/src/pins.rs
@@ -10,12 +10,23 @@ avr_hal_generic::impl_board_pins! {
         portc: crate::atmega32u4::PORTC,
         portd: crate::atmega32u4::PORTD,
         porte: crate::atmega32u4::PORTE,
-        // Not used yet
-        // portf: crate::atmega32u4::PORTF,
+        portf: crate::atmega32u4::PORTF,
     }
 
     /// Reexport of the Pro Micro's pins, with the names they have on the board
     pub struct Pins {
+        /// `A0`
+        pub a0: portf::pf7::PF7,
+        /// `A1`
+        pub a1: portf::pf6::PF6,
+        /// `A2`
+        pub a2: portf::pf5::PF5,
+        /// `A3`
+        pub a3: portf::pf4::PF4,
+        /// `A4`
+        pub a4: portf::pf1::PF1,
+        /// `A5`
+        pub a5: portf::pf0::PF0,
         /// `D0` / `RX`
         ///
         /// * `RX` (UART)

--- a/boards/sparkfun-pro-micro/src/pins.rs
+++ b/boards/sparkfun-pro-micro/src/pins.rs
@@ -1,0 +1,109 @@
+use atmega32u4_hal::port::PortExt;
+
+avr_hal_generic::impl_board_pins! {
+    #[port_defs]
+    use atmega32u4_hal::port;
+
+    /// Generic DDR that works for all ports
+    pub struct DDR {
+        portb: crate::atmega32u4::PORTB,
+        portc: crate::atmega32u4::PORTC,
+        portd: crate::atmega32u4::PORTD,
+        porte: crate::atmega32u4::PORTE,
+        // Not used yet
+        // portf: crate::atmega32u4::PORTF,
+    }
+
+    /// Reexport of the Pro Micro's pins, with the names they have on the board
+    pub struct Pins {
+        /// `D0` / `RX`
+        ///
+        /// * `RX` (UART)
+        /// * `INT2`: External Interrupt
+        pub d0: portd::pd2::PD2,
+        /// `D1` / `TX`
+        ///
+        /// * `TX` (UART)
+        /// * `INT3`: External Interrupt
+        pub d1: portd::pd3::PD3,
+        /// `D2` / `SDA`
+        ///
+        /// * `SDA`: i2c/twi data
+        /// * `INT1`: External Interrupt
+        pub d2: portd::pd1::PD1,
+        /// `D3` / `SCL`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer0Pwm]
+        /// * `SCL`: i2c/twi clock
+        /// * `INT0`: External Interrupt
+        /// * `OC0B`: Output Compare Channel `B` for Timer/Counter0
+        pub d3: portd::pd0::PD0,
+        /// `D4`
+        pub d4: portd::pd4::PD4,
+        /// `D5`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer3Pwm]
+        /// * `OC3A`: Output Compare Channel `A` for Timer/Counter3
+        /// * `#OC4A`: Inverted Output Compare Channel `A` for Timer/Counter4 (Not implemented)
+        pub d5: portc::pc6::PC6,
+        /// `D6`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer4Pwm]
+        /// * `OC4D`: Output Compare Channel `D` for Timer/Counter4
+        pub d6: portd::pd7::PD7,
+        /// `D7`
+        ///
+        /// * `INT6`: External Interrupt
+        pub d7: porte::pe6::PE6,
+        /// `D8`
+        pub d8: portb::pb4::PB4,
+        /// `D9`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer1Pwm]
+        /// * `OC1A`: Output Compare Channel `A` for Timer/Counter1
+        /// * `#OC4B`: Inverted Output Compare Channel `B` for Timer/Counter4 (Not implemented)
+        pub d9: portb::pb5::PB5,
+        /// `D10`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer1Pwm]
+        /// * `OC1B`: Output Compare Channel `B` for Timer/Counter1
+        /// * `OC4B`: Output Compare Channel `B` for Timer/Counter4 (Not implemented)
+        pub d10: portb::pb6::PB6,
+        /// `D11`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer0Pwm]
+        /// * `OC0A`: Output Compare Channel `B` for Timer/Counter0
+        /// * `OC1C`: Output Compare Channel `C` for Timer/Counter1
+        pub d11: portb::pb7::PB7,
+        /// `D12`
+        ///
+        /// * `#OC4D`: Inverted Output Compare Channel `D` for Timer/Counter4 (Not implemented)
+        pub d12: portd::pd6::PD6,
+        /// `D13` / `LED_BUILTIN`
+        ///
+        /// * Onboard LED
+        /// * **PWM**: [atmega32u4_hal::timer::Timer4Pwm]
+        /// * `OC4A`: Output Compare Channel `A` for Timer/Counter4
+        pub d13: portc::pc7::PC7,
+        /// `RX`
+        ///
+        /// Led for indicating inbound data.  Also the CS pin.
+        pub led_rx: portb::pb0::PB0,
+        /// `TX`
+        ///
+        /// Led for indicating outbound data
+        pub led_tx: portd::pd5::PD5,
+        /// `SCLK`
+        ///
+        /// ICSP SCLK pin
+        pub sck: portb::pb1::PB1,
+        /// `MOSI`
+        ///
+        /// ICSP MOSI pin
+        pub mosi: portb::pb2::PB2,
+        /// `MISO`
+        ///
+        /// ICSP MISO pin
+        pub miso: portb::pb3::PB3,
+    }
+}


### PR DESCRIPTION
Hello @Rahix 

I just started making the sparkfun-pro-micro crate by copying and renaming everything from the arduino-leonardo one (26698a0a191).

> @cecton, for the pins, just reference the [schematic for your board](https://cdn.sparkfun.com/assets/4/4/f/2/a/Qwiic_Pro_Micro_V2_0_USB_C_Schematic.pdf). It shows quite well which MCU pin is named what on the PCB.

It honestly took me some time to see it on the schematics :sweat_smile: I used the right most diagram.

It doesn't really show D11 to D13 but I supposed this is assumed because of the order? So I did the same with A4-A5 (Please double check that b66921e87)

Closes #52 