### PR TITLE
Refactor hal crates

### DIFF
--- a/avr-hal-generic/src/adc.rs
+++ b/avr-hal-generic/src/adc.rs
@@ -60,7 +60,7 @@ macro_rules! impl_adc {
         use $crate::hal::adc::{Channel, OneShot};
         use $crate::nb;
         use $crate::port::mode::Analog;
-        pub use avr_hal::adc::*;
+        pub use $crate::adc::*;
 
         pub struct $Adc {
             peripheral: $ADC,

--- a/avr-hal-generic/src/wdt.rs
+++ b/avr-hal-generic/src/wdt.rs
@@ -85,7 +85,7 @@ macro_rules! impl_wdt {
                 //     2. Within the next four clock cycles, write the WDE and Watchdog prescaler
                 //        bits (WDP) as desired, but with the WDCE bit cleared. This must be done in
                 //        one operation.
-                avr_hal::avr_device::interrupt::free(|_| {
+                $crate::avr_device::interrupt::free(|_| {
                     // Reset the watchdog timer
                     self.feed();
                     // Enable watchdog configuration mode
@@ -116,7 +116,7 @@ macro_rules! impl_wdt {
                 //        previous value of the WDE bit.
                 //     2. Within the next four clock cycles, clear the WDE and WDCE bits.
                 //        This must be done in one operation.
-                avr_hal::avr_device::interrupt::free(|_| {
+                $crate::avr_device::interrupt::free(|_| {
                     // Reset the watchdog timer
                     self.feed();
                     // Enable watchdog configuration mode

--- a/boards/arduino-diecimila/src/lib.rs
+++ b/boards/arduino-diecimila/src/lib.rs
@@ -1,20 +1,22 @@
 #![no_std]
 
-pub extern crate atmega168_hal as hal;
+// Expose hal & pac crates
+pub use atmega168_hal as hal;
+pub use crate::hal::pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
-pub use hal::entry;
+pub use crate::hal::entry;
 
 mod pins;
 
-pub use crate::atmega168::Peripherals;
+pub use crate::pac::Peripherals;
 pub use crate::pins::*;
-pub use atmega168_hal::adc;
-pub use atmega168_hal::atmega168;
-pub use atmega168_hal::prelude;
-pub use atmega168_hal::pwm;
-pub use atmega168_hal::spi;
+pub use crate::hal::adc;
+pub use crate::hal::prelude;
+pub use crate::hal::pwm;
+pub use crate::hal::spi;
 
-pub type Delay = hal::delay::Delay<hal::clock::MHz16>;
-pub type Serial<IMODE> = hal::usart::Usart0<hal::clock::MHz16, IMODE>;
-pub type I2c<M> = hal::i2c::I2c<hal::clock::MHz16, M>;
+pub type Delay = crate::hal::delay::Delay<hal::clock::MHz16>;
+pub type Serial<IMODE> = crate::hal::usart::Usart0<hal::clock::MHz16, IMODE>;
+pub type I2c<M> = crate::hal::i2c::I2c<hal::clock::MHz16, M>;

--- a/boards/arduino-diecimila/src/pins.rs
+++ b/boards/arduino-diecimila/src/pins.rs
@@ -1,14 +1,14 @@
-use atmega168_hal::port::PortExt;
+use crate::hal::port::PortExt;
 
 avr_hal_generic::impl_board_pins! {
     #[port_defs]
-    use atmega168_hal::port;
+    use crate::hal::port;
 
     /// Generic DDR that works for all ports
     pub struct DDR {
-        portb: crate::atmega168::PORTB,
-        portc: crate::atmega168::PORTC,
-        portd: crate::atmega168::PORTD,
+        portb: crate::pac::PORTB,
+        portc: crate::pac::PORTC,
+        portd: crate::pac::PORTD,
     }
 
     /// Reexport of the Diecimila's pins, with the names they have on the board

--- a/boards/arduino-leonardo/src/lib.rs
+++ b/boards/arduino-leonardo/src/lib.rs
@@ -41,18 +41,20 @@
 
 #![no_std]
 
-pub extern crate atmega32u4_hal as hal;
+// Expose hal & pac crates
+pub use atmega32u4_hal as hal;
+pub use crate::hal::pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
-pub use hal::entry;
+pub use crate::hal::entry;
+
+pub use crate::pac::Peripherals;
 
 mod pins;
 pub use crate::pins::*;
 
-pub use atmega32u4_hal::atmega32u4;
-pub use crate::atmega32u4::Peripherals;
-pub use atmega32u4_hal::prelude;
-
+pub use crate::hal::prelude;
 
 /// Busy-Delay
 ///

--- a/boards/arduino-leonardo/src/pins.rs
+++ b/boards/arduino-leonardo/src/pins.rs
@@ -1,16 +1,16 @@
-use atmega32u4_hal::port::PortExt;
+use crate::hal::port::PortExt;
 
 avr_hal_generic::impl_board_pins! {
     #[port_defs]
-    use atmega32u4_hal::port;
+    use crate::hal::port;
 
     /// Generic DDR that works for all ports
     pub struct DDR {
-        portb: crate::atmega32u4::PORTB,
-        portc: crate::atmega32u4::PORTC,
-        portd: crate::atmega32u4::PORTD,
-        porte: crate::atmega32u4::PORTE,
-        portf: crate::atmega32u4::PORTF,
+        portb: crate::pac::PORTB,
+        portc: crate::pac::PORTC,
+        portd: crate::pac::PORTD,
+        porte: crate::pac::PORTE,
+        portf: crate::pac::PORTF,
     }
 
     /// Reexport of the Leonardo's pins, with the names they have on the board

--- a/boards/arduino-mega2560/src/lib.rs
+++ b/boards/arduino-mega2560/src/lib.rs
@@ -1,22 +1,26 @@
 #![no_std]
 
-pub extern crate atmega2560_hal as hal;
+// Expose hal & pac crates
+pub use atmega2560_hal as hal;
+pub use crate::hal::pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
-pub use hal::entry;
+pub use crate::hal::entry;
+
+pub use crate::pac::Peripherals;
 
 mod pins;
-
-pub use atmega2560_hal::atmega2560;
-pub use crate::atmega2560::Peripherals;
-pub use atmega2560_hal::prelude;
-pub use atmega2560_hal::spi;
-pub use atmega2560_hal::adc;
 pub use crate::pins::*;
 
-pub type Delay = hal::delay::Delay<hal::clock::MHz16>;
-pub type Serial<IMODE> = atmega2560_hal::usart::Usart0<hal::clock::MHz16, IMODE>;
-pub type I2c<M> = hal::i2c::I2c<hal::clock::MHz16, M>;
+pub use crate::hal::prelude;
+
+pub use crate::hal::spi;
+pub use crate::hal::adc;
+
+pub type Delay = crate::hal::delay::Delay<hal::clock::MHz16>;
+pub type Serial<IMODE> = crate::hal::usart::Usart0<hal::clock::MHz16, IMODE>;
+pub type I2c<M> = crate::hal::i2c::I2c<hal::clock::MHz16, M>;
 
 /// Support for PWM pins
 ///
@@ -62,5 +66,5 @@ pub type I2c<M> = hal::i2c::I2c<hal::clock::MHz16, M>;
 ///
 /// [ex-pwm]: https://github.com/sepotvin/avr-hal/blob/master/boards/arduino-mega2560/examples/mega2560-pwm.rs
 pub mod pwm {
-    pub use atmega2560_hal::pwm::*;
+    pub use crate::hal::pwm::*;
 }

--- a/boards/arduino-mega2560/src/pins.rs
+++ b/boards/arduino-mega2560/src/pins.rs
@@ -1,22 +1,22 @@
-use atmega2560_hal::port::PortExt;
+use crate::hal::port::PortExt;
 
 avr_hal_generic::impl_board_pins! {
     #[port_defs]
-    use atmega2560_hal::port;
+    use crate::hal::port;
 
     /// Generic DDR that works for all ports
     pub struct DDR {
-        porta: crate::atmega2560::PORTA,
-        portb: crate::atmega2560::PORTB,
-        portc: crate::atmega2560::PORTC,
-        portd: crate::atmega2560::PORTD,
-        porte: crate::atmega2560::PORTE,
-        portf: crate::atmega2560::PORTF,
-        portg: crate::atmega2560::PORTG,
-        porth: crate::atmega2560::PORTH,
-        portj: crate::atmega2560::PORTJ,
-        portk: crate::atmega2560::PORTK,
-        portl: crate::atmega2560::PORTL,
+        porta: crate::pac::PORTA,
+        portb: crate::pac::PORTB,
+        portc: crate::pac::PORTC,
+        portd: crate::pac::PORTD,
+        porte: crate::pac::PORTE,
+        portf: crate::pac::PORTF,
+        portg: crate::pac::PORTG,
+        porth: crate::pac::PORTH,
+        portj: crate::pac::PORTJ,
+        portk: crate::pac::PORTK,
+        portl: crate::pac::PORTL,
     }
 
     /// Reexport of the Mega 2560's pins, with the names they have on the board

--- a/boards/arduino-uno/src/lib.rs
+++ b/boards/arduino-uno/src/lib.rs
@@ -55,17 +55,20 @@
 
 #![no_std]
 
-pub extern crate atmega328p_hal as hal;
+// Expose hal & pac crates
+pub use atmega328p_hal as hal;
+pub use crate::hal::pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
-pub use hal::entry;
+pub use crate::hal::entry;
+
+pub use crate::pac::Peripherals;
 
 mod pins;
 pub use crate::pins::*;
 
-pub use atmega328p_hal::atmega328p;
-pub use crate::atmega328p::Peripherals;
-pub use atmega328p_hal::prelude;
+pub use crate::hal::prelude;
 
 /// Busy-Delay
 ///

--- a/boards/arduino-uno/src/pins.rs
+++ b/boards/arduino-uno/src/pins.rs
@@ -1,14 +1,14 @@
-use atmega328p_hal::port::PortExt;
+use crate::hal::port::PortExt;
 
 avr_hal_generic::impl_board_pins! {
     #[port_defs]
-    use atmega328p_hal::port;
+    use crate::hal::port;
 
     /// Generic DDR that works for all ports
     pub struct DDR {
-        portb: crate::atmega328p::PORTB,
-        portc: crate::atmega328p::PORTC,
-        portd: crate::atmega328p::PORTD,
+        portb: crate::pac::PORTB,
+        portc: crate::pac::PORTC,
+        portd: crate::pac::PORTD,
     }
 
     /// Reexport of the Leonardo's pins, with the names they have on the board

--- a/boards/bigavr6/src/lib.rs
+++ b/boards/bigavr6/src/lib.rs
@@ -1,14 +1,16 @@
 #![no_std]
 
-pub extern crate atmega1280_hal as hal;
+// Expose hal & pac crates
+pub use atmega1280_hal as hal;
+pub use crate::hal::pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
-pub use hal::entry;
+pub use crate::hal::entry;
 
-pub use atmega1280_hal::atmega1280;
-pub use crate::atmega1280::Peripherals;
-pub use atmega1280_hal::prelude;
+pub use crate::pac::Peripherals;
+pub use crate::hal::prelude;
 
-pub type Delay = hal::delay::Delay<hal::clock::MHz16>;
-pub type Serial<IMODE> = atmega1280_hal::usart::Usart0<hal::clock::MHz16, IMODE>;
-pub type I2c<M> = hal::i2c::I2c<hal::clock::MHz16, M>;
+pub type Delay = crate::hal::delay::Delay<hal::clock::MHz16>;
+pub type Serial<IMODE> = crate::hal::usart::Usart0<hal::clock::MHz16, IMODE>;
+pub type I2c<M> = crate::hal::i2c::I2c<hal::clock::MHz16, M>;

--- a/boards/sparkfun-pro-micro/src/lib.rs
+++ b/boards/sparkfun-pro-micro/src/lib.rs
@@ -41,17 +41,18 @@
 
 #![no_std]
 
-pub extern crate atmega32u4_hal as hal;
+pub use atmega32u4_hal as hal;
+pub use crate::hal::pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
-pub use hal::entry;
+pub use crate::hal::entry;
 
 mod pins;
 pub use crate::pins::*;
 
-pub use atmega32u4_hal::atmega32u4;
-pub use crate::atmega32u4::Peripherals;
-pub use atmega32u4_hal::prelude;
+pub use crate::pac::Peripherals;
+pub use crate::hal::prelude;
 
 
 /// Busy-Delay

--- a/boards/sparkfun-pro-micro/src/pins.rs
+++ b/boards/sparkfun-pro-micro/src/pins.rs
@@ -1,16 +1,16 @@
-use atmega32u4_hal::port::PortExt;
+use crate::hal::port::PortExt;
 
 avr_hal_generic::impl_board_pins! {
     #[port_defs]
-    use atmega32u4_hal::port;
+    use crate::hal::port;
 
     /// Generic DDR that works for all ports
     pub struct DDR {
-        portb: crate::atmega32u4::PORTB,
-        portc: crate::atmega32u4::PORTC,
-        portd: crate::atmega32u4::PORTD,
-        porte: crate::atmega32u4::PORTE,
-        portf: crate::atmega32u4::PORTF,
+        portb: crate::pac::PORTB,
+        portc: crate::pac::PORTC,
+        portd: crate::pac::PORTD,
+        porte: crate::pac::PORTE,
+        portf: crate::pac::PORTF,
     }
 
     /// Reexport of the Pro Micro's pins, with the names they have on the board

--- a/boards/trinket/src/lib.rs
+++ b/boards/trinket/src/lib.rs
@@ -1,27 +1,29 @@
 #![no_std]
 
-pub extern crate attiny85_hal as hal;
+// Expose hal & pac crates
+pub use attiny85_hal as hal;
+pub use crate::hal::pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
-pub use hal::entry;
+pub use crate::hal::entry;
 
-pub use attiny85_hal::attiny85;
-pub use crate::attiny85::Peripherals;
-pub use attiny85_hal::prelude;
+pub use crate::pac::Peripherals;
+pub use crate::hal::prelude;
 
-pub type Delay = hal::delay::Delay<hal::clock::MHz8>;
+pub type Delay = crate::hal::delay::Delay<hal::clock::MHz8>;
 
 pub use crate::pins::*;
 mod pins {
-    use attiny85_hal::port::PortExt;
+    use crate::hal::port::PortExt;
 
     avr_hal_generic::impl_board_pins! {
         #[port_defs]
-        use attiny85_hal::port;
+        use crate::hal::port;
 
         /// Generic DDR (not strictly necessary for ATtiny85)
         pub struct DDR {
-            portb: crate::attiny85::PORTB,
+            portb: crate::pac::PORTB,
         }
 
         /// Reexport of the pins with names as on the Trinket board

--- a/chips/atmega1280-hal/src/lib.rs
+++ b/chips/atmega1280-hal/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-pub use avr_device::atmega1280;
+/// Reexport of `atemga1280` from `avr-device`
+pub use avr_device::atmega1280 as pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
@@ -22,7 +24,7 @@ pub mod i2c {
 
     avr_hal_generic::impl_twi_i2c! {
         pub struct I2c {
-            peripheral: crate::atmega1280::TWI,
+            peripheral: crate::pac::TWI,
             pins: {
                 sda: portd::PD1,
                 scl: portd::PD0,

--- a/chips/atmega1280-hal/src/lib.rs
+++ b/chips/atmega1280-hal/src/lib.rs
@@ -1,28 +1,26 @@
 #![no_std]
 
-extern crate avr_hal_generic as avr_hal;
-
 pub use avr_device::atmega1280;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
-pub use avr_hal::clock;
-pub use avr_hal::delay;
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
 
 pub mod port;
 pub mod usart;
 
 pub mod prelude {
-    pub use crate::avr_hal::prelude::*;
+    pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }
 
 pub mod i2c {
     use crate::port::portd;
-    pub use avr_hal::i2c::*;
+    pub use avr_hal_generic::i2c::*;
 
-    avr_hal::impl_twi_i2c! {
+    avr_hal_generic::impl_twi_i2c! {
         pub struct I2c {
             peripheral: crate::atmega1280::TWI,
             pins: {

--- a/chips/atmega1280-hal/src/port.rs
+++ b/chips/atmega1280-hal/src/port.rs
@@ -14,17 +14,17 @@ pub trait PortExt {
 
 avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
-        A(crate::atmega1280::PORTA, porta, pina, ddra),
-        B(crate::atmega1280::PORTB, portb, pinb, ddrb),
-        C(crate::atmega1280::PORTC, portc, pinc, ddrc),
-        D(crate::atmega1280::PORTD, portd, pind, ddrd),
-        E(crate::atmega1280::PORTE, porte, pine, ddre),
-        F(crate::atmega1280::PORTF, portf, pinf, ddrf),
-        G(crate::atmega1280::PORTG, portg, ping, ddrg),
-        H(crate::atmega1280::PORTH, porth, pinh, ddrh),
-        J(crate::atmega1280::PORTJ, portj, pinj, ddrj),
-        K(crate::atmega1280::PORTK, portk, pink, ddrk),
-        L(crate::atmega1280::PORTL, portl, pinl, ddrl),
+        A(crate::pac::PORTA, porta, pina, ddra),
+        B(crate::pac::PORTB, portb, pinb, ddrb),
+        C(crate::pac::PORTC, portc, pinc, ddrc),
+        D(crate::pac::PORTD, portd, pind, ddrd),
+        E(crate::pac::PORTE, porte, pine, ddre),
+        F(crate::pac::PORTF, portf, pinf, ddrf),
+        G(crate::pac::PORTG, portg, ping, ddrg),
+        H(crate::pac::PORTH, porth, pinh, ddrh),
+        J(crate::pac::PORTJ, portj, pinj, ddrj),
+        K(crate::pac::PORTK, portk, pink, ddrk),
+        L(crate::pac::PORTL, portl, pinl, ddrl),
     }
 }
 
@@ -36,7 +36,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::A;
 
-        impl PortExt for crate::atmega1280::PORTA {
+        impl PortExt for crate::pac::PORTA {
             regs: (pina, ddra, porta),
             pa0: (PA0, 0),
             pa1: (PA1, 1),
@@ -58,7 +58,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::B;
 
-        impl PortExt for crate::atmega1280::PORTB {
+        impl PortExt for crate::pac::PORTB {
             regs: (pinb, ddrb, portb),
             pb0: (PB0, 0),
             pb1: (PB1, 1),
@@ -80,7 +80,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::C;
 
-        impl PortExt for crate::atmega1280::PORTC {
+        impl PortExt for crate::pac::PORTC {
             regs: (pinc, ddrc, portc),
             pc0: (PC0, 0),
             pc1: (PC1, 1),
@@ -102,7 +102,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::D;
 
-        impl PortExt for crate::atmega1280::PORTD {
+        impl PortExt for crate::pac::PORTD {
             regs: (pind, ddrd, portd),
             pd0: (PD0, 0),
             pd1: (PD1, 1),
@@ -124,7 +124,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::E;
 
-        impl PortExt for crate::atmega1280::PORTE {
+        impl PortExt for crate::pac::PORTE {
             regs: (pine, ddre, porte),
             pe0: (PE0, 0),
             pe1: (PE1, 1),
@@ -146,7 +146,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::F;
 
-        impl PortExt for crate::atmega1280::PORTF {
+        impl PortExt for crate::pac::PORTF {
             regs: (pinf, ddrf, portf),
             pf0: (PF0, 0),
             pf1: (PF1, 1),
@@ -168,7 +168,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::G;
 
-        impl PortExt for crate::atmega1280::PORTG {
+        impl PortExt for crate::pac::PORTG {
             regs: (ping, ddrg, portg),
             pg0: (PG0, 0),
             pg1: (PG1, 1),
@@ -188,7 +188,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::H;
 
-        impl PortExt for crate::atmega1280::PORTH {
+        impl PortExt for crate::pac::PORTH {
             regs: (pinh, ddrh, porth),
             ph0: (PH0, 0),
             ph1: (PH1, 1),
@@ -210,7 +210,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::J;
 
-        impl PortExt for crate::atmega1280::PORTJ {
+        impl PortExt for crate::pac::PORTJ {
             regs: (pinj, ddrj, portj),
             pj0: (PJ0, 0),
             pj1: (PJ1, 1),
@@ -232,7 +232,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::K;
 
-        impl PortExt for crate::atmega1280::PORTK {
+        impl PortExt for crate::pac::PORTK {
             regs: (pink, ddrk, portk),
             pk0: (PK0, 0),
             pk1: (PK1, 1),
@@ -254,7 +254,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::L;
 
-        impl PortExt for crate::atmega1280::PORTL {
+        impl PortExt for crate::pac::PORTL {
             regs: (pinl, ddrl, portl),
             pl0: (PL0, 0),
             pl1: (PL1, 1),

--- a/chips/atmega1280-hal/src/port.rs
+++ b/chips/atmega1280-hal/src/port.rs
@@ -4,7 +4,7 @@
 //!
 //! [1]: ../../avr_hal_generic/port/index.html
 
-pub use avr_hal::port::mode;
+pub use avr_hal_generic::port::mode;
 
 pub trait PortExt {
     type Parts;
@@ -12,7 +12,7 @@ pub trait PortExt {
     fn split(self) -> Self::Parts;
 }
 
-avr_hal::impl_generic_pin! {
+avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
         A(crate::atmega1280::PORTA, porta, pina, ddra),
         B(crate::atmega1280::PORTB, portb, pinb, ddrb),
@@ -28,7 +28,7 @@ avr_hal::impl_generic_pin! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod porta {
         #[port_ext]
         use super::PortExt;
@@ -50,7 +50,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portb {
         #[port_ext]
         use super::PortExt;
@@ -72,7 +72,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portc {
         #[port_ext]
         use super::PortExt;
@@ -94,7 +94,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portd {
         #[port_ext]
         use super::PortExt;
@@ -116,7 +116,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod porte {
         #[port_ext]
         use super::PortExt;
@@ -138,7 +138,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portf {
         #[port_ext]
         use super::PortExt;
@@ -160,7 +160,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portg {
         #[port_ext]
         use super::PortExt;
@@ -180,7 +180,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod porth {
         #[port_ext]
         use super::PortExt;
@@ -202,7 +202,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portj {
         #[port_ext]
         use super::PortExt;
@@ -224,7 +224,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portk {
         #[port_ext]
         use super::PortExt;
@@ -246,7 +246,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portl {
         #[port_ext]
         use super::PortExt;

--- a/chips/atmega1280-hal/src/usart.rs
+++ b/chips/atmega1280-hal/src/usart.rs
@@ -5,7 +5,7 @@ use crate::port::portj;
 
 avr_hal_generic::impl_usart! {
     pub struct Usart0 {
-        peripheral: crate::atmega1280::USART0,
+        peripheral: crate::pac::USART0,
         pins: {
             rx: porte::PE0,
             tx: porte::PE1,
@@ -16,7 +16,7 @@ avr_hal_generic::impl_usart! {
 
 avr_hal_generic::impl_usart! {
     pub struct Usart1 {
-        peripheral: crate::atmega1280::USART1,
+        peripheral: crate::pac::USART1,
         pins: {
             rx: portd::PD2,
             tx: portd::PD3,
@@ -27,7 +27,7 @@ avr_hal_generic::impl_usart! {
 
 avr_hal_generic::impl_usart! {
     pub struct Usart2 {
-        peripheral: crate::atmega1280::USART2,
+        peripheral: crate::pac::USART2,
         pins: {
             rx: porth::PH0,
             tx: porth::PH1,
@@ -38,7 +38,7 @@ avr_hal_generic::impl_usart! {
 
 avr_hal_generic::impl_usart! {
     pub struct Usart3 {
-        peripheral: crate::atmega1280::USART3,
+        peripheral: crate::pac::USART3,
         pins: {
             rx: portj::PJ0,
             tx: portj::PJ1,

--- a/chips/atmega1280-hal/src/usart.rs
+++ b/chips/atmega1280-hal/src/usart.rs
@@ -3,7 +3,7 @@ use crate::port::portd;
 use crate::port::porth;
 use crate::port::portj;
 
-crate::avr_hal::impl_usart! {
+avr_hal_generic::impl_usart! {
     pub struct Usart0 {
         peripheral: crate::atmega1280::USART0,
         pins: {
@@ -14,7 +14,7 @@ crate::avr_hal::impl_usart! {
     }
 }
 
-crate::avr_hal::impl_usart! {
+avr_hal_generic::impl_usart! {
     pub struct Usart1 {
         peripheral: crate::atmega1280::USART1,
         pins: {
@@ -25,7 +25,7 @@ crate::avr_hal::impl_usart! {
     }
 }
 
-crate::avr_hal::impl_usart! {
+avr_hal_generic::impl_usart! {
     pub struct Usart2 {
         peripheral: crate::atmega1280::USART2,
         pins: {
@@ -36,7 +36,7 @@ crate::avr_hal::impl_usart! {
     }
 }
 
-crate::avr_hal::impl_usart! {
+avr_hal_generic::impl_usart! {
     pub struct Usart3 {
         peripheral: crate::atmega1280::USART3,
         pins: {

--- a/chips/atmega168-hal/src/adc.rs
+++ b/chips/atmega168-hal/src/adc.rs
@@ -2,12 +2,12 @@ extern crate avr_hal_generic as avr_hal;
 
 use crate::port::portc::{PC0, PC1, PC2, PC3, PC4, PC5};
 
-use crate::atmega168::adc::admux::MUX_A;
+use crate::pac::adc::admux::MUX_A;
 
 avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
-        peripheral: crate::atmega168::ADC,
+        peripheral: crate::pac::ADC,
         set_mux: |peripheral, id| {
             peripheral.admux.modify(|_, w| w.mux().variant(id));
         },
@@ -27,7 +27,7 @@ avr_hal_generic::impl_adc! {
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
     use avr_hal_generic::hal::adc::Channel;
-    use crate::atmega168::adc::admux::MUX_A;
+    use crate::pac::adc::admux::MUX_A;
 
     /// Channel for the _Bandgap Reference Voltage_
     pub struct Vbg;

--- a/chips/atmega168-hal/src/adc.rs
+++ b/chips/atmega168-hal/src/adc.rs
@@ -4,7 +4,7 @@ use crate::port::portc::{PC0, PC1, PC2, PC3, PC4, PC5};
 
 use crate::atmega168::adc::admux::MUX_A;
 
-avr_hal::impl_adc! {
+avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
         peripheral: crate::atmega168::ADC,
@@ -26,7 +26,7 @@ avr_hal::impl_adc! {
 ///
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
-    use avr_hal::hal::adc::Channel;
+    use avr_hal_generic::hal::adc::Channel;
     use crate::atmega168::adc::admux::MUX_A;
 
     /// Channel for the _Bandgap Reference Voltage_

--- a/chips/atmega168-hal/src/lib.rs
+++ b/chips/atmega168-hal/src/lib.rs
@@ -5,31 +5,29 @@
 //!
 #![no_std]
 
-extern crate avr_hal_generic as avr_hal;
-
 pub use avr_device::atmega168;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
-pub use avr_hal::clock;
-pub use avr_hal::delay;
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
 
 pub mod adc;
 pub mod port;
 pub mod pwm;
 
 pub mod prelude {
-    pub use crate::avr_hal::prelude::*;
+    pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }
 
 /// I2C Bus
 pub mod i2c {
     use crate::port::portc;
-    pub use avr_hal::i2c::*;
+    pub use avr_hal_generic::i2c::*;
 
-    avr_hal::impl_twi_i2c! {
+    avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATmega168's TWI peripheral
         pub struct I2c {
             peripheral: crate::atmega168::TWI,
@@ -82,9 +80,9 @@ pub mod spi {
     //! also instantiate a Settings object with the other options available.
 
     use crate::port::portb;
-    pub use avr_hal::spi::*;
+    pub use avr_hal_generic::spi::*;
 
-    avr_hal::impl_spi! {
+    avr_hal_generic::impl_spi! {
         pub struct Spi {
             peripheral: crate::atmega168::SPI,
             pins: {
@@ -99,9 +97,9 @@ pub mod spi {
 /// Serial interface using USART
 pub mod usart {
     use crate::port::portd;
-    pub use avr_hal::serial::*;
+    pub use avr_hal_generic::serial::*;
 
-    crate::avr_hal::impl_usart! {
+    avr_hal_generic::impl_usart! {
         /// Serial interface based on ATmega168's USART0 peripheral
         ///
         /// Maximum baudrate seems to be 57600

--- a/chips/atmega168-hal/src/lib.rs
+++ b/chips/atmega168-hal/src/lib.rs
@@ -5,7 +5,8 @@
 //!
 #![no_std]
 
-pub use avr_device::atmega168;
+pub use avr_device::atmega168 as pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
@@ -30,7 +31,7 @@ pub mod i2c {
     avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATmega168's TWI peripheral
         pub struct I2c {
-            peripheral: crate::atmega168::TWI,
+            peripheral: crate::pac::TWI,
             pins: {
                 sda: portc::PC4,
                 scl: portc::PC5,
@@ -84,7 +85,7 @@ pub mod spi {
 
     avr_hal_generic::impl_spi! {
         pub struct Spi {
-            peripheral: crate::atmega168::SPI,
+            peripheral: crate::pac::SPI,
             pins: {
                 sclk: portb::PB5,
                 mosi: portb::PB3,
@@ -104,7 +105,7 @@ pub mod usart {
         ///
         /// Maximum baudrate seems to be 57600
         pub struct Usart0 {
-            peripheral: crate::atmega168::USART0,
+            peripheral: crate::pac::USART0,
             pins: {
                 rx: portd::PD0,
                 tx: portd::PD1,

--- a/chips/atmega168-hal/src/port.rs
+++ b/chips/atmega168-hal/src/port.rs
@@ -1,5 +1,5 @@
 //! `PORTB` - `PORTD` digital IO
-pub use avr_hal::port::mode;
+pub use avr_hal_generic::port::mode;
 
 pub trait PortExt {
     type Parts;
@@ -7,7 +7,7 @@ pub trait PortExt {
     fn split(self) -> Self::Parts;
 }
 
-avr_hal::impl_generic_pin! {
+avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
         B(crate::atmega168::PORTB, portb, pinb, ddrb),
         C(crate::atmega168::PORTC, portc, pinc, ddrc),
@@ -15,7 +15,7 @@ avr_hal::impl_generic_pin! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portb {
         #[port_ext]
         use super::PortExt;
@@ -37,7 +37,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portc {
         #[port_ext]
         use super::PortExt;
@@ -58,7 +58,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portd {
         #[port_ext]
         use super::PortExt;

--- a/chips/atmega168-hal/src/port.rs
+++ b/chips/atmega168-hal/src/port.rs
@@ -9,9 +9,9 @@ pub trait PortExt {
 
 avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
-        B(crate::atmega168::PORTB, portb, pinb, ddrb),
-        C(crate::atmega168::PORTC, portc, pinc, ddrc),
-        D(crate::atmega168::PORTD, portd, pind, ddrd),
+        B(crate::pac::PORTB, portb, pinb, ddrb),
+        C(crate::pac::PORTC, portc, pinc, ddrc),
+        D(crate::pac::PORTD, portd, pind, ddrd),
     }
 }
 
@@ -23,7 +23,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::B;
 
-        impl PortExt for crate::atmega168::PORTB {
+        impl PortExt for crate::pac::PORTB {
             regs: (pinb, ddrb, portb),
             pb0: (PB0, 0),
             pb1: (PB1, 1),
@@ -45,7 +45,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::C;
 
-        impl PortExt for crate::atmega168::PORTC {
+        impl PortExt for crate::pac::PORTC {
             regs: (pinc, ddrc, portc),
             pc0: (PC0, 0),
             pc1: (PC1, 1),
@@ -66,7 +66,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::D;
 
-        impl PortExt for crate::atmega168::PORTD {
+        impl PortExt for crate::pac::PORTD {
             regs: (pind, ddrd, portd),
             pd0: (PD0, 0),
             pd1: (PD1, 1),

--- a/chips/atmega168-hal/src/pwm.rs
+++ b/chips/atmega168-hal/src/pwm.rs
@@ -26,9 +26,9 @@
 //! | `PD6` | `.into_pwm(&mut timer0)` |
 
 use crate::port::{portb, portd};
-pub use avr_hal::pwm::*;
+pub use avr_hal_generic::pwm::*;
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC0` for PWM (pins `PD5`, `PD6`)
     ///
     /// # Example
@@ -75,7 +75,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC1` for PWM (pins `PB1`, `PB2`)
     ///
     /// # Example
@@ -125,7 +125,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC2` for PWM (pins `PB3`, `PD3`)
     ///
     /// # Example

--- a/chips/atmega168-hal/src/pwm.rs
+++ b/chips/atmega168-hal/src/pwm.rs
@@ -43,7 +43,7 @@ avr_hal_generic::impl_pwm! {
     /// pd5.enable();
     /// ```
     pub struct Timer0Pwm {
-        timer: crate::atmega168::TC0,
+        timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
             tim.tccr0b.modify(|_, w| match prescaler {
@@ -90,7 +90,7 @@ avr_hal_generic::impl_pwm! {
     /// pb1.enable();
     /// ```
     pub struct Timer1Pwm {
-        timer: crate::atmega168::TC1,
+        timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
             tim.tccr1b.modify(|_, w| {
@@ -141,7 +141,7 @@ avr_hal_generic::impl_pwm! {
     /// pb3.enable();
     /// ```
     pub struct Timer2Pwm {
-        timer: crate::atmega168::TC2,
+        timer: crate::pac::TC2,
         init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().pwm_fast());
             tim.tccr2b.modify(|_, w| match prescaler {

--- a/chips/atmega2560-hal/src/adc.rs
+++ b/chips/atmega2560-hal/src/adc.rs
@@ -3,12 +3,12 @@ extern crate avr_hal_generic as avr_hal;
 use crate::port::portf::{PF0, PF1, PF2, PF3, PF4, PF5, PF6, PF7};
 use crate::port::portk::{PK0, PK1, PK2, PK3, PK4, PK5, PK6, PK7};
 
-use crate::atmega2560::adc::admux::MUX_A;
+use crate::pac::adc::admux::MUX_A;
 
 avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
-        peripheral: crate::atmega2560::ADC,
+        peripheral: crate::pac::ADC,
         set_mux: |peripheral, id| {
             peripheral.admux.modify(|_, w| w.mux().variant(id));
             // n.b. the high bit of ADMUX[MUX] is in the ADCSRB register
@@ -40,7 +40,7 @@ avr_hal_generic::impl_adc! {
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
     use avr_hal_generic::hal::adc::Channel;
-    use crate::atmega2560::adc::admux::MUX_A;
+    use crate::pac::adc::admux::MUX_A;
 
     /// Channel for the _Bandgap Reference Voltage_
     pub struct Vbg;

--- a/chips/atmega2560-hal/src/adc.rs
+++ b/chips/atmega2560-hal/src/adc.rs
@@ -5,7 +5,7 @@ use crate::port::portk::{PK0, PK1, PK2, PK3, PK4, PK5, PK6, PK7};
 
 use crate::atmega2560::adc::admux::MUX_A;
 
-avr_hal::impl_adc! {
+avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
         peripheral: crate::atmega2560::ADC,
@@ -39,7 +39,7 @@ avr_hal::impl_adc! {
 ///
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
-    use avr_hal::hal::adc::Channel;
+    use avr_hal_generic::hal::adc::Channel;
     use crate::atmega2560::adc::admux::MUX_A;
 
     /// Channel for the _Bandgap Reference Voltage_

--- a/chips/atmega2560-hal/src/lib.rs
+++ b/chips/atmega2560-hal/src/lib.rs
@@ -1,14 +1,12 @@
 #![no_std]
 
-extern crate avr_hal_generic as avr_hal;
-
 pub use avr_device::atmega2560;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
-pub use avr_hal::clock;
-pub use avr_hal::delay;
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
 
 pub mod adc;
 pub mod port;
@@ -17,15 +15,15 @@ pub mod spi;
 pub mod usart;
 
 pub mod prelude {
-    pub use crate::avr_hal::prelude::*;
+    pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }
 
 pub mod i2c {
     use crate::port::portd;
-    pub use avr_hal::i2c::*;
+    pub use avr_hal_generic::i2c::*;
 
-    avr_hal::impl_twi_i2c! {
+    avr_hal_generic::impl_twi_i2c! {
         pub struct I2c {
             peripheral: crate::atmega2560::TWI,
             pins: {

--- a/chips/atmega2560-hal/src/lib.rs
+++ b/chips/atmega2560-hal/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-pub use avr_device::atmega2560;
+/// Reexport of `atmega2560` from `avr-device`
+pub use avr_device::atmega2560 as pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
@@ -25,7 +27,7 @@ pub mod i2c {
 
     avr_hal_generic::impl_twi_i2c! {
         pub struct I2c {
-            peripheral: crate::atmega2560::TWI,
+            peripheral: crate::pac::TWI,
             pins: {
                 sda: portd::PD1,
                 scl: portd::PD0,

--- a/chips/atmega2560-hal/src/port.rs
+++ b/chips/atmega2560-hal/src/port.rs
@@ -4,7 +4,7 @@
 //!
 //! [1]: ../../avr_hal_generic/port/index.html
 
-pub use avr_hal::port::mode;
+pub use avr_hal_generic::port::mode;
 
 pub trait PortExt {
     type Parts;
@@ -12,7 +12,7 @@ pub trait PortExt {
     fn split(self) -> Self::Parts;
 }
 
-avr_hal::impl_generic_pin! {
+avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
         A(crate::atmega2560::PORTA, porta, pina, ddra),
         B(crate::atmega2560::PORTB, portb, pinb, ddrb),
@@ -28,7 +28,7 @@ avr_hal::impl_generic_pin! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod porta {
         #[port_ext]
         use super::PortExt;
@@ -50,7 +50,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portb {
         #[port_ext]
         use super::PortExt;
@@ -72,7 +72,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portc {
         #[port_ext]
         use super::PortExt;
@@ -94,7 +94,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portd {
         #[port_ext]
         use super::PortExt;
@@ -116,7 +116,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod porte {
         #[port_ext]
         use super::PortExt;
@@ -138,7 +138,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portf {
         #[port_ext]
         use super::PortExt;
@@ -160,7 +160,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portg {
         #[port_ext]
         use super::PortExt;
@@ -180,7 +180,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod porth {
         #[port_ext]
         use super::PortExt;
@@ -202,7 +202,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portj {
         #[port_ext]
         use super::PortExt;
@@ -224,7 +224,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portk {
         #[port_ext]
         use super::PortExt;
@@ -246,7 +246,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portl {
         #[port_ext]
         use super::PortExt;

--- a/chips/atmega2560-hal/src/port.rs
+++ b/chips/atmega2560-hal/src/port.rs
@@ -14,17 +14,17 @@ pub trait PortExt {
 
 avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
-        A(crate::atmega2560::PORTA, porta, pina, ddra),
-        B(crate::atmega2560::PORTB, portb, pinb, ddrb),
-        C(crate::atmega2560::PORTC, portc, pinc, ddrc),
-        D(crate::atmega2560::PORTD, portd, pind, ddrd),
-        E(crate::atmega2560::PORTE, porte, pine, ddre),
-        F(crate::atmega2560::PORTF, portf, pinf, ddrf),
-        G(crate::atmega2560::PORTG, portg, ping, ddrg),
-        H(crate::atmega2560::PORTH, porth, pinh, ddrh),
-        J(crate::atmega2560::PORTJ, portj, pinj, ddrj),
-        K(crate::atmega2560::PORTK, portk, pink, ddrk),
-        L(crate::atmega2560::PORTL, portl, pinl, ddrl),
+        A(crate::pac::PORTA, porta, pina, ddra),
+        B(crate::pac::PORTB, portb, pinb, ddrb),
+        C(crate::pac::PORTC, portc, pinc, ddrc),
+        D(crate::pac::PORTD, portd, pind, ddrd),
+        E(crate::pac::PORTE, porte, pine, ddre),
+        F(crate::pac::PORTF, portf, pinf, ddrf),
+        G(crate::pac::PORTG, portg, ping, ddrg),
+        H(crate::pac::PORTH, porth, pinh, ddrh),
+        J(crate::pac::PORTJ, portj, pinj, ddrj),
+        K(crate::pac::PORTK, portk, pink, ddrk),
+        L(crate::pac::PORTL, portl, pinl, ddrl),
     }
 }
 
@@ -36,7 +36,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::A;
 
-        impl PortExt for crate::atmega2560::PORTA {
+        impl PortExt for crate::pac::PORTA {
             regs: (pina, ddra, porta),
             pa0: (PA0, 0),
             pa1: (PA1, 1),
@@ -58,7 +58,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::B;
 
-        impl PortExt for crate::atmega2560::PORTB {
+        impl PortExt for crate::pac::PORTB {
             regs: (pinb, ddrb, portb),
             pb0: (PB0, 0),
             pb1: (PB1, 1),
@@ -80,7 +80,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::C;
 
-        impl PortExt for crate::atmega2560::PORTC {
+        impl PortExt for crate::pac::PORTC {
             regs: (pinc, ddrc, portc),
             pc0: (PC0, 0),
             pc1: (PC1, 1),
@@ -102,7 +102,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::D;
 
-        impl PortExt for crate::atmega2560::PORTD {
+        impl PortExt for crate::pac::PORTD {
             regs: (pind, ddrd, portd),
             pd0: (PD0, 0),
             pd1: (PD1, 1),
@@ -124,7 +124,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::E;
 
-        impl PortExt for crate::atmega2560::PORTE {
+        impl PortExt for crate::pac::PORTE {
             regs: (pine, ddre, porte),
             pe0: (PE0, 0),
             pe1: (PE1, 1),
@@ -146,7 +146,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::F;
 
-        impl PortExt for crate::atmega2560::PORTF {
+        impl PortExt for crate::pac::PORTF {
             regs: (pinf, ddrf, portf),
             pf0: (PF0, 0),
             pf1: (PF1, 1),
@@ -168,7 +168,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::G;
 
-        impl PortExt for crate::atmega2560::PORTG {
+        impl PortExt for crate::pac::PORTG {
             regs: (ping, ddrg, portg),
             pg0: (PG0, 0),
             pg1: (PG1, 1),
@@ -188,7 +188,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::H;
 
-        impl PortExt for crate::atmega2560::PORTH {
+        impl PortExt for crate::pac::PORTH {
             regs: (pinh, ddrh, porth),
             ph0: (PH0, 0),
             ph1: (PH1, 1),
@@ -210,7 +210,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::J;
 
-        impl PortExt for crate::atmega2560::PORTJ {
+        impl PortExt for crate::pac::PORTJ {
             regs: (pinj, ddrj, portj),
             pj0: (PJ0, 0),
             pj1: (PJ1, 1),
@@ -232,7 +232,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::K;
 
-        impl PortExt for crate::atmega2560::PORTK {
+        impl PortExt for crate::pac::PORTK {
             regs: (pink, ddrk, portk),
             pk0: (PK0, 0),
             pk1: (PK1, 1),
@@ -254,7 +254,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::L;
 
-        impl PortExt for crate::atmega2560::PORTL {
+        impl PortExt for crate::pac::PORTL {
             regs: (pinl, ddrl, portl),
             pl0: (PL0, 0),
             pl1: (PL1, 1),

--- a/chips/atmega2560-hal/src/pwm.rs
+++ b/chips/atmega2560-hal/src/pwm.rs
@@ -35,9 +35,9 @@
 //! | `PL5` | `.into_pwm(&mut timer5)` | |
 
 use crate::port::{portb, porte, portg, porth, portl};
-pub use avr_hal::pwm::*;
+pub use avr_hal_generic::pwm::*;
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC0` for PWM (pins `PB7`, `PG5`)
     ///
     /// # Example
@@ -85,7 +85,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC1` for PWM (pins `PB5`, `PB6`, `PB7`)
     ///
     /// # Example
@@ -146,7 +146,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC2` for PWM (pins `PB4`, `PH6`)
     ///
     /// # Example
@@ -197,7 +197,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC3` for PWM (pins `PE3`, `PE4`, `PE5`)
     ///
     /// # Example
@@ -256,7 +256,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC4` for PWM (pins `PH3`, `PH4`, `PH5`)
     ///
     /// # Example
@@ -315,7 +315,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC5` for PWM (pins `PL3`, `PL4`, `PL5`)
     ///
     /// # Example

--- a/chips/atmega2560-hal/src/pwm.rs
+++ b/chips/atmega2560-hal/src/pwm.rs
@@ -53,7 +53,7 @@ avr_hal_generic::impl_pwm! {
     /// pb7.enable();
     /// ```
     pub struct Timer0Pwm {
-        timer: crate::atmega2560::TC0,
+        timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
             tim.tccr0b.modify(|_, w| match prescaler {
@@ -103,7 +103,7 @@ avr_hal_generic::impl_pwm! {
     ///
     /// **Note**: For `PB7` the method is called `into_pwm1()`!
     pub struct Timer1Pwm {
-        timer: crate::atmega2560::TC1,
+        timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
             tim.tccr1b.modify(|_, w|  {
@@ -162,7 +162,7 @@ avr_hal_generic::impl_pwm! {
     /// pb4.enable();
     /// ```
     pub struct Timer2Pwm {
-        timer: crate::atmega2560::TC2,
+        timer: crate::pac::TC2,
         init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().bits(0b01));
             tim.tccr2b.modify(|_, w| {
@@ -213,7 +213,7 @@ avr_hal_generic::impl_pwm! {
     /// pe3.enable();
     /// ```
     pub struct Timer3Pwm {
-        timer: crate::atmega2560::TC3,
+        timer: crate::pac::TC3,
         init: |tim, prescaler| {
             tim.tccr3a.modify(|_, w| w.wgm3().bits(0b01));
             tim.tccr3b.modify(|_, w| {
@@ -272,7 +272,7 @@ avr_hal_generic::impl_pwm! {
     /// ph3.enable();
     /// ```
     pub struct Timer4Pwm {
-        timer: crate::atmega2560::TC4,
+        timer: crate::pac::TC4,
         init: |tim, prescaler| {
             tim.tccr4a.modify(|_, w| w.wgm4().bits(0b01));
             tim.tccr4b.modify(|_, w| {
@@ -331,7 +331,7 @@ avr_hal_generic::impl_pwm! {
     /// pl3.enable();
     /// ```
     pub struct Timer5Pwm {
-        timer: crate::atmega2560::TC5,
+        timer: crate::pac::TC5,
         init: |tim, prescaler| {
             tim.tccr5a.modify(|_, w| w.wgm5().bits(0b01));
             tim.tccr5b.modify(|_, w| {

--- a/chips/atmega2560-hal/src/spi.rs
+++ b/chips/atmega2560-hal/src/spi.rs
@@ -24,11 +24,11 @@
 
 extern crate avr_hal_generic as avr_hal;
 
-pub use avr_hal::spi::*;
+pub use avr_hal_generic::spi::*;
 use crate::port::portb;
 
 
-avr_hal::impl_spi! {
+avr_hal_generic::impl_spi! {
     pub struct Spi {
         peripheral: crate::atmega2560::SPI,
         pins: {

--- a/chips/atmega2560-hal/src/spi.rs
+++ b/chips/atmega2560-hal/src/spi.rs
@@ -30,7 +30,7 @@ use crate::port::portb;
 
 avr_hal_generic::impl_spi! {
     pub struct Spi {
-        peripheral: crate::atmega2560::SPI,
+        peripheral: crate::pac::SPI,
         pins: {
             sclk: portb::PB1,
             mosi: portb::PB2,

--- a/chips/atmega2560-hal/src/usart.rs
+++ b/chips/atmega2560-hal/src/usart.rs
@@ -3,7 +3,7 @@ use crate::port::portd;
 use crate::port::porth;
 use crate::port::portj;
 
-crate::avr_hal::impl_usart! {
+avr_hal_generic::impl_usart! {
     pub struct Usart0 {
         peripheral: crate::atmega2560::USART0,
         pins: {
@@ -14,7 +14,7 @@ crate::avr_hal::impl_usart! {
     }
 }
 
-crate::avr_hal::impl_usart! {
+avr_hal_generic::impl_usart! {
     pub struct Usart1 {
         peripheral: crate::atmega2560::USART1,
         pins: {
@@ -25,7 +25,7 @@ crate::avr_hal::impl_usart! {
     }
 }
 
-crate::avr_hal::impl_usart! {
+avr_hal_generic::impl_usart! {
     pub struct Usart2 {
         peripheral: crate::atmega2560::USART2,
         pins: {
@@ -36,7 +36,7 @@ crate::avr_hal::impl_usart! {
     }
 }
 
-crate::avr_hal::impl_usart! {
+avr_hal_generic::impl_usart! {
     pub struct Usart3 {
         peripheral: crate::atmega2560::USART3,
         pins: {

--- a/chips/atmega2560-hal/src/usart.rs
+++ b/chips/atmega2560-hal/src/usart.rs
@@ -5,7 +5,7 @@ use crate::port::portj;
 
 avr_hal_generic::impl_usart! {
     pub struct Usart0 {
-        peripheral: crate::atmega2560::USART0,
+        peripheral: crate::pac::USART0,
         pins: {
             rx: porte::PE0,
             tx: porte::PE1,
@@ -16,7 +16,7 @@ avr_hal_generic::impl_usart! {
 
 avr_hal_generic::impl_usart! {
     pub struct Usart1 {
-        peripheral: crate::atmega2560::USART1,
+        peripheral: crate::pac::USART1,
         pins: {
             rx: portd::PD2,
             tx: portd::PD3,
@@ -27,7 +27,7 @@ avr_hal_generic::impl_usart! {
 
 avr_hal_generic::impl_usart! {
     pub struct Usart2 {
-        peripheral: crate::atmega2560::USART2,
+        peripheral: crate::pac::USART2,
         pins: {
             rx: porth::PH0,
             tx: porth::PH1,
@@ -38,7 +38,7 @@ avr_hal_generic::impl_usart! {
 
 avr_hal_generic::impl_usart! {
     pub struct Usart3 {
-        peripheral: crate::atmega2560::USART3,
+        peripheral: crate::pac::USART3,
         pins: {
             rx: portj::PJ0,
             tx: portj::PJ1,

--- a/chips/atmega328p-hal/src/adc.rs
+++ b/chips/atmega328p-hal/src/adc.rs
@@ -4,7 +4,7 @@ use crate::port::portc::{PC0, PC1, PC2, PC3, PC4, PC5};
 
 use crate::atmega328p::adc::admux::MUX_A;
 
-avr_hal::impl_adc! {
+avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
         peripheral: crate::atmega328p::ADC,
@@ -26,7 +26,7 @@ avr_hal::impl_adc! {
 ///
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
-    use avr_hal::hal::adc::Channel;
+    use avr_hal_generic::hal::adc::Channel;
     use crate::atmega328p::adc::admux::MUX_A;
 
     /// Channel for `ADC6` pin.

--- a/chips/atmega328p-hal/src/adc.rs
+++ b/chips/atmega328p-hal/src/adc.rs
@@ -2,12 +2,12 @@ extern crate avr_hal_generic as avr_hal;
 
 use crate::port::portc::{PC0, PC1, PC2, PC3, PC4, PC5};
 
-use crate::atmega328p::adc::admux::MUX_A;
+use crate::pac::adc::admux::MUX_A;
 
 avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
-        peripheral: crate::atmega328p::ADC,
+        peripheral: crate::pac::ADC,
         set_mux: |peripheral, id| {
             peripheral.admux.modify(|_, w| w.mux().variant(id));
         },
@@ -27,7 +27,7 @@ avr_hal_generic::impl_adc! {
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
     use avr_hal_generic::hal::adc::Channel;
-    use crate::atmega328p::adc::admux::MUX_A;
+    use crate::pac::adc::admux::MUX_A;
 
     /// Channel for `ADC6` pin.
     ///

--- a/chips/atmega328p-hal/src/lib.rs
+++ b/chips/atmega328p-hal/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-pub use avr_device::atmega328p;
+/// Reexport of `atmega328p` from `avr-device`
+pub use avr_device::atmega328p as pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
@@ -27,7 +29,7 @@ pub mod i2c {
     avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATmega328P's TWI peripheral
         pub struct I2c {
-            peripheral: crate::atmega328p::TWI,
+            peripheral: crate::pac::TWI,
             pins: {
                 sda: portc::PC4,
                 scl: portc::PC5,
@@ -81,7 +83,7 @@ pub mod spi {
 
     avr_hal_generic::impl_spi! {
         pub struct Spi {
-            peripheral: crate::atmega328p::SPI,
+            peripheral: crate::pac::SPI,
             pins: {
                 sclk: portb::PB5,
                 mosi: portb::PB3,
@@ -101,7 +103,7 @@ pub mod usart {
         ///
         /// Maximum baudrate seems to be 57600
         pub struct Usart0 {
-            peripheral: crate::atmega328p::USART0,
+            peripheral: crate::pac::USART0,
             pins: {
                 rx: portd::PD0,
                 tx: portd::PD1,

--- a/chips/atmega328p-hal/src/lib.rs
+++ b/chips/atmega328p-hal/src/lib.rs
@@ -1,14 +1,12 @@
 #![no_std]
 
-extern crate avr_hal_generic as avr_hal;
-
 pub use avr_device::atmega328p;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
-pub use avr_hal::clock;
-pub use avr_hal::delay;
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
 
 pub mod port;
 
@@ -17,16 +15,16 @@ pub mod pwm;
 pub mod wdt;
 
 pub mod prelude {
-    pub use crate::avr_hal::prelude::*;
+    pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }
 
 /// I2C Bus
 pub mod i2c {
     use crate::port::portc;
-    pub use avr_hal::i2c::*;
+    pub use avr_hal_generic::i2c::*;
 
-    avr_hal::impl_twi_i2c! {
+    avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATmega328P's TWI peripheral
         pub struct I2c {
             peripheral: crate::atmega328p::TWI,
@@ -79,9 +77,9 @@ pub mod spi {
     //! also instantiate a Settings object with the other options available.
 
     use crate::port::portb;
-    pub use avr_hal::spi::*;
+    pub use avr_hal_generic::spi::*;
 
-    avr_hal::impl_spi! {
+    avr_hal_generic::impl_spi! {
         pub struct Spi {
             peripheral: crate::atmega328p::SPI,
             pins: {
@@ -96,9 +94,9 @@ pub mod spi {
 /// Serial interface using USART
 pub mod usart {
     use crate::port::portd;
-    pub use avr_hal::serial::*;
+    pub use avr_hal_generic::serial::*;
 
-    crate::avr_hal::impl_usart! {
+    avr_hal_generic::impl_usart! {
         /// Serial interface based on ATmega328P's USART0 peripheral
         ///
         /// Maximum baudrate seems to be 57600

--- a/chips/atmega328p-hal/src/port.rs
+++ b/chips/atmega328p-hal/src/port.rs
@@ -4,7 +4,7 @@
 //!
 //! [1]: ../../avr_hal_generic/port/index.html
 
-pub use avr_hal::port::mode;
+pub use avr_hal_generic::port::mode;
 
 pub trait PortExt {
     type Parts;
@@ -12,7 +12,7 @@ pub trait PortExt {
     fn split(self) -> Self::Parts;
 }
 
-avr_hal::impl_generic_pin! {
+avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
         B(crate::atmega328p::PORTB, portb, pinb, ddrb),
         C(crate::atmega328p::PORTC, portc, pinc, ddrc),
@@ -20,7 +20,7 @@ avr_hal::impl_generic_pin! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portb {
         #[port_ext]
         use super::PortExt;
@@ -42,7 +42,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portc {
         #[port_ext]
         use super::PortExt;
@@ -63,7 +63,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portd {
         #[port_ext]
         use super::PortExt;

--- a/chips/atmega328p-hal/src/port.rs
+++ b/chips/atmega328p-hal/src/port.rs
@@ -14,9 +14,9 @@ pub trait PortExt {
 
 avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
-        B(crate::atmega328p::PORTB, portb, pinb, ddrb),
-        C(crate::atmega328p::PORTC, portc, pinc, ddrc),
-        D(crate::atmega328p::PORTD, portd, pind, ddrd),
+        B(crate::pac::PORTB, portb, pinb, ddrb),
+        C(crate::pac::PORTC, portc, pinc, ddrc),
+        D(crate::pac::PORTD, portd, pind, ddrd),
     }
 }
 
@@ -28,7 +28,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::B;
 
-        impl PortExt for crate::atmega328p::PORTB {
+        impl PortExt for crate::pac::PORTB {
             regs: (pinb, ddrb, portb),
             pb0: (PB0, 0),
             pb1: (PB1, 1),
@@ -50,7 +50,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::C;
 
-        impl PortExt for crate::atmega328p::PORTC {
+        impl PortExt for crate::pac::PORTC {
             regs: (pinc, ddrc, portc),
             pc0: (PC0, 0),
             pc1: (PC1, 1),
@@ -71,7 +71,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::D;
 
-        impl PortExt for crate::atmega328p::PORTD {
+        impl PortExt for crate::pac::PORTD {
             regs: (pind, ddrd, portd),
             pd0: (PD0, 0),
             pd1: (PD1, 1),

--- a/chips/atmega328p-hal/src/pwm.rs
+++ b/chips/atmega328p-hal/src/pwm.rs
@@ -26,9 +26,9 @@
 //! | `PD6` | `.into_pwm(&mut timer0)` |
 
 use crate::port::{portb, portd};
-pub use avr_hal::pwm::*;
+pub use avr_hal_generic::pwm::*;
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC0` for PWM (pins `PD5`, `PD6`)
     ///
     /// # Example
@@ -75,7 +75,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC1` for PWM (pins `PB1`, `PB2`)
     ///
     /// # Example
@@ -125,7 +125,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC2` for PWM (pins `PB3`, `PD3`)
     ///
     /// # Example

--- a/chips/atmega328p-hal/src/pwm.rs
+++ b/chips/atmega328p-hal/src/pwm.rs
@@ -43,7 +43,7 @@ avr_hal_generic::impl_pwm! {
     /// pd5.enable();
     /// ```
     pub struct Timer0Pwm {
-        timer: crate::atmega328p::TC0,
+        timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
             tim.tccr0b.modify(|_, w| match prescaler {
@@ -90,7 +90,7 @@ avr_hal_generic::impl_pwm! {
     /// pb1.enable();
     /// ```
     pub struct Timer1Pwm {
-        timer: crate::atmega328p::TC1,
+        timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
             tim.tccr1b.modify(|_, w| {
@@ -141,7 +141,7 @@ avr_hal_generic::impl_pwm! {
     /// pb3.enable();
     /// ```
     pub struct Timer2Pwm {
-        timer: crate::atmega328p::TC2,
+        timer: crate::pac::TC2,
         init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().pwm_fast());
             tim.tccr2b.modify(|_, w| match prescaler {

--- a/chips/atmega328p-hal/src/wdt.rs
+++ b/chips/atmega328p-hal/src/wdt.rs
@@ -27,7 +27,7 @@ avr_hal_generic::impl_wdt! {
     }
 
     pub struct Wdt {
-        mcu_status_register: crate::atmega328p::cpu::MCUSR,
-        peripheral: crate::atmega328p::WDT,
+        mcu_status_register: crate::pac::cpu::MCUSR,
+        peripheral: crate::pac::WDT,
     }
 }

--- a/chips/atmega328p-hal/src/wdt.rs
+++ b/chips/atmega328p-hal/src/wdt.rs
@@ -2,8 +2,7 @@
 
 pub use avr_hal_generic::wdt::*;
 
-avr_hal::impl_wdt! {
-
+avr_hal_generic::impl_wdt! {
     pub enum Timeout {
         /// 16 milliseconds
         Ms16 { wdpl().cycles_2k_512k() },

--- a/chips/atmega32u4-hal/src/adc.rs
+++ b/chips/atmega32u4-hal/src/adc.rs
@@ -31,7 +31,7 @@ pub enum AdcMux {
 avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = AdcMux;
-        peripheral: crate::atmega32u4::ADC,
+        peripheral: crate::pac::ADC,
         set_mux: |peripheral, id| {
             let id = id as u8;
             peripheral.admux.modify(|_, w| w.mux().bits(id & 0x1f));

--- a/chips/atmega32u4-hal/src/adc.rs
+++ b/chips/atmega32u4-hal/src/adc.rs
@@ -2,7 +2,7 @@ use crate::port::portb::{PB4, PB5, PB6};
 use crate::port::portd::{PD4, PD6, PD7};
 use crate::port::portf::{PF0, PF1, PF4, PF5, PF6, PF7};
 
-pub use crate::avr_hal::adc::*;
+pub use avr_hal_generic::adc::*;
 
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -28,7 +28,7 @@ pub enum AdcMux {
     AdcTemp = 0b100111,
 }
 
-avr_hal::impl_adc! {
+avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = AdcMux;
         peripheral: crate::atmega32u4::ADC,
@@ -58,7 +58,7 @@ avr_hal::impl_adc! {
 ///
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
-    use avr_hal::hal::adc::Channel;
+    use avr_hal_generic::hal::adc::Channel;
     use super::AdcMux;
 
     /// Channel for the _Bandgap Reference Voltage_

--- a/chips/atmega32u4-hal/src/lib.rs
+++ b/chips/atmega32u4-hal/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
-pub use avr_device::atmega32u4;
+/// Reexport of `atmega32u4` from `avr-device`
+pub use avr_device::atmega32u4 as pac;
 
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
@@ -27,7 +28,7 @@ pub mod i2c {
     avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATmega32U4's TWI peripheral
         pub struct I2c {
-            peripheral: crate::atmega32u4::TWI,
+            peripheral: crate::pac::TWI,
             pins: {
                 sda: portd::PD1,
                 scl: portd::PD0,
@@ -80,7 +81,7 @@ pub mod spi {
 
     avr_hal_generic::impl_spi! {
         pub struct Spi {
-            peripheral: crate::atmega32u4::SPI,
+            peripheral: crate::pac::SPI,
             pins: {
                 sclk: portb::PB1,
                 mosi: portb::PB2,
@@ -100,7 +101,7 @@ pub mod usart {
         ///
         /// Maximum baudrate seems to be 57600
         pub struct Usart1 {
-            peripheral: crate::atmega32u4::USART1,
+            peripheral: crate::pac::USART1,
             pins: {
                 rx: portd::PD2,
                 tx: portd::PD3,

--- a/chips/atmega32u4-hal/src/lib.rs
+++ b/chips/atmega32u4-hal/src/lib.rs
@@ -1,14 +1,13 @@
 #![no_std]
 
-extern crate avr_hal_generic as avr_hal;
-
 pub use avr_device::atmega32u4;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
-pub use avr_hal::clock;
-pub use avr_hal::delay;
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
 
 pub mod adc;
 pub mod port;
@@ -16,16 +15,16 @@ pub mod pwm;
 pub mod wdt;
 
 pub mod prelude {
-    pub use crate::avr_hal::prelude::*;
+    pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }
 
 /// I2C Bus
 pub mod i2c {
     use crate::port::portd;
-    pub use avr_hal::i2c::*;
+    pub use avr_hal_generic::i2c::*;
 
-    avr_hal::impl_twi_i2c! {
+    avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATmega32U4's TWI peripheral
         pub struct I2c {
             peripheral: crate::atmega32u4::TWI,
@@ -76,10 +75,10 @@ pub mod spi {
     //! In the example above, all of the settings are left at the default.  You can
     //! also instantiate a Settings object with the other options available.
 
-    pub use avr_hal::spi::*;
+    pub use avr_hal_generic::spi::*;
     use crate::port::portb;
 
-    avr_hal::impl_spi! {
+    avr_hal_generic::impl_spi! {
         pub struct Spi {
             peripheral: crate::atmega32u4::SPI,
             pins: {
@@ -94,9 +93,9 @@ pub mod spi {
 /// Serial interface using USART
 pub mod usart {
     use crate::port::portd;
-    pub use avr_hal::serial::*;
+    pub use avr_hal_generic::serial::*;
 
-    crate::avr_hal::impl_usart! {
+    avr_hal_generic::impl_usart! {
         /// Serial interface based on ATmega32U4's USART1 peripheral
         ///
         /// Maximum baudrate seems to be 57600

--- a/chips/atmega32u4-hal/src/port.rs
+++ b/chips/atmega32u4-hal/src/port.rs
@@ -14,11 +14,11 @@ pub trait PortExt {
 
 avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
-        B(crate::atmega32u4::PORTB, portb, pinb, ddrb),
-        C(crate::atmega32u4::PORTC, portc, pinc, ddrc),
-        D(crate::atmega32u4::PORTD, portd, pind, ddrd),
-        E(crate::atmega32u4::PORTE, porte, pine, ddre),
-        F(crate::atmega32u4::PORTF, portf, pinf, ddrf),
+        B(crate::pac::PORTB, portb, pinb, ddrb),
+        C(crate::pac::PORTC, portc, pinc, ddrc),
+        D(crate::pac::PORTD, portd, pind, ddrd),
+        E(crate::pac::PORTE, porte, pine, ddre),
+        F(crate::pac::PORTF, portf, pinf, ddrf),
     }
 }
 
@@ -30,7 +30,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::B;
 
-        impl PortExt for crate::atmega32u4::PORTB {
+        impl PortExt for crate::pac::PORTB {
             regs: (pinb, ddrb, portb),
             pb0: (PB0, 0),
             pb1: (PB1, 1),
@@ -52,7 +52,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::C;
 
-        impl PortExt for crate::atmega32u4::PORTC {
+        impl PortExt for crate::pac::PORTC {
             regs: (pinc, ddrc, portc),
             pc6: (PC6, 6),
             pc7: (PC7, 7),
@@ -68,7 +68,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::D;
 
-        impl PortExt for crate::atmega32u4::PORTD {
+        impl PortExt for crate::pac::PORTD {
             regs: (pind, ddrd, portd),
             pd0: (PD0, 0),
             pd1: (PD1, 1),
@@ -90,7 +90,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::E;
 
-        impl PortExt for crate::atmega32u4::PORTE {
+        impl PortExt for crate::pac::PORTE {
             regs: (pine, ddre, porte),
             pe2: (PE2, 2),
             pe6: (PE6, 6),
@@ -106,7 +106,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::F;
 
-        impl PortExt for crate::atmega32u4::PORTF {
+        impl PortExt for crate::pac::PORTF {
             regs: (pinf, ddrf, portf),
             pf0: (PF0, 0),
             pf1: (PF1, 1),

--- a/chips/atmega32u4-hal/src/port.rs
+++ b/chips/atmega32u4-hal/src/port.rs
@@ -4,7 +4,7 @@
 //!
 //! [1]: ../../avr_hal_generic/port/index.html
 
-pub use avr_hal::port::mode;
+pub use avr_hal_generic::port::mode;
 
 pub trait PortExt {
     type Parts;
@@ -12,7 +12,7 @@ pub trait PortExt {
     fn split(self) -> Self::Parts;
 }
 
-avr_hal::impl_generic_pin! {
+avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
         B(crate::atmega32u4::PORTB, portb, pinb, ddrb),
         C(crate::atmega32u4::PORTC, portc, pinc, ddrc),
@@ -22,7 +22,7 @@ avr_hal::impl_generic_pin! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portb {
         #[port_ext]
         use super::PortExt;
@@ -44,7 +44,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portc {
         #[port_ext]
         use super::PortExt;
@@ -60,7 +60,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portd {
         #[port_ext]
         use super::PortExt;
@@ -82,7 +82,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod porte {
         #[port_ext]
         use super::PortExt;
@@ -98,7 +98,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portf {
         #[port_ext]
         use super::PortExt;

--- a/chips/atmega32u4-hal/src/pwm.rs
+++ b/chips/atmega32u4-hal/src/pwm.rs
@@ -27,9 +27,9 @@
 //! | `PD7` | `.into_pwm(&mut timer4)` | |
 
 use crate::port::{portb, portc, portd};
-pub use avr_hal::pwm::*;
+pub use avr_hal_generic::pwm::*;
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC0` for PWM (pins `PB7`, `PD0`)
     ///
     /// # Example
@@ -77,7 +77,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC1` for PWM (pins `PB5`, `PB6`, `PB7`)
     ///
     /// # Example
@@ -138,7 +138,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC3` for PWM (pin `PC6`)
     ///
     /// # Example
@@ -179,7 +179,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC4` for PWM (pins `PB6`, `PC7`, `PD7`)
     ///
     /// # Example

--- a/chips/atmega32u4-hal/src/pwm.rs
+++ b/chips/atmega32u4-hal/src/pwm.rs
@@ -45,7 +45,7 @@ avr_hal_generic::impl_pwm! {
     /// pb7.enable();
     /// ```
     pub struct Timer0Pwm {
-        timer: crate::atmega32u4::TC0,
+        timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
             tim.tccr0b.modify(|_, w| match prescaler {
@@ -95,7 +95,7 @@ avr_hal_generic::impl_pwm! {
     ///
     /// **Note**: For `PB7` the method is called `into_pwm1()`!
     pub struct Timer1Pwm {
-        timer: crate::atmega32u4::TC1,
+        timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
             tim.tccr1b.modify(|_, w| {
@@ -152,7 +152,7 @@ avr_hal_generic::impl_pwm! {
     /// pc6.enable();
     /// ```
     pub struct Timer3Pwm {
-        timer: crate::atmega32u4::TC3,
+        timer: crate::pac::TC3,
         init: |tim, prescaler| {
             tim.tccr3a.modify(|_, w| w.wgm3().bits(0b01));
             tim.tccr3b.modify(|_, w| {
@@ -199,7 +199,7 @@ avr_hal_generic::impl_pwm! {
     ///
     /// **Note**: For `PB6` the method is called `into_pwm6()`!
     pub struct Timer4Pwm {
-        timer: crate::atmega32u4::TC4,
+        timer: crate::pac::TC4,
         init: |tim, prescaler| {
             tim.tccr4b.modify(|_, w| match prescaler {
                     Prescaler::Direct => w.cs4().direct(),

--- a/chips/atmega32u4-hal/src/wdt.rs
+++ b/chips/atmega32u4-hal/src/wdt.rs
@@ -27,7 +27,7 @@ avr_hal_generic::impl_wdt! {
     }
 
     pub struct Wdt {
-        mcu_status_register: crate::atmega32u4::cpu::MCUSR,
-        peripheral: crate::atmega32u4::WDT,
+        mcu_status_register: crate::pac::cpu::MCUSR,
+        peripheral: crate::pac::WDT,
     }
 }

--- a/chips/atmega32u4-hal/src/wdt.rs
+++ b/chips/atmega32u4-hal/src/wdt.rs
@@ -2,7 +2,7 @@
 
 pub use avr_hal_generic::wdt::*;
 
-avr_hal::impl_wdt! {
+avr_hal_generic::impl_wdt! {
     pub enum Timeout {
         /// 16 milliseconds
         Ms16 { wdpl().cycles_2k_512k() },

--- a/chips/atmega48p-hal/src/adc.rs
+++ b/chips/atmega48p-hal/src/adc.rs
@@ -2,12 +2,12 @@ extern crate avr_hal_generic as avr_hal;
 
 use crate::port::portc::{PC0, PC1, PC2, PC3, PC4, PC5};
 
-use crate::atmega48p::adc::admux::MUX_A;
+use crate::pac::adc::admux::MUX_A;
 
 avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
-        peripheral: crate::atmega48p::ADC,
+        peripheral: crate::pac::ADC,
         set_mux: |peripheral, id| {
             peripheral.admux.modify(|_, w| w.mux().variant(id));
         },
@@ -26,7 +26,7 @@ avr_hal_generic::impl_adc! {
 ///
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
-    use crate::atmega48p::adc::admux::MUX_A;
+    use crate::pac::adc::admux::MUX_A;
     use avr_hal_generic::hal::adc::Channel;
 
     /// Channel for the _Bandgap Reference Voltage_

--- a/chips/atmega48p-hal/src/adc.rs
+++ b/chips/atmega48p-hal/src/adc.rs
@@ -4,7 +4,7 @@ use crate::port::portc::{PC0, PC1, PC2, PC3, PC4, PC5};
 
 use crate::atmega48p::adc::admux::MUX_A;
 
-avr_hal::impl_adc! {
+avr_hal_generic::impl_adc! {
     pub struct Adc {
         type ChannelID = MUX_A;
         peripheral: crate::atmega48p::ADC,
@@ -27,7 +27,7 @@ avr_hal::impl_adc! {
 /// This module contains ADC channels, additional to the direct pin channels.
 pub mod channel {
     use crate::atmega48p::adc::admux::MUX_A;
-    use avr_hal::hal::adc::Channel;
+    use avr_hal_generic::hal::adc::Channel;
 
     /// Channel for the _Bandgap Reference Voltage_
     pub struct Vbg;

--- a/chips/atmega48p-hal/src/lib.rs
+++ b/chips/atmega48p-hal/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-pub use avr_device::atmega48p;
+/// Reexport of `atmega48p` from `avr-device`
+pub use avr_device::atmega48p as pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
@@ -28,7 +30,7 @@ pub mod i2c {
     avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATmega328P's TWI peripheral
         pub struct I2c {
-            peripheral: crate::atmega48p::TWI,
+            peripheral: crate::pac::TWI,
             pins: {
                 sda: portc::PC4,
                 scl: portc::PC5,
@@ -62,7 +64,7 @@ pub mod usart {
         ///
         /// Maximum baudrate seems to be 57600
         pub struct Usart0 {
-            peripheral: crate::atmega48p::USART0,
+            peripheral: crate::pac::USART0,
             pins: {
                 rx: portd::PD0,
                 tx: portd::PD1,

--- a/chips/atmega48p-hal/src/lib.rs
+++ b/chips/atmega48p-hal/src/lib.rs
@@ -1,14 +1,12 @@
 #![no_std]
 
-extern crate avr_hal_generic as avr_hal;
-
 pub use avr_device::atmega48p;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
-pub use avr_hal::clock;
-pub use avr_hal::delay;
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
 
 pub mod port;
 
@@ -18,16 +16,16 @@ pub mod pwm;
 pub mod spi;
 
 pub mod prelude {
-    pub use crate::avr_hal::prelude::*;
+    pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }
 
 /// I2C Bus
 pub mod i2c {
     use crate::port::portc;
-    pub use avr_hal::i2c::*;
+    pub use avr_hal_generic::i2c::*;
 
-    avr_hal::impl_twi_i2c! {
+    avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATmega328P's TWI peripheral
         pub struct I2c {
             peripheral: crate::atmega48p::TWI,
@@ -57,9 +55,9 @@ pub mod i2c {
 /// Serial interface using USART
 pub mod usart {
     use crate::port::portd;
-    pub use avr_hal::serial::*;
+    pub use avr_hal_generic::serial::*;
 
-    crate::avr_hal::impl_usart! {
+    avr_hal_generic::impl_usart! {
         /// Serial interface based on ATmega48P's USART0 peripheral
         ///
         /// Maximum baudrate seems to be 57600

--- a/chips/atmega48p-hal/src/port.rs
+++ b/chips/atmega48p-hal/src/port.rs
@@ -14,9 +14,9 @@ pub trait PortExt {
 
 avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
-        B(crate::atmega48p::PORTB, portb, pinb, ddrb),
-        C(crate::atmega48p::PORTC, portc, pinc, ddrc),
-        D(crate::atmega48p::PORTD, portd, pind, ddrd),
+        B(crate::pac::PORTB, portb, pinb, ddrb),
+        C(crate::pac::PORTC, portc, pinc, ddrc),
+        D(crate::pac::PORTD, portd, pind, ddrd),
     }
 }
 
@@ -28,7 +28,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::B;
 
-        impl PortExt for crate::atmega48p::PORTB {
+        impl PortExt for crate::pac::PORTB {
             regs: (pinb, ddrb, portb),
             pb0: (PB0, 0),
             pb1: (PB1, 1),
@@ -50,7 +50,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::C;
 
-        impl PortExt for crate::atmega48p::PORTC {
+        impl PortExt for crate::pac::PORTC {
             regs: (pinc, ddrc, portc),
             pc0: (PC0, 0),
             pc1: (PC1, 1),
@@ -71,7 +71,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::D;
 
-        impl PortExt for crate::atmega48p::PORTD {
+        impl PortExt for crate::pac::PORTD {
             regs: (pind, ddrd, portd),
             pd0: (PD0, 0),
             pd1: (PD1, 1),

--- a/chips/atmega48p-hal/src/port.rs
+++ b/chips/atmega48p-hal/src/port.rs
@@ -4,7 +4,7 @@
 //!
 //! [1]: ../../avr_hal_generic/port/index.html
 
-pub use avr_hal::port::mode;
+pub use avr_hal_generic::port::mode;
 
 pub trait PortExt {
     type Parts;
@@ -12,7 +12,7 @@ pub trait PortExt {
     fn split(self) -> Self::Parts;
 }
 
-avr_hal::impl_generic_pin! {
+avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
         B(crate::atmega48p::PORTB, portb, pinb, ddrb),
         C(crate::atmega48p::PORTC, portc, pinc, ddrc),
@@ -20,7 +20,7 @@ avr_hal::impl_generic_pin! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portb {
         #[port_ext]
         use super::PortExt;
@@ -42,7 +42,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portc {
         #[port_ext]
         use super::PortExt;
@@ -63,7 +63,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portd {
         #[port_ext]
         use super::PortExt;

--- a/chips/atmega48p-hal/src/pwm.rs
+++ b/chips/atmega48p-hal/src/pwm.rs
@@ -26,9 +26,9 @@
 //! | `PD6` | `.into_pwm(&mut timer0)` |
 
 use crate::port::{portb, portd};
-pub use avr_hal::pwm::*;
+pub use avr_hal_generic::pwm::*;
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC0` for PWM (pins `PD5`, `PD6`)
     ///
     /// # Example
@@ -75,7 +75,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC1` for PWM (pins `PB1`, `PB2`)
     ///
     /// # Example
@@ -125,7 +125,7 @@ avr_hal::impl_pwm! {
     }
 }
 
-avr_hal::impl_pwm! {
+avr_hal_generic::impl_pwm! {
     /// Use `TC2` for PWM (pins `PB3`, `PD3`)
     ///
     /// # Example

--- a/chips/atmega48p-hal/src/pwm.rs
+++ b/chips/atmega48p-hal/src/pwm.rs
@@ -43,7 +43,7 @@ avr_hal_generic::impl_pwm! {
     /// pd5.enable();
     /// ```
     pub struct Timer0Pwm {
-        timer: crate::atmega48p::TC0,
+        timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
             tim.tccr0b.modify(|_, w| match prescaler {
@@ -90,7 +90,7 @@ avr_hal_generic::impl_pwm! {
     /// pb1.enable();
     /// ```
     pub struct Timer1Pwm {
-        timer: crate::atmega48p::TC1,
+        timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
             tim.tccr1b.modify(|_, w| {
@@ -141,7 +141,7 @@ avr_hal_generic::impl_pwm! {
     /// pb3.enable();
     /// ```
     pub struct Timer2Pwm {
-        timer: crate::atmega48p::TC2,
+        timer: crate::pac::TC2,
         init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().pwm_fast());
             tim.tccr2b.modify(|_, w| match prescaler {

--- a/chips/atmega48p-hal/src/spi.rs
+++ b/chips/atmega48p-hal/src/spi.rs
@@ -27,7 +27,7 @@ pub use avr_hal_generic::spi::*;
 
 avr_hal_generic::impl_spi! {
     pub struct Spi {
-        peripheral: crate::atmega48p::SPI,
+        peripheral: crate::pac::SPI,
         pins: {
             sclk: portb::PB5,
             mosi: portb::PB3,

--- a/chips/atmega48p-hal/src/spi.rs
+++ b/chips/atmega48p-hal/src/spi.rs
@@ -23,9 +23,9 @@
 //! also instantiate a Settings object with the other options available.
 
 use crate::port::portb;
-pub use avr_hal::spi::*;
+pub use avr_hal_generic::spi::*;
 
-avr_hal::impl_spi! {
+avr_hal_generic::impl_spi! {
     pub struct Spi {
         peripheral: crate::atmega48p::SPI,
         pins: {

--- a/chips/attiny85-hal/src/lib.rs
+++ b/chips/attiny85-hal/src/lib.rs
@@ -1,18 +1,16 @@
 #![no_std]
 
-extern crate avr_hal_generic as avr_hal;
-
 pub use avr_device::attiny85;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
-pub use avr_hal::clock;
-pub use avr_hal::delay;
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
 
 pub mod port;
 
 pub mod prelude {
-    pub use crate::avr_hal::prelude::*;
+    pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }

--- a/chips/attiny85-hal/src/lib.rs
+++ b/chips/attiny85-hal/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-pub use avr_device::attiny85;
+/// Reexport of `attiny85` from `avr-device`
+pub use avr_device::attiny85 as pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;

--- a/chips/attiny85-hal/src/port.rs
+++ b/chips/attiny85-hal/src/port.rs
@@ -17,7 +17,7 @@ avr_hal_generic::impl_port! {
         #[port_ext]
         use super::PortExt;
 
-        impl PortExt for crate::attiny85::PORTB {
+        impl PortExt for crate::pac::PORTB {
             regs: (pinb, ddrb, portb),
             pb0: (PB0, 0),
             pb1: (PB1, 1),

--- a/chips/attiny85-hal/src/port.rs
+++ b/chips/attiny85-hal/src/port.rs
@@ -4,7 +4,7 @@
 //!
 //! [1]: ../../avr_hal_generic/port/index.html
 
-pub use avr_hal::port::mode;
+pub use avr_hal_generic::port::mode;
 
 pub trait PortExt {
     type Parts;
@@ -12,7 +12,7 @@ pub trait PortExt {
     fn split(self) -> Self::Parts;
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portb {
         #[port_ext]
         use super::PortExt;

--- a/chips/attiny88-hal/src/lib.rs
+++ b/chips/attiny88-hal/src/lib.rs
@@ -1,30 +1,28 @@
 #![no_std]
 
-extern crate avr_hal_generic as avr_hal;
-
 pub use avr_device::attiny88;
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
-pub use avr_hal::clock;
-pub use avr_hal::delay;
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
 
 pub mod port;
 
 pub mod spi;
 
 pub mod prelude {
-    pub use crate::avr_hal::prelude::*;
+    pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }
 
 /// I2C Bus
 pub mod i2c {
     use crate::port::portc;
-    pub use avr_hal::i2c::*;
+    pub use avr_hal_generic::i2c::*;
 
-    avr_hal::impl_twi_i2c! {
+    avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATtiny88's TWI peripheral
         pub struct I2c {
             peripheral: crate::attiny88::TWI,

--- a/chips/attiny88-hal/src/lib.rs
+++ b/chips/attiny88-hal/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-pub use avr_device::attiny88;
+/// Reexport of `attiny88` from `avr-device`
+pub use avr_device::attiny88 as pac;
+
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
@@ -25,7 +27,7 @@ pub mod i2c {
     avr_hal_generic::impl_twi_i2c! {
         /// I2C based on ATtiny88's TWI peripheral
         pub struct I2c {
-            peripheral: crate::attiny88::TWI,
+            peripheral: crate::pac::TWI,
             pins: {
                 sda: portc::PC4,
                 scl: portc::PC5,

--- a/chips/attiny88-hal/src/port.rs
+++ b/chips/attiny88-hal/src/port.rs
@@ -4,7 +4,7 @@
 //!
 //! [1]: ../../avr_hal_generic/port/index.html
 
-pub use avr_hal::port::mode;
+pub use avr_hal_generic::port::mode;
 
 pub trait PortExt {
     type Parts;
@@ -12,7 +12,7 @@ pub trait PortExt {
     fn split(self) -> Self::Parts;
 }
 
-avr_hal::impl_generic_pin! {
+avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
         A(crate::attiny88::PORTA, porta, pina, ddra),
         B(crate::attiny88::PORTB, portb, pinb, ddrb),
@@ -21,7 +21,7 @@ avr_hal::impl_generic_pin! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod porta {
         #[port_ext]
         use super::PortExt;
@@ -39,7 +39,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portb {
         #[port_ext]
         use super::PortExt;
@@ -61,7 +61,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portc {
         #[port_ext]
         use super::PortExt;
@@ -83,7 +83,7 @@ avr_hal::impl_port! {
     }
 }
 
-avr_hal::impl_port! {
+avr_hal_generic::impl_port! {
     pub mod portd {
         #[port_ext]
         use super::PortExt;

--- a/chips/attiny88-hal/src/port.rs
+++ b/chips/attiny88-hal/src/port.rs
@@ -14,10 +14,10 @@ pub trait PortExt {
 
 avr_hal_generic::impl_generic_pin! {
     pub enum Pin {
-        A(crate::attiny88::PORTA, porta, pina, ddra),
-        B(crate::attiny88::PORTB, portb, pinb, ddrb),
-        C(crate::attiny88::PORTC, portc, pinc, ddrc),
-        D(crate::attiny88::PORTD, portd, pind, ddrd),
+        A(crate::pac::PORTA, porta, pina, ddra),
+        B(crate::pac::PORTB, portb, pinb, ddrb),
+        C(crate::pac::PORTC, portc, pinc, ddrc),
+        D(crate::pac::PORTD, portd, pind, ddrd),
     }
 }
 
@@ -29,7 +29,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::A;
 
-        impl PortExt for crate::attiny88::PORTA {
+        impl PortExt for crate::pac::PORTA {
             regs: (pina, ddra, porta),
             pa0: (PA0, 0),
             pa1: (PA1, 1),
@@ -47,7 +47,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::B;
 
-        impl PortExt for crate::attiny88::PORTB {
+        impl PortExt for crate::pac::PORTB {
             regs: (pinb, ddrb, portb),
             pb0: (PB0, 0),
             pb1: (PB1, 1),
@@ -69,7 +69,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::C;
 
-        impl PortExt for crate::attiny88::PORTC {
+        impl PortExt for crate::pac::PORTC {
             regs: (pinc, ddrc, portc),
             pc0: (PC0, 0),
             pc1: (PC1, 1),
@@ -91,7 +91,7 @@ avr_hal_generic::impl_port! {
         #[generic_pin]
         use Pin::D;
 
-        impl PortExt for crate::attiny88::PORTD {
+        impl PortExt for crate::pac::PORTD {
             regs: (pind, ddrd, portd),
             pd0: (PD0, 0),
             pd1: (PD1, 1),

--- a/chips/attiny88-hal/src/spi.rs
+++ b/chips/attiny88-hal/src/spi.rs
@@ -23,9 +23,9 @@
 //! also instantiate a Settings object with the other options available.
 
 use crate::port::portb;
-pub use avr_hal::spi::*;
+pub use avr_hal_generic::spi::*;
 
-avr_hal::impl_spi! {
+avr_hal_generic::impl_spi! {
     pub struct Spi {
         peripheral: crate::attiny88::SPI,
         pins: {

--- a/chips/attiny88-hal/src/spi.rs
+++ b/chips/attiny88-hal/src/spi.rs
@@ -27,7 +27,7 @@ pub use avr_hal_generic::spi::*;
 
 avr_hal_generic::impl_spi! {
     pub struct Spi {
-        peripheral: crate::attiny88::SPI,
+        peripheral: crate::pac::SPI,
         pins: {
             sclk: portb::PB5,
             mosi: portb::PB3,


### PR DESCRIPTION
I'm working on cleaning up the import and module structure to make the hal crates look more similar.  This is hopefully a first step towards making them more maintainable.  In the future we should explore combining some of them to reduce the hellish amount of code duplication.

**Note**: This might break some downstream code as public items are being moved around/renamed.