### PR TITLE
Fix max-atomic-width target setting

### DIFF
--- a/chips/atmega1280-hal/avr-atmega1280.json
+++ b/chips/atmega1280-hal/avr-atmega1280.json
@@ -9,6 +9,8 @@
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "max-atomic-width": 8,
+
   "executables": true,
   "linker": "avr-gcc",
   "linker-flavor": "gcc",

--- a/chips/atmega168-hal/avr-atmega168.json
+++ b/chips/atmega168-hal/avr-atmega168.json
@@ -9,6 +9,7 @@
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "max-atomic-width": 8,
 
   "executables": true,
 

--- a/chips/atmega2560-hal/avr-atmega2560.json
+++ b/chips/atmega2560-hal/avr-atmega2560.json
@@ -9,6 +9,8 @@
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "max-atomic-width": 8,
+
   "executables": true,
   "linker": "avr-gcc",
   "linker-flavor": "gcc",

--- a/chips/atmega328p-hal/avr-atmega328p.json
+++ b/chips/atmega328p-hal/avr-atmega328p.json
@@ -9,6 +9,7 @@
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "max-atomic-width": 8,
 
   "executables": true,
 

--- a/chips/atmega32u4-hal/avr-atmega32u4.json
+++ b/chips/atmega32u4-hal/avr-atmega32u4.json
@@ -9,6 +9,7 @@
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "max-atomic-width": 8,
 
   "executables": true,
 

--- a/chips/atmega48p-hal/avr-atmega48p.json
+++ b/chips/atmega48p-hal/avr-atmega48p.json
@@ -9,6 +9,7 @@
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "max-atomic-width": 8,
 
   "executables": true,
 

--- a/chips/attiny85-hal/avr-attiny85.json
+++ b/chips/attiny85-hal/avr-attiny85.json
@@ -9,6 +9,7 @@
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "max-atomic-width": 8,
 
   "executables": true,
 

--- a/chips/attiny88-hal/avr-attiny88.json
+++ b/chips/attiny88-hal/avr-attiny88.json
@@ -9,6 +9,7 @@
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "max-atomic-width": 8,
 
   "executables": true,
 


### PR DESCRIPTION
Nightly rustc throws compiler errors since upstream commit [3be40b22c834 ("Fix AtomicPtr::from_mut align check: Avoid generic arg in const expr.")][1].

They seem to be related to some discrepancies in the alignment requirements for pointer types on AVR.  While this should probably be investigated at some point, for now let's set `max-atomic-width` to 8 to make everything build again but still retain at least some atomic types (those aren't actual atomics but intrinsics that are lowered to critical sections for atomic access).

[1]: https://github.com/rust-lang/rust/commit/3be40b22c83491e4a4d34e2ad06aa81b804b9fad