### PR TITLE
Add attiny841 and attiny861

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
     "chips/atmega48p-hal",
     "chips/attiny85-hal",
     "chips/attiny88-hal",
+    "chips/attiny841-hal",
+    "chips/attiny861-hal",
 
     # The board crates
     "boards/arduino-diecimila",

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -9,7 +9,8 @@ cfg-if = "0.1.7"
 nb = "0.1.2"
 ufmt = "0.1.0"
 paste = "1.0.0"
-avr-device = "0.2.2"
+#avr-device = "0.2.2"
+avr-device = { path = "../../avr-device/" }
 
 [dependencies.embedded-hal]
 version = "0.2.3"

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -10,7 +10,7 @@ nb = "0.1.2"
 ufmt = "0.1.0"
 paste = "1.0.0"
 #avr-device = "0.2.2"
-avr-device = { path = "../../avr-device/" }
+avr-device = { git = "https://github.com/Rahix/avr-device" }
 
 [dependencies.embedded-hal]
 version = "0.2.3"

--- a/avr-specs/avr-attiny841.json
+++ b/avr-specs/avr-attiny841.json
@@ -1,7 +1,7 @@
 {
   "arch": "avr",
   "atomic-cas": false,
-  "cpu": "avr25",
+  "cpu": "attiny841",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
   "eh-frame-header": false,
   "env": "",

--- a/avr-specs/avr-attiny841.json
+++ b/avr-specs/avr-attiny841.json
@@ -1,0 +1,32 @@
+{
+  "arch": "avr",
+  "atomic-cas": false,
+  "cpu": "avr25",
+  "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "eh-frame-header": false,
+  "env": "",
+  "exe-suffix": ".elf",
+  "executables": true,
+  "late-link-args": {
+    "gcc": [
+      "-lgcc"
+    ]
+  },
+  "linker": "avr-gcc",
+  "linker-flavor": "gcc",
+  "linker-is-gnu": true,
+  "llvm-target": "avr-unknown-unknown",
+  "max-atomic-width": 8,
+  "no-default-libraries": false,
+  "os": "unknown",
+  "pre-link-args": {
+    "gcc": [
+      "-mmcu=attiny841",
+      "-Wl,--as-needed"
+    ]
+  },
+  "target-c-int-width": "16",
+  "target-endian": "little",
+  "target-pointer-width": "16",
+  "vendor": "unknown"
+}

--- a/avr-specs/avr-attiny861.json
+++ b/avr-specs/avr-attiny861.json
@@ -1,7 +1,7 @@
 {
   "arch": "avr",
   "atomic-cas": false,
-  "cpu": "avr25",
+  "cpu": "attiny861",
   "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
   "eh-frame-header": false,
   "env": "",

--- a/avr-specs/avr-attiny861.json
+++ b/avr-specs/avr-attiny861.json
@@ -1,0 +1,32 @@
+{
+  "arch": "avr",
+  "atomic-cas": false,
+  "cpu": "avr25",
+  "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "eh-frame-header": false,
+  "env": "",
+  "exe-suffix": ".elf",
+  "executables": true,
+  "late-link-args": {
+    "gcc": [
+      "-lgcc"
+    ]
+  },
+  "linker": "avr-gcc",
+  "linker-flavor": "gcc",
+  "linker-is-gnu": true,
+  "llvm-target": "avr-unknown-unknown",
+  "max-atomic-width": 8,
+  "no-default-libraries": false,
+  "os": "unknown",
+  "pre-link-args": {
+    "gcc": [
+      "-mmcu=attiny861",
+      "-Wl,--as-needed"
+    ]
+  },
+  "target-c-int-width": "16",
+  "target-endian": "little",
+  "target-pointer-width": "16",
+  "vendor": "unknown"
+}

--- a/avr-specs/sync-from-upstream.py
+++ b/avr-specs/sync-from-upstream.py
@@ -28,6 +28,12 @@ SPECS = {
     "attiny88": {
         "cpu": "attiny88",
     },
+    "attiny841": {
+        "cpu": "attiny841",
+    },
+    "attiny861": {
+        "cpu": "attiny861",
+    },
 }
 
 COMMON = {

--- a/chips/attiny841-hal/.cargo/config.toml
+++ b/chips/attiny841-hal/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "../../avr-specs/avr-attiny85.json"
+
+[unstable]
+build-std = ["core"]

--- a/chips/attiny841-hal/.cargo/config.toml
+++ b/chips/attiny841-hal/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-target = "../../avr-specs/avr-attiny85.json"
+target = "../../avr-specs/avr-attiny841.json"
 
 [unstable]
 build-std = ["core"]

--- a/chips/attiny841-hal/Cargo.toml
+++ b/chips/attiny841-hal/Cargo.toml
@@ -11,5 +11,5 @@ rt = ["avr-device/rt"]
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-version = "0.2.3"
+version = "0.2.2"
 features = ["attiny841"]

--- a/chips/attiny841-hal/Cargo.toml
+++ b/chips/attiny841-hal/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "attiny841-hal"
+version = "0.1.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
+
+[features]
+rt = ["avr-device/rt"]
+
+[dependencies]
+avr-hal-generic = { path = "../../avr-hal-generic/" }
+
+[dependencies.avr-device]
+version = "0.2.3"
+features = ["attiny841"]

--- a/chips/attiny841-hal/Cargo.toml
+++ b/chips/attiny841-hal/Cargo.toml
@@ -11,5 +11,6 @@ rt = ["avr-device/rt"]
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-version = "0.2.2"
+#version = "0.2.2"
+git = "https://github.com/Rahix/avr-device"
 features = ["attiny841"]

--- a/chips/attiny841-hal/src/lib.rs
+++ b/chips/attiny841-hal/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+
+/// Reexport of `attiny841` from `avr-device`
+pub use avr_device::attiny841 as pac;
+
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
+
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
+
+pub mod port;
+
+pub mod prelude {
+    pub use avr_hal_generic::prelude::*;
+    pub use crate::port::PortExt as _;
+}

--- a/chips/attiny841-hal/src/port.rs
+++ b/chips/attiny841-hal/src/port.rs
@@ -1,0 +1,48 @@
+//! Digital IO Implementations
+//!
+//! For a detailed explanation, refer to the [general Digital IO documentation][1].
+//!
+//! [1]: ../../avr_hal_generic/port/index.html
+
+pub use avr_hal_generic::port::mode;
+
+pub trait PortExt {
+    type Parts;
+
+    fn split(self) -> Self::Parts;
+}
+
+avr_hal_generic::impl_port! {
+    pub mod porta {
+        #[port_ext]
+        use super::PortExt;
+
+        impl PortExt for crate::pac::PORTA {
+            regs: (pina, ddra, porta),
+            pa0: (PA0, 0),
+            pa1: (PA1, 1),
+            pa2: (PA2, 2),
+            pa3: (PA3, 3),
+            pa4: (PA4, 4),
+            pa5: (PA5, 5),
+            pa6: (PA6, 6),
+            pa7: (PA7, 7),
+        }
+    }
+}
+
+avr_hal_generic::impl_port! {
+    pub mod portb {
+        #[port_ext]
+        use super::PortExt;
+
+        impl PortExt for crate::pac::PORTB {
+            regs: (pinb, ddrb, portb),
+            pb0: (PB0, 0),
+            pb1: (PB1, 1),
+            pb2: (PB2, 2),
+            pb3: (PB3, 3),
+            pb4: (PB4, 4),
+        }
+    }
+}

--- a/chips/attiny861-hal/.cargo/config.toml
+++ b/chips/attiny861-hal/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-target = "../../avr-specs/avr-attiny85.json"
+target = "../../avr-specs/avr-attiny861.json"
 
 [unstable]
 build-std = ["core"]

--- a/chips/attiny861-hal/.cargo/config.toml
+++ b/chips/attiny861-hal/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "../../avr-specs/avr-attiny85.json"
+
+[unstable]
+build-std = ["core"]

--- a/chips/attiny861-hal/Cargo.toml
+++ b/chips/attiny861-hal/Cargo.toml
@@ -11,5 +11,6 @@ rt = ["avr-device/rt"]
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-version = "0.2.3"
+#version = "0.2.3"
+path = "../../../avr-device/"
 features = ["attiny861"]

--- a/chips/attiny861-hal/Cargo.toml
+++ b/chips/attiny861-hal/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "attiny861-hal"
+version = "0.1.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
+
+[features]
+rt = ["avr-device/rt"]
+
+[dependencies]
+avr-hal-generic = { path = "../../avr-hal-generic/" }
+
+[dependencies.avr-device]
+version = "0.2.3"
+features = ["attiny861"]

--- a/chips/attiny861-hal/src/lib.rs
+++ b/chips/attiny861-hal/src/lib.rs
@@ -16,3 +16,13 @@ pub mod prelude {
     pub use avr_hal_generic::prelude::*;
     pub use crate::port::PortExt as _;
 }
+
+pub mod i2c {
+	use crate::port::{portc, mode};
+	struct I2c {
+		peripheral: crate::pac::USI,
+		sda: portb::PA0<mode::Input<mode::Floating>>,
+		scl: portb::PA2<mode::Input<mode::Floating>>,
+		speed: u32,
+	}
+}

--- a/chips/attiny861-hal/src/lib.rs
+++ b/chips/attiny861-hal/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+
+/// Reexport of `attiny861` from `avr-device`
+pub use avr_device::attiny861 as pac;
+
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
+
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
+
+pub mod port;
+
+pub mod prelude {
+    pub use avr_hal_generic::prelude::*;
+    pub use crate::port::PortExt as _;
+}

--- a/chips/attiny861-hal/src/port.rs
+++ b/chips/attiny861-hal/src/port.rs
@@ -1,0 +1,51 @@
+//! Digital IO Implementations
+//!
+//! For a detailed explanation, refer to the [general Digital IO documentation][1].
+//!
+//! [1]: ../../avr_hal_generic/port/index.html
+
+pub use avr_hal_generic::port::mode;
+
+pub trait PortExt {
+    type Parts;
+
+    fn split(self) -> Self::Parts;
+}
+
+avr_hal_generic::impl_port! {
+    pub mod porta {
+        #[port_ext]
+        use super::PortExt;
+
+        impl PortExt for crate::pac::PORTA {
+            regs: (pina, ddra, porta),
+            pa0: (PA0, 0),
+            pa1: (PA1, 1),
+            pa2: (PA2, 2),
+            pa3: (PA3, 3),
+            pa4: (PA4, 4),
+            pa5: (PA5, 5),
+            pa6: (PA6, 6),
+            pa7: (PA7, 7),
+        }
+    }
+}
+
+avr_hal_generic::impl_port! {
+    pub mod portb {
+        #[port_ext]
+        use super::PortExt;
+
+        impl PortExt for crate::pac::PORTB {
+            regs: (pinb, ddrb, portb),
+            pb0: (PB0, 0),
+            pb1: (PB1, 1),
+            pb2: (PB2, 2),
+            pb3: (PB3, 3),
+            pb4: (PB4, 4),
+            pb5: (PB5, 5),
+            pb6: (PB6, 6),
+            pb7: (PB7, 7),
+        }
+    }
+}


### PR DESCRIPTION
Preliminary pull request adding attiny841 and attiny861 chips. I tested a blink example on both, and it works in both cases, but I haven't tested much else.

It might also be worth mentioning in the README or something that the attiny841 is not supported by the current version of avrdude, so you need to add a section to the .avrduderc