### PR TITLE
Fix board runners to correctly detect dependencies

### DIFF
--- a/boards/arduino-leonardo/leonardo-runner.sh
+++ b/boards/arduino-leonardo/leonardo-runner.sh
@@ -7,14 +7,14 @@ case "$(uname -s)" in
     *)          OS="Unknown";;
 esac
 
-if ! command -v numfmt &> /dev/null
+if ! command -v numfmt > /dev/null 2>&1
 then
     echo "numfmt is needed for human-readable sizes." >&2
     echo "please install https://command-not-found.com/numfmt" >&2
     alias numfmt=true
 fi
 
-if ! command -v avrdude &> /dev/null
+if ! command -v avrdude > /dev/null 2>&1
 then
     echo "required avrdude could not be found!" >&2
     echo "please install https://command-not-found.com/avrdude" >&2

--- a/boards/arduino-uno/uno-runner.sh
+++ b/boards/arduino-uno/uno-runner.sh
@@ -7,14 +7,14 @@ case "$(uname -s)" in
     *)          OS="Unknown";;
 esac
 
-if ! command -v numfmt &> /dev/null
+if ! command -v numfmt > /dev/null 2>&1
 then
     echo "numfmt is needed for human-readable sizes." >&2
     echo "please install https://command-not-found.com/numfmt" >&2
     alias numfmt=true
 fi
 
-if ! command -v avrdude &> /dev/null
+if ! command -v avrdude > /dev/null 2>&1
 then
     echo "required avrdude could not be found!" >&2
     echo "please install https://command-not-found.com/avrdude" >&2

--- a/boards/sparkfun-pro-micro/pro-micro-runner.sh
+++ b/boards/sparkfun-pro-micro/pro-micro-runner.sh
@@ -7,14 +7,14 @@ case "$(uname -s)" in
     *)          OS="Unknown";;
 esac
 
-if ! command -v numfmt &> /dev/null
+if ! command -v numfmt > /dev/null 2>&1
 then
     echo "numfmt is needed for human-readable sizes." >&2
     echo "please install https://command-not-found.com/numfmt" >&2
     alias numfmt=true
 fi
 
-if ! command -v avrdude &> /dev/null
+if ! command -v avrdude > /dev/null 2>&1
 then
     echo "required avrdude could not be found!" >&2
     echo "please install https://command-not-found.com/avrdude" >&2


### PR DESCRIPTION
the `&>` redirection literal is undefined behavior in `sh`, leading to
incorrect dependency detection --
https://github.com/koalaman/shellcheck/wiki/SC2039\#redirect-both-stdout-and-stderr

before:
![2021-01-31_14-08-05](https://user-images.githubusercontent.com/9776239/106395033-fd0f0e80-63cd-11eb-84a6-1a82571fc237.png)

after:
![2021-01-31_14-11-17](https://user-images.githubusercontent.com/9776239/106395359-e964a780-63cf-11eb-9220-187f6e94d508.png)


