### PR TITLE
Support Arduino Nano in `arduino-uno` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Each board crate comes with a few examples showing how to use them.  For more de
   - [Website](https://www.arduino.cc/en/Main/Arduino_BoardLeonardo)
 * [Arduino Uno](./boards/arduino-uno) - [Crate Documentation](https://rahix.github.io/avr-hal/arduino_uno)
   - [Website](https://store.arduino.cc/usa/arduino-uno-rev3)
+* [Arduino Nano](./boards/arduino-uno) (via `arduino-uno` crate) - [Crate Documentation](https://rahix.github.io/avr-hal/arduino_uno)
+  - [Website](https://store.arduino.cc/arduino-nano)
 * [Arduino Mega 2560](./boards/arduino-mega2560) - [Crate Documentation](https://rahix.github.io/avr-hal/arduino_mega2560)
   - [Website](http://arduino.cc/en/Main/ArduinoBoardMega2560)
 * [Adafruit Trinket (3V3 or 5V)](./boards/trinket) (**not** PRO!) - [Crate Documentation](https://rahix.github.io/avr-hal/trinket)

--- a/boards/arduino-uno/Cargo.toml
+++ b/boards/arduino-uno/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 default = ["rt"]
 rt = ["atmega328p-hal/rt"]
+arduino-nano = ["atmega328p-hal/adc-pins"]
 
 [dependencies]
 atmega328p-hal = { path = "../../chips/atmega328p-hal/" }

--- a/boards/arduino-uno/examples/uno-adc.rs
+++ b/boards/arduino-uno/examples/uno-adc.rs
@@ -50,8 +50,28 @@ fn main() -> ! {
         for (i, v) in values.iter().enumerate() {
             ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
         }
-        ufmt::uwriteln!(&mut serial, "\r").void_unwrap();
 
+        // Arduino Nano has two more ADC pins A6 and A7.  Accessing them works a bit different from
+        // the other pins as they are not normal IO pins.  The code below shows how it works.
+        //
+        // The `arduino-nano` feature of this crate needs to be enabled to make them available.
+        // You can build the example for Arduino Nano like this:
+        //
+        //      cargo +nightly build --example uno-adc --features arduino-nano
+        //
+        // And run it with:
+        //
+        //      cargo +nightly run --example uno-adc --features arduino-nano
+        #[cfg(feature = "arduino-nano")]
+        {
+            let adc6: u16 = nb::block!(adc.read(&mut adc::channel::ADC6)).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A6: {} ", adc6).void_unwrap();
+
+            let adc7: u16 = nb::block!(adc.read(&mut adc::channel::ADC7)).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A7: {} ", adc7).void_unwrap();
+        }
+
+        ufmt::uwriteln!(&mut serial, "\r").void_unwrap();
         arduino_uno::delay_ms(1000);
     }
 }

--- a/boards/arduino-uno/examples/uno-adc.rs
+++ b/boards/arduino-uno/examples/uno-adc.rs
@@ -5,8 +5,9 @@ use arduino_uno::adc;
 use arduino_uno::prelude::*;
 use panic_halt as _;
 
-// This example opens a serial connection to the host computer.  On most POSIX operating systems (like GNU/Linux or
-// OSX), you can interface with the program by running (assuming the device appears as ttyACM0)
+// This example opens a serial connection to the host computer.  On most POSIX operating systems
+// (like GNU/Linux or OSX), you can interface with the program by running (assuming the device
+// appears as ttyACM0)
 //
 // $ sudo screen /dev/ttyACM0 9600
 
@@ -20,12 +21,37 @@ fn main() -> ! {
         arduino_uno::Serial::new(dp.USART0, pins.d0, pins.d1.into_output(&mut pins.ddr), 9600);
 
     let mut adc = adc::Adc::new(dp.ADC, Default::default());
-    let mut a0 = pins.a0.into_analog_input(&mut adc);
 
-    ufmt::uwriteln!(&mut serial, "Reading analog input on pin A0\r").void_unwrap();
+    let (vbg, gnd): (u16, u16) = (
+        nb::block!(adc.read(&mut adc::channel::Vbg)).void_unwrap(),
+        nb::block!(adc.read(&mut adc::channel::Gnd)).void_unwrap(),
+    );
+
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}\r", vbg).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "GND: {}\r", gnd).void_unwrap();
+
+    let mut a0 = pins.a0.into_analog_input(&mut adc);
+    let mut a1 = pins.a1.into_analog_input(&mut adc);
+    let mut a2 = pins.a2.into_analog_input(&mut adc);
+    let mut a3 = pins.a3.into_analog_input(&mut adc);
+    let mut a4 = pins.a4.into_analog_input(&mut adc);
+    let mut a5 = pins.a5.into_analog_input(&mut adc);
 
     loop {
-        let value: u16 = nb::block!(adc.read(&mut a0)).void_unwrap();
-        ufmt::uwriteln!(&mut serial, "read: {}\r", value).void_unwrap();
+        let values: [u16; 6] = [
+            nb::block!(adc.read(&mut a0)).void_unwrap(),
+            nb::block!(adc.read(&mut a1)).void_unwrap(),
+            nb::block!(adc.read(&mut a2)).void_unwrap(),
+            nb::block!(adc.read(&mut a3)).void_unwrap(),
+            nb::block!(adc.read(&mut a4)).void_unwrap(),
+            nb::block!(adc.read(&mut a5)).void_unwrap(),
+        ];
+
+        for (i, v) in values.iter().enumerate() {
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+        }
+        ufmt::uwriteln!(&mut serial, "\r").void_unwrap();
+
+        arduino_uno::delay_ms(1000);
     }
 }

--- a/boards/arduino-uno/src/lib.rs
+++ b/boards/arduino-uno/src/lib.rs
@@ -1,4 +1,4 @@
-//! Board Support Crate for _Arduino Uno_.
+//! Board Support Crate for [Arduino Uno] (and compatible boards; [see below](#compatible-boards)).
 //!
 //! This crate provides abstractions for interfacing with the hardware of Arduino Uno.  It
 //! re-exports functionality from the underlying HAL in ways that make more sense for this
@@ -38,6 +38,20 @@
 //! ```
 //!
 //! [guide]: https://github.com/Rahix/avr-hal#starting-your-own-project
+//!
+//! # Compatible Boards
+//! This crate primarily targets [Arduino Uno] but is also compatible with a number of very similar
+//! boards.  Where there are differences, those can be enabled with a crate feature.  Here is an
+//! overview:
+//!
+//! | Feature | Board | Differences against Uno |
+//! | --- | --- | --- |
+//! | `arduino-nano` | [Arduino Nano] | Additional `ADC6` and `ADC7` pins/channels (see [`examples/uno-adc.rs`]) |
+//!
+//! [`examples/uno-adc.rs`]: https://github.com/Rahix/avr-hal/blob/master/boards/arduino-uno/examples/uno-adc.rs
+//!
+//! [Arduino Uno]: https://store.arduino.cc/usa/arduino-uno-rev3
+//! [Arduino Nano]: https://store.arduino.cc/arduino-nano
 
 #![no_std]
 

--- a/chips/atmega328p-hal/Cargo.toml
+++ b/chips/atmega328p-hal/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [features]
 rt = ["avr-device/rt"]
+# Package exposes the ADC6 and ADC7 pins (only 32TQFP, 32MLF, 32UFBGA)
+adc-pins = []
 
 [dependencies]
 avr-hal-generic = { path = "../../avr-hal-generic/" }

--- a/chips/atmega328p-hal/src/adc.rs
+++ b/chips/atmega328p-hal/src/adc.rs
@@ -29,6 +29,30 @@ pub mod channel {
     use avr_hal::hal::adc::Channel;
     use crate::atmega328p::adc::admux::MUX_A;
 
+    /// Channel for `ADC6` pin.
+    ///
+    /// This pin is not available in all ATmega328P packages (only 32TQFP, 32MLF, 32UFBGA).  If you
+    /// are using one of them, enable the `adc-pins` feature to make them available.
+    #[cfg(feature = "adc-pins")]
+    pub struct ADC6;
+    #[cfg(feature = "adc-pins")]
+    impl Channel<super::Adc> for ADC6 {
+        type ID = MUX_A;
+        fn channel() -> Self::ID { MUX_A::ADC6 }
+    }
+
+    /// Channel for `ADC7` pin.
+    ///
+    /// This pin is not available in all ATmega328P packages (only 32TQFP, 32MLF, 32UFBGA).  If you
+    /// are using one of them, enable the `adc-pins` feature to make them available.
+    #[cfg(feature = "adc-pins")]
+    pub struct ADC7;
+    #[cfg(feature = "adc-pins")]
+    impl Channel<super::Adc> for ADC7 {
+        type ID = MUX_A;
+        fn channel() -> Self::ID { MUX_A::ADC7 }
+    }
+
     /// Channel for the _Bandgap Reference Voltage_
     pub struct Vbg;
     impl Channel<super::Adc> for Vbg {


### PR DESCRIPTION
Implement support for Arduino Nano as proposed in issue #64.