### PR TITLE
Reexport avr-hal-generic

### DIFF
--- a/chips/atmega328p-hal/src/lib.rs
+++ b/chips/atmega328p-hal/src/lib.rs
@@ -25,6 +25,7 @@ pub use avr_device::entry;
 
 pub use avr_hal_generic::clock;
 pub use avr_hal_generic::delay;
+pub use avr_hal_generic;
 
 #[cfg(feature = "device-selected")]
 pub mod port;


### PR DESCRIPTION
Reexport avr_hal_generic so that its functionality can be used by hals outside of this crate.

I'm creating a custom HAL for a custom board at https://github.com/jkristell/rustyremote and want to be able to do so outside of this crate. One showstopper is the need for avr-hal-generic as it's not possible to use it as a git dependency. I guess the plan is to release it to crates.io as well. But in the mean time this seems to work.