### PR TITLE
generic: delay: Reduce overhead of u32 delay_us

### DIFF
--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -214,9 +214,11 @@ where
     Delay<SPEED>: delay::DelayUs<u16>,
 {
     fn delay_us(&mut self, us: u32) {
-        // TODO: Somehow fix the overhead induced by this loop
-        for _ in 0..(us >> 12) {
+        let iters = (us >> 12);
+        let mut i = 0;
+        while i < iters {
             delay::DelayUs::<u16>::delay_us(self, 0xfff);
+            i += 1;
         }
         delay::DelayUs::<u16>::delay_us(self, (us & 0xfff) as u16);
     }

--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -214,6 +214,11 @@ where
     Delay<SPEED>: delay::DelayUs<u16>,
 {
     fn delay_us(&mut self, us: u32) {
+        // TODO: Somehow fix the overhead induced by this loop
+        // This was previously a range-based for loop, but that would
+        // compile down to fairly poor code. This is slightly better,
+        // but still has some overhead and may not lead to cycle-accurate
+        // delays.
         let iters = (us >> 12);
         let mut i = 0;
         while i < iters {


### PR DESCRIPTION
The range iterator was compiling to pretty ugly code with stack spilling,
so simplify by using a C-style for loop.