### PR TITLE
Start work on the architectural refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - next
       - wip
   pull_request:
 
@@ -16,11 +17,6 @@ jobs:
         board:
           - arduino-uno
           - arduino-leonardo
-
-          - arduino-mega2560
-          - bigavr6
-          - trinket
-          - sparkfun-pro-micro
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -35,4 +31,4 @@ jobs:
       - name: Install avr-gcc, binutils, and libc
         run: sudo apt-get install -y avr-libc binutils-avr gcc-avr
       - name: Compile board crate and examples
-        run: cd "boards/${{ matrix.board }}" && cargo build --examples
+        run: cd "examples/${{ matrix.board }}" && cargo build --bins

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ members = [
     "chips/attiny85-hal",
     "chips/attiny88-hal",
 
+    # MCU HAL crates
+    "mcu/atmega-hal",
+
     # The board crates
     "boards/arduino-diecimila",
     "boards/arduino-leonardo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ members = [
     # MCU HAL crates
     "mcu/atmega-hal",
 
+    # Higher level crates
+    "arduino-hal",
+
     # The board crates
     "boards/arduino-diecimila",
     "boards/arduino-leonardo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ members = [
     # Higher level crates
     "arduino-hal",
 
+    # Examples
+    "examples/arduino-uno",
+
     # The board crates
     "boards/arduino-diecimila",
     "boards/arduino-leonardo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "arduino-hal",
 
     # Examples
+    "examples/arduino-leonardo",
     "examples/arduino-uno",
 
     # The board crates

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@ avr-hal ![Continuous Integration](https://github.com/Rahix/avr-hal/workflows/Con
 =======
 `embedded-hal` implementations for AVR microcontrollers.  Based on the register definitions from [`avr-device`](https://github.com/Rahix/avr-device).
 
+## Warning
+**This branch is currently undergoing a big architectural refactor!  There are many parts still WiP and probably lots of code/crates which cannot compile.**  If you want to work on the future of avr-hal you're in the right place.  If you just want to _use_ avr-hal for a project, please use the "stable" version on the `master` branch instead.
+
+Also note that the following documentation is **not** up to date for the state in this branch!
+
 - [Quickstart](#quickstart)
 - [Starting your own project](#starting-your-own-project)
 - [Repository Structure](#repository-structure)

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -11,6 +11,7 @@ rt = ["atmega-hal/rt"]
 board-selected = []
 mcu-atmega=[]
 arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
+arduino-leonardo = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 
 [dependencies]
 cfg-if = "1"

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "arduino-hal"
+version = "0.1.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
+
+[features]
+default = ["rt"]
+rt = ["atmega-hal/rt"]
+
+board-selected = []
+mcu-atmega=[]
+arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
+
+[dependencies]
+cfg-if = "1"
+embedded-hal = "0.2.3"
+ufmt = "0.1.0"
+
+[dependencies.void]
+version = "1.0.2"
+default-features = false
+
+[dependencies.avr-hal-generic]
+path = "../avr-hal-generic/"
+
+[dependencies.atmega-hal]
+path = "../mcu/atmega-hal/"
+optional = true
+
+# Because this crate has its own check that at least one device is selected, we
+# can safely "circumvent" the check in `atmega-hal`.  Due to compile order,
+# this allows us to show our error instead of the one from `atmega-hal` (which
+# is much less helpful in this situation).
+features = ["disable-device-selection-error"]
+
+[dependencies.avr-device]
+version = "0.3"

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -1,0 +1,9 @@
+pub use avr_hal_generic::clock::*;
+
+pub(crate) mod default {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "arduino-uno")] {
+            pub type DefaultClock = avr_hal_generic::clock::MHz16;
+        }
+    }
+}

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -1,9 +1,8 @@
 pub use avr_hal_generic::clock::*;
 
 pub(crate) mod default {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "arduino-uno")] {
-            pub type DefaultClock = avr_hal_generic::clock::MHz16;
-        }
-    }
+    #[cfg(feature = "arduino-uno")]
+    pub type DefaultClock = avr_hal_generic::clock::MHz16;
+    #[cfg(feature = "arduino-leonardo")]
+    pub type DefaultClock = avr_hal_generic::clock::MHz16;
 }

--- a/arduino-hal/src/delay.rs
+++ b/arduino-hal/src/delay.rs
@@ -1,0 +1,11 @@
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+
+pub type Delay = avr_hal_generic::delay::Delay<crate::DefaultClock>;
+
+pub fn delay_ms(ms: u16) {
+    Delay::new().delay_ms(ms)
+}
+
+pub fn delay_us(us: u32) {
+    Delay::new().delay_us(us)
+}

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -65,6 +65,8 @@ pub struct Peripherals {
     pub pins: Pins,
     #[cfg(feature = "arduino-uno")]
     pub USART0: hal::RawPeripheral<pac::USART0>,
+    #[cfg(feature = "arduino-leonardo")]
+    pub USART1: hal::RawPeripheral<pac::USART1>,
 }
 
 #[cfg(feature = "board-selected")]
@@ -73,8 +75,11 @@ impl Peripherals {
         Self {
             #[cfg(feature = "atmega-hal")]
             pins: Pins::with_mcu_pins(dp.pins),
+
             #[cfg(feature = "arduino-uno")]
             USART0: dp.USART0,
+            #[cfg(feature = "arduino-leonardo")]
+            USART1: dp.USART1,
         }
     }
 

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -1,0 +1,84 @@
+#![no_std]
+
+#[cfg(not(feature = "board-selected"))]
+compile_error!(
+    "This crate requires you to specify your target Arduino board as a feature.
+
+    Please select one of the following
+
+    * arduino-uno
+    "
+);
+
+#[cfg(feature = "mcu-atmega")]
+pub use atmega_hal as hal;
+#[cfg(feature = "mcu-atmega")]
+pub use atmega_hal::entry;
+#[cfg(feature = "mcu-atmega")]
+pub use atmega_hal::pac;
+
+#[cfg(feature = "board-selected")]
+pub mod clock;
+#[cfg(feature = "board-selected")]
+pub use clock::default::DefaultClock;
+
+#[cfg(feature = "board-selected")]
+mod delay;
+#[cfg(feature = "board-selected")]
+pub use delay::{delay_ms, delay_us, Delay};
+
+#[cfg(feature = "board-selected")]
+pub mod port;
+#[cfg(feature = "board-selected")]
+pub use port::Pins;
+
+#[cfg(feature = "board-selected")]
+pub mod usart {
+    pub use crate::hal::usart::{Baudrate, UsartOps};
+
+    pub type Usart<USART, RX, TX> = crate::hal::usart::Usart<USART, RX, TX, crate::DefaultClock>;
+    pub type UsartWriter<USART, RX, TX> =
+        crate::hal::usart::UsartWriter<USART, RX, TX, crate::DefaultClock>;
+    pub type UsartReader<USART, RX, TX> =
+        crate::hal::usart::UsartReader<USART, RX, TX, crate::DefaultClock>;
+}
+#[cfg(feature = "board-selected")]
+pub use usart::Usart;
+
+pub mod prelude {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "arduino-uno")] {
+            pub use crate::hal::usart::BaudrateArduinoExt as _;
+        } else {
+            pub use crate::hal::usart::BaudrateExt as _;
+        }
+    }
+
+    pub use void::ResultVoidExt as _;
+    pub use void::ResultVoidErrExt as _;
+    pub use ufmt::uWrite as _;
+}
+
+#[allow(non_snake_case)]
+#[cfg(feature = "board-selected")]
+pub struct Peripherals {
+    pub pins: Pins,
+    #[cfg(feature = "arduino-uno")]
+    pub USART0: hal::RawPeripheral<pac::USART0>,
+}
+
+#[cfg(feature = "board-selected")]
+impl Peripherals {
+    fn new(dp: hal::Peripherals) -> Self {
+        Self {
+            #[cfg(feature = "atmega-hal")]
+            pins: Pins::with_mcu_pins(dp.pins),
+            #[cfg(feature = "arduino-uno")]
+            USART0: dp.USART0,
+        }
+    }
+
+    pub fn take() -> Option<Self> {
+        hal::Peripherals::take().map(Self::new)
+    }
+}

--- a/arduino-hal/src/port/leonardo.rs
+++ b/arduino-hal/src/port/leonardo.rs
@@ -1,0 +1,122 @@
+pub use atmega_hal::port::mode;
+pub use atmega_hal::port::Pin;
+
+avr_hal_generic::renamed_pins! {
+    type Pin = Pin;
+
+    pub struct Pins from atmega_hal::Pins {
+        /// `D0` / `RX`
+        ///
+        /// * `RX` (UART)
+        /// * `INT2`: External Interrupt
+        pub d0: atmega_hal::port::PD2 = pd2,
+        /// `D1` / `TX`
+        ///
+        /// * `TX` (UART)
+        /// * `INT3`: External Interrupt
+        pub d1: atmega_hal::port::PD3 = pd3,
+        /// `D2` / `SDA`
+        ///
+        /// * `SDA`: i2c/twi data
+        /// * `INT1`: External Interrupt
+        pub d2: atmega_hal::port::PD1 = pd1,
+        /// `D3` / `SCL`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer0Pwm]
+        /// * `SCL`: i2c/twi clock
+        /// * `INT0`: External Interrupt
+        /// * `OC0B`: Output Compare Channel `B` for Timer/Counter0
+        pub d3: atmega_hal::port::PD0 = pd0,
+        /// `D4`
+        pub d4: atmega_hal::port::PD4 = pd4,
+        /// `D5`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer3Pwm]
+        /// * `OC3A`: Output Compare Channel `A` for Timer/Counter3
+        /// * `#OC4A`: Inverted Output Compare Channel `A` for Timer/Counter4 (Not implemented)
+        pub d5: atmega_hal::port::PC6 = pc6,
+        /// `D6`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer4Pwm]
+        /// * `OC4D`: Output Compare Channel `D` for Timer/Counter4
+        pub d6: atmega_hal::port::PD7 = pd7,
+        /// `D7`
+        ///
+        /// * `INT6`: External Interrupt
+        pub d7: atmega_hal::port::PE6 = pe6,
+        /// `D8`
+        pub d8: atmega_hal::port::PB4 = pb4,
+        /// `D9`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer1Pwm]
+        /// * `OC1A`: Output Compare Channel `A` for Timer/Counter1
+        /// * `#OC4B`: Inverted Output Compare Channel `B` for Timer/Counter4 (Not implemented)
+        pub d9: atmega_hal::port::PB5 = pb5,
+        /// `D10`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer1Pwm]
+        /// * `OC1B`: Output Compare Channel `B` for Timer/Counter1
+        /// * `OC4B`: Output Compare Channel `B` for Timer/Counter4 (Not implemented)
+        pub d10: atmega_hal::port::PB6 = pb6,
+        /// `D11`
+        ///
+        /// * **PWM**: [atmega32u4_hal::timer::Timer0Pwm]
+        /// * `OC0A`: Output Compare Channel `B` for Timer/Counter0
+        /// * `OC1C`: Output Compare Channel `C` for Timer/Counter1
+        pub d11: atmega_hal::port::PB7 = pb7,
+        /// `D12`
+        ///
+        /// * `#OC4D`: Inverted Output Compare Channel `D` for Timer/Counter4 (Not implemented)
+        pub d12: atmega_hal::port::PD6 = pd6,
+        /// `D13` / `LED_BUILTIN`
+        ///
+        /// * Onboard LED
+        /// * **PWM**: [atmega32u4_hal::timer::Timer4Pwm]
+        /// * `OC4A`: Output Compare Channel `A` for Timer/Counter4
+        pub d13: atmega_hal::port::PC7 = pc7,
+        /// `RX`
+        ///
+        /// Led for indicating inbound data.  Also the CS pin.
+        pub led_rx: atmega_hal::port::PB0 = pb0,
+        /// `TX`
+        ///
+        /// Led for indicating outbound data
+        pub led_tx: atmega_hal::port::PD5 = pd5,
+        /// `SCLK`
+        ///
+        /// ICSP SCLK pin
+        pub sck: atmega_hal::port::PB1 = pb1,
+        /// `MOSI`
+        ///
+        /// ICSP MOSI pin
+        pub mosi: atmega_hal::port::PB2 = pb2,
+        /// `MISO`
+        ///
+        /// ICSP MISO pin
+        pub miso: atmega_hal::port::PB3 = pb3,
+        /// `A0`
+        ///
+        /// * `ADC7` channel
+        pub a0: atmega_hal::port::PF7 = pf7,
+        /// `A1`
+        ///
+        /// * `ADC6` channel
+        pub a1: atmega_hal::port::PF6 = pf6,
+        /// `A2`
+        ///
+        /// * `ADC5` channel
+        pub a2: atmega_hal::port::PF5 = pf5,
+        /// `A3`
+        ///
+        /// * `ADC4` channel
+        pub a3: atmega_hal::port::PF4 = pf4,
+        /// `A4`
+        ///
+        /// * `ADC1` channel
+        pub a4: atmega_hal::port::PF1 = pf1,
+        /// `A5`
+        ///
+        /// * `ADC0` channel
+        pub a5: atmega_hal::port::PF0 = pf0,
+    }
+}

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "arduino-uno")]
+mod uno;
+#[cfg(feature = "arduino-uno")]
+pub use uno::*;

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "arduino-leonardo")]
+mod leonardo;
+#[cfg(feature = "arduino-leonardo")]
+pub use leonardo::*;
 #[cfg(feature = "arduino-uno")]
 mod uno;
 #[cfg(feature = "arduino-uno")]

--- a/arduino-hal/src/port/uno.rs
+++ b/arduino-hal/src/port/uno.rs
@@ -1,0 +1,126 @@
+pub use atmega_hal::port::mode;
+pub use atmega_hal::port::Pin;
+
+avr_hal_generic::renamed_pins! {
+    type Pin = Pin;
+
+    pub struct Pins from atmega_hal::Pins {
+        /// `A0`
+        ///
+        /// * ADC0 (ADC input channel 0)
+        /// * PCINT8 (pin change interrupt 8)
+        pub a0: atmega_hal::port::PC0 = pc0,
+        /// `A1`
+        ///
+        /// * ADC1 (ADC input channel 1)
+        /// * PCINT9 (pin change interrupt 9)
+        pub a1: atmega_hal::port::PC1 = pc1,
+        /// `A2`
+        ///
+        /// * ADC2 (ADC input channel 2)
+        /// * PCINT10 (pin change interrupt 10)
+        pub a2: atmega_hal::port::PC2 = pc2,
+        /// `A3`
+        ///
+        /// * ADC3 (ADC input channel 3)
+        /// * PCINT11 (pin change interrupt 11)
+        pub a3: atmega_hal::port::PC3 = pc3,
+        /// `A4`
+        ///
+        /// * ADC4 (ADC input channel 4)
+        /// * SDA (2-wire serial bus data input/output line)
+        /// * PCINT12 (pin change interrupt 12)
+        pub a4: atmega_hal::port::PC4 = pc4,
+        /// `A5`
+        ///
+        /// ADC5 (ADC input channel 5)
+        /// SCL (2-wire serial bus clock line)
+        /// PCINT13 (pin change interrupt 13)
+        pub a5: atmega_hal::port::PC5 = pc5,
+
+        /// `D0` / `RX`
+        ///
+        /// * RXD (USART input pin)
+        /// * PCINT16 (pin change interrupt 16)
+        pub d0: atmega_hal::port::PD0 = pd0,
+        /// `D1` / `TX`
+        ///
+        /// * TXD (USART output pin)
+        /// * PCINT17 (pin change interrupt 17)
+        pub d1: atmega_hal::port::PD1 = pd1,
+        /// `D2`
+        ///
+        /// * INT0 (external interrupt 0 input)
+        /// * PCINT18 (pin change interrupt 18)
+        pub d2: atmega_hal::port::PD2 = pd2,
+        /// `D3`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * INT1 (external interrupt 1 input)
+        /// * OC2B (Timer/Counter2 output compare match B output)
+        /// * PCINT19 (pin change interrupt 19)
+        pub d3: atmega_hal::port::PD3 = pd3,
+        /// `D4`
+        ///
+        /// * XCK (USART external clock input/output)
+        /// * T0 (Timer/Counter 0 external counter input)
+        /// * PCINT20 (pin change interrupt 20)
+        pub d4: atmega_hal::port::PD4 = pd4,
+        /// `D5`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * T1 (Timer/Counter 1 external counter input)
+        /// * OC0B (Timer/Counter0 output compare match B output)
+        /// * PCINT21 (pin change interrupt 21)
+        pub d5: atmega_hal::port::PD5 = pd5,
+        /// `D6`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * AIN0 (analog comparator positive input)
+        /// * OC0A (Timer/Counter0 output compare match A output)
+        /// * PCINT22 (pin change interrupt 22)
+        pub d6: atmega_hal::port::PD6 = pd6,
+        /// `D7`
+        ///
+        /// * AIN1 (analog comparator negative input)
+        /// * PCINT23 (pin change interrupt 23)
+        pub d7: atmega_hal::port::PD7 = pd7,
+        /// `D8`
+        ///
+        /// * ICP1 (Timer/Counter1 input capture input)
+        /// * CLKO (divided system clock output)
+        /// * PCINT0 (pin change interrupt 0)
+        pub d8: atmega_hal::port::PB0 = pb0,
+        /// `D9`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * OC1A (Timer/Counter1 output compare match A output)
+        /// * PCINT1 (pin change interrupt 1)
+        pub d9: atmega_hal::port::PB1 = pb1,
+        /// `D10`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * SS (SPI bus master slave select)
+        /// * OC1B (Timer/Counter1 output compare match B output)
+        /// * PCINT2 (pin change interrupt 2)
+        pub d10: atmega_hal::port::PB2 = pb2,
+        /// `D11`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * MOSI (SPI bus master/slave input)
+        /// * OC2A (Timer/Counter2 output compare match A output)
+        /// * PCINT3 (pin change interrupt 3)
+        pub d11: atmega_hal::port::PB3 = pb3,
+        /// `D12`
+        ///
+        /// * MISO (SPI bus master input/slave output)
+        /// * PCINT4 (pin change interrupt 4)
+        pub d12: atmega_hal::port::PB4 = pb4,
+        /// `D13`
+        ///
+        /// * SCK (SPI bus master clock input)
+        /// * PCINT5 (pin change interrupt 5)
+        /// * L LED on Arduino Uno
+        pub d13: atmega_hal::port::PB5 = pb5,
+    }
+}

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -35,3 +35,9 @@ pub mod prelude {
     pub use void::ResultVoidErrExt as _;
     pub use ufmt::uWrite as _;
 }
+
+// For making certain traits unimplementable from outside this crate.
+mod sealed {
+    pub trait Sealed {}
+}
+pub(crate) use sealed::Sealed;

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -1,733 +1,440 @@
-//! PORTx digital IO Implementations
+//! Digital IO implementations for the `PORT#` peripherals
 //!
-//! # Design Rationale
-//! Each pin has a distinct type which allows pin-dependent HAL functionality to ensure at
-//! compile-time that the correct pins are used.  For example, certain peripherals have the IO
-//! hardwired to some specific pins which can't be changed.  For purposes where the exact pin does
-//! not matter, the distinct types can be 'downgraded' into a generic `Pin<MODE>` type.  See the
-//! section about [downgrading](#downgrading) further down.
-//!
-//! To instanciate the pin types, a port is `.split()` into its pins:
-//!
-//! ```ignore
-//! let dp = atmega32u4::Peripherals::take().unwrap();
-//!
-//! let mut portd = dp.PORTD.split();
-//!
-//! let pd2 = portd.pd2.into_output(&mut portd.ddr);
-//! ```
-//!
-//! Board crates usually provide a wrapper around that which makes access more convenient:
-//!
-//! ```ignore
-//! let dp = arduino_leonardo::Peripherals::take().unwrap();
-//!
-//! let mut pins = arduino_leonardo::Pins::new(
-//!     dp.PORTB,
-//!     dp.PORTC,
-//!     dp.PORTD,
-//!     dp.PORTE,
-//! );
-//!
-//! let mut led0 = pins.led_rx.into_output(&mut pins.ddr);
-//! let mut led1 = pins.led_tx.into_output(&mut pins.ddr);
-//! let mut led2 = pins.d13.into_output(&mut pins.ddr);
-//! ```
-//!
-//! # Modes
-//! A pin's mode is modelled via the `<MODE>` generic parameter.  Only when the pin is in the
-//! correct mode, relevant methods (e.g. `set_high()`) are available.  Changing the mode is done
-//! via conversion methods that consume the pin:
-//!
-//! ```ignore
-//! // By default, pins are floating inputs
-//! let pd2: PD2<mode::Input<mode::Floating>> = portd.pd2;
-//!
-//! // Convert into pull-up input
-//! let pd2: PD2<mode::Input<mode::PullUp>> = pd2.into_pull_up_input(&mut portd.ddr);
-//!
-//! // Convert into output
-//! let pd2: PD2<mode::Output> = pd2.into_output(&mut portd.ddr);
-//!
-//! // Convert into tri-state input and output.
-//! let pd2: PD2<mode::TriState> = pd2.into_tri_state(&mut portd.ddr);
-//! ```
-//!
-//! ### Digital Input
-//! Digital Input pins (i.e. where `MODE` = `mode::Input<_>`) have the following methods available:
-//!
-//! ```ignore
-//! // `true` if the pin is high, `false` if it is low
-//! pd2.is_high().void_unwrap();
-//!
-//! // `true if the pin is low, `false` if it is high
-//! pd2.is_low().void_unwrap();
-//! ```
-//!
-//! ### Digital Output
-//! Digital Output pins (i.e. where `MODE` = `mode::Output`) can be used like this:
-//!
-//! ```ignore
-//! // Set high or low
-//! pd2.set_high().void_unwrap();
-//! pd2.set_low().void_unwrap();
-//!
-//! // Check what the pin was last set to
-//! pd2.is_set_high().void_unwrap();
-//! pd2.is_set_low().void_unwrap();
-//! ```
-//!
-//! ### Digital Tri-State Output and Input
-//! Digital I/O pins in tri-state mode (i.e. where `MODE` = `mode::TriState`),
-//! usually with an external pull-up, are useful for a one wire bus.
-//! They can be used as both output and input pins, like this:
-//!
-//! ```ignore
-//! // Actively drive the pin low.
-//! pd2.set_low().void_unwrap();
-//! // Release the pin, allowing the external pull-up to pull the pin
-//! // in the absence of another driver
-//! pd2.set_high().void_unwrap();
-//!
-//! // `true` if the pin is electrically high, `false` if it is low
-//! pd2.is_high().void_unwrap();
-//! // `true` if the pin is electrically low, driven by either the
-//! // microcontroller or externally
-//! pd2.is_low().void_unwrap();
-//! ```
-//!
-//! ### Other Modes
-//! Apart from input and output, certain pins can have other functionality associated with them.
-//! E.g. some pins can be used for PWM output, others as ADC inputs.  For those pins, specific
-//! conversion methods exist:
-//!
-//! ```ignore
-//! // Digital IO by default
-//! let pd2 = portd.pd2;
-//!
-//! // Make a pin an ADC channel
-//! let pd2_analog = pd2.into_analog_input(&mut adc);
-//!
-//! // Make a pin a PWM output
-//! let pd2_pwm = pd2.into_output().into_pwm(&mut timer0);
-//! ```
-//!
-//! ## Downgrading
-//! As described above, usually each pin has its own distinct type.  This is useful in a lot of
-//! cases but can be difficult to deal with when code does not care about the exact pin(s) it is
-//! working with.  An easy example is trying to store a number of pins in an array; this is not
-//! possible when each pin has its own type.
-//!
-//! For those usecases, a generic `Pin` type exists which can represent any pin.  Specific pins are
-//! converted using the `.downgrade()` method:
-//!
-//! ```ignore
-//! let pd2 = portd.pd2.into_output(&mut portd.ddr);
-//! let pd3 = portd.pd3.into_output(&mut portd.ddr);
-//!
-//! let pins: [Pin<mode::Output>; 2] = [pd2.downgrade(), pd3.downgrade()];
-//! ```
+//! Please take a look at the documentation for [`Pin`] for a detailed explanation.
 
-/// IO Modes
+use core::marker::PhantomData;
+
+pub trait PinMode: crate::Sealed {}
 pub mod mode {
-    /// Any digital IO mode
-    pub trait DigitalIO: private::Unimplementable {}
-    /// Any input mode
-    pub trait InputMode: private::Unimplementable {}
+    use core::marker::PhantomData;
 
-    /// Pin configured as a digital input
-    pub struct Input<MODE: InputMode> {
-        _m: core::marker::PhantomData<MODE>,
-    }
-    /// Pin configured as a digital output
+    pub trait Io: crate::Sealed + super::PinMode {}
+
     pub struct Output;
-    /// Pin configured as an ADC channel
-    pub struct Analog;
-    /// Pin configured as PWM output
-    pub struct Pwm<TIMER> {
-        _m: core::marker::PhantomData<TIMER>,
+    impl super::PinMode for Output {}
+    impl Io for Output {}
+    impl crate::Sealed for Output {}
+
+    pub trait InputMode: crate::Sealed {}
+
+    pub struct Input<IMODE> {
+        pub(crate) _imode: PhantomData<IMODE>,
     }
-    /// Pin configured in open drain mode.
-    pub struct TriState;
+    impl<IMODE: InputMode> super::PinMode for Input<IMODE> {}
+    impl<IMODE: InputMode> Io for Input<IMODE> {}
+    impl<IMODE: InputMode> crate::Sealed for Input<IMODE> {}
 
-    impl private::Unimplementable for Output {}
-    impl<M: InputMode> private::Unimplementable for Input<M> {}
-    impl private::Unimplementable for TriState {}
-    impl DigitalIO for Output {}
-    impl<M: InputMode> DigitalIO for Input<M> {}
-    impl DigitalIO for TriState {}
-
-    /// Pin input configured **without** internal pull-up
     pub struct Floating;
-    /// Pin input configured with internal pull-up
-    pub struct PullUp;
-
-    impl private::Unimplementable for Floating {}
-    impl private::Unimplementable for PullUp {}
     impl InputMode for Floating {}
-    impl InputMode for PullUp {}
+    impl crate::Sealed for Floating {}
 
-    mod private {
-        pub trait Unimplementable {}
+    pub struct PullUp;
+    impl InputMode for PullUp {}
+    impl crate::Sealed for PullUp {}
+}
+
+pub trait PinOps {
+    type Dynamic;
+
+    fn into_dynamic(self) -> Self::Dynamic;
+
+    unsafe fn out_set(&mut self);
+    unsafe fn out_clear(&mut self);
+    unsafe fn out_toggle(&mut self);
+    unsafe fn out_get(&self) -> bool;
+
+    unsafe fn in_get(&self) -> bool;
+
+    unsafe fn make_output(&mut self);
+    unsafe fn make_input(&mut self, pull_up: bool);
+}
+
+/// Representation of an MCU pin.
+///
+/// # Design Rationale
+/// We want individual types per pin to model constraints which depend on a specific pin.  For
+/// example, some peripherals are internally hard-wired to certain pins of the MCU.
+///
+/// Additionally, the mode of a pin should also be a part of the type to model enforcement of pins
+/// being in a certain mode and preventing misuse like for example calling `set_high()` on a pin
+/// configured as input.
+///
+/// To do this, the [`Pin`] type is generic over the `MODE` (input, output, ...) and the `PIN`
+/// (pd0, pb5, pc6, ...).
+///
+/// Of course, in some applications one does not care about the specific pin used.  For these
+/// situations, the specific pin types can be "downgraded" into a dynamic type that can represent
+/// any pin.  See [Downgrading](#downgrading) for more details.
+///
+/// # Instantiation
+/// The `Peripherals` struct in HAL and board-support crates usually contains a `.pins` field which
+/// is of type `Pins`.  This `Pins` struct in turn has fields for each individual pin, in its
+/// default mode.  You can then move the pin out of this struct to reconfigure it (examples in this
+/// documentation are for `atmega-hal`):
+///
+/// ```ignore
+/// use atmega_hal::port::{Pin, mode, self};
+///
+/// let dp = atmega_hal::Peripherals::take().unwrap();
+///
+/// let output: Pin<mode::Output, port::PD3> = dp.pins.pd3.into_output();
+/// ```
+pub struct Pin<MODE, PIN> {
+    pub(crate) pin: PIN,
+    pub(crate) _mode: PhantomData<MODE>,
+}
+
+impl<PIN: PinOps> Pin<mode::Input<mode::Floating>, PIN> {
+    #[doc(hidden)]
+    pub fn new(pin: PIN) -> Self {
+        Pin {
+            pin,
+            _mode: PhantomData,
+        }
     }
 }
 
-/// Create a generic pin to be used for downgrading
-#[macro_export]
-macro_rules! impl_generic_pin {
-    (
-        pub enum $GenericPin:ident {
-            $($PortEnum:ident($PORTX:ty, $reg_port:ident, $reg_pin:ident, $reg_ddr:ident),)+
+/// # Configuration
+/// To change the mode of a pin, use one of the following conversion functions.  They consume the
+/// original [`Pin`] and return one with the desired mode.  Only when a pin is in the correct mode,
+/// does it have the mode-relevant methods availailable (e.g. `set_high()` is only available for
+/// `Output` pins).
+impl<PIN: PinOps, MODE: mode::Io> Pin<MODE, PIN> {
+    /// Convert this pin into an output pin.  See [Digital Output](#digital-output).
+    pub fn into_output(mut self) -> Pin<mode::Output, PIN> {
+        unsafe { self.pin.make_output() };
+        Pin {
+            pin: self.pin,
+            _mode: PhantomData,
         }
-    ) => {
-        mod generic_pin {
-            use $crate::hal::digital::v2 as digital;
-            use $crate::port::mode;
-            use $crate::void::Void;
-            use core::marker;
+    }
 
-            /// Generic pin type.
-            ///
-            /// As described in the [general Digital IO documentation][1], this type can represent
-            /// any pin for use-cases where the exact pin is not relevant.  This is especially
-            /// useful when, e.g. wanting to store a number of pins in an array.
-            ///
-            /// The generic pin implements all the same digital IO methods (`set_high()`,
-            /// `set_low()`, `is_high()`, `is_low()`, etc.) as specific pin types, except that it
-            /// cannot be used for pin-specific functions (e.g. PWM, ADC Channel).
-            ///
-            /// [1]: ../../avr_hal_generic/port/index.html
-            pub enum $GenericPin<MODE> {
-                $($PortEnum(u8, marker::PhantomData<MODE>),)+
-            }
-
-            // Input & Output implementations ------------------------- {{{
-            // - Unsafe:  The unsafe blocks in here are ok, because these
-            //            operations will compile down to single, atomic
-            //            `sbi`, `cbi`, `sbic`, `sbis` instructions.
-            impl digital::OutputPin for $GenericPin<mode::Output> {
-                type Error = Void;
-
-                fn set_high(&mut self) -> Result<(), Self::Error> {
-                    match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr())
-                                    .$reg_port
-                                    .modify(|r, w| {
-                                        w.bits(r.bits() | (1 << *i))
-                                    })
-                            },
-                        )+
-                    }
-                    Ok(())
-                }
-
-                fn set_low(&mut self) -> Result<(), Self::Error> {
-                    match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr())
-                                    .$reg_port
-                                    .modify(|r, w| {
-                                        w.bits(r.bits() & !(1 << *i))
-                                    })
-                            },
-                        )+
-                    }
-                    Ok(())
-                }
-            }
-
-            impl digital::StatefulOutputPin for $GenericPin<mode::Output> {
-                fn is_set_high(&self) -> Result<bool, Self::Error> {
-                    Ok(match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr())
-                                    .$reg_port.read().bits() & (1 << *i) != 0
-                            },
-                        )+
-                    })
-                }
-
-                fn is_set_low(&self) -> Result<bool, Self::Error> {
-                    self.is_set_high().map(|b| !b)
-                }
-            }
-
-            impl digital::ToggleableOutputPin for $GenericPin<mode::Output> {
-                type Error = Void;
-
-                fn toggle(&mut self) -> Result<(), Self::Error> {
-                    match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr())
-                                    .$reg_pin
-                                    .write(|w| w.bits(1 << *i))
-                            },
-                        )+
-                    }
-                    Ok(())
-                }
-            }
-
-            impl<MODE: mode::InputMode> digital::InputPin for $GenericPin<mode::Input<MODE>> {
-                type Error = Void;
-
-                fn is_high(&self) -> Result<bool, Self::Error> {
-                    Ok(match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr())
-                                    .$reg_pin.read().bits() & (1 << *i) != 0
-                            }
-                        )+
-                    })
-                }
-
-                fn is_low(&self) -> Result<bool, Self::Error> {
-                    Ok(match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr())
-                                    .$reg_pin.read().bits() & (1 << *i) == 0
-                            }
-                        )+
-                    })
-                }
-            }
-
-            impl digital::OutputPin for $GenericPin<mode::TriState> {
-                type Error = Void;
-
-                fn set_high(&mut self) -> Result<(), Self::Error> {
-                    match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr()).$reg_ddr.modify(|r, w| {
-                                        w.bits(r.bits() & !(1 << *i))
-                                    })
-                            },
-                        )+
-                    }
-                    Ok(())
-                }
-
-                fn set_low(&mut self) -> Result<(), Self::Error> {
-                    match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr()).$reg_ddr.modify(|r, w| {
-                                        w.bits(r.bits() | (1 << *i))
-                                    })
-                            },
-                        )+
-                    }
-                    Ok(())
-                }
-            }
-
-            impl digital::InputPin for $GenericPin<mode::TriState> {
-                type Error = Void;
-
-                fn is_high(&self) -> Result<bool, Self::Error> {
-                    Ok(match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr())
-                                    .$reg_pin.read().bits() & (1 << *i) != 0
-                            }
-                        )+
-                    })
-                }
-
-                fn is_low(&self) -> Result<bool, Self::Error> {
-                    Ok(match self {
-                        $(
-                            $GenericPin::$PortEnum(i, _) => unsafe {
-                                (*<$PORTX>::ptr())
-                                    .$reg_pin.read().bits() & (1 << *i) == 0
-                            }
-                        )+
-                    })
-                }
-            }
-            // -------------------------------------------------------- }}}
+    /// Convert this pin into a floating input pin.  See [Digital Input](#digital-input).
+    ///
+    /// *Note*: To read deterministic values from the pin, it must be externally pulled to a
+    /// defined level (either VCC or GND).
+    pub fn into_floating_input(mut self) -> Pin<mode::Input<mode::Floating>, PIN> {
+        unsafe { self.pin.make_input(false) };
+        Pin {
+            pin: self.pin,
+            _mode: PhantomData,
         }
-        pub use self::generic_pin::$GenericPin;
-    };
+    }
+
+    /// Convert this pin into a pulled-up input pin.  See [Digital Input](#digital-input).
+    ///
+    /// With no external circuit pulling the pin low, it will be read high.
+    pub fn into_pull_up_input(mut self) -> Pin<mode::Input<mode::PullUp>, PIN> {
+        unsafe { self.pin.make_input(true) };
+        Pin {
+            pin: self.pin,
+            _mode: PhantomData,
+        }
+    }
 }
 
-/// Implement pin abstractions for a port peripheral
-#[macro_export]
-macro_rules! impl_port {
-    // With a generic pin
-    (
-        pub mod $portx:ident {
-            #[port_ext]
-            use $portext_use:path;
-
-            #[generic_pin]
-            use $GenericPin:ident::$PortEnum:ident;
-
-            impl $PortExt:ident for $PORTX:ty {
-                regs: ($reg_pin:ident, $reg_ddr:ident, $reg_port:ident),
-                $($pxi:ident: ($PXi:ident, $i:expr),)+
-            }
+/// # Downgrading
+/// For applications where the exact pin is irrelevant, a specific pin can be downgraded to a
+/// "dynamic pin" which can represent any pin:
+///
+/// ```ignore
+/// use atmega_hal::port::{Pin, mode};
+///
+/// let dp = atmega_hal::Peripherals::take().unwrap();
+///
+/// let any_output_pin1: Pin<mode::Output> = dp.pins.pd0.into_output().downgrade();
+/// let any_output_pin2: Pin<mode::Output> = dp.pins.pd1.into_output().downgrade();
+///
+/// // Because they now have the same type, you can, for example, stuff them into an array:
+/// let pins: [Pin<mode::Output>; 2] = [any_output_pin1, any_output_pin2];
+/// ```
+impl<PIN: PinOps, MODE: mode::Io> Pin<MODE, PIN> {
+    /// "Erase" type-level information about which specific pin is represented.
+    ///
+    /// *Note*: The returned "dynamic" pin has runtime overhead compared to a specific pin.
+    pub fn downgrade(self) -> Pin<MODE, PIN::Dynamic> {
+        Pin {
+            pin: self.pin.into_dynamic(),
+            _mode: PhantomData,
         }
-    ) => {
-        $crate::impl_port! {
-            pub mod $portx {
-                #[port_ext]
-                use $portext_use;
-
-                impl $PortExt for $PORTX {
-                    regs: ($reg_pin, $reg_ddr, $reg_port),
-                    $($pxi: ($PXi, $i),)+
-                }
-            }
-        }
-
-        // Downgrade implementation ------------------------------- {{{
-        $(
-            impl<MODE> $portx::$PXi<MODE> {
-                /// Downgrade this pin into a type that is generic over all pins.
-                ///
-                /// The main use for this function is to store multiple pins in an array.  Please
-                /// note that generic pins have a runtime overhead.
-                ///
-                /// See the [general Digital IO documentation][1] and the [`Pin` type][2] for more
-                /// information.
-                ///
-                /// # Example
-                /// ```rust
-                /// let p1 = portb.pb1.downgrade();
-                /// let p2 = portc.pc7.downgrade();
-                /// let pins = [p1, p2];
-                /// ```
-                ///
-                /// [1]: ../../../avr_hal_generic/port/index.html
-                /// [2]: ../enum.Pin.html
-                pub fn downgrade(self) -> $GenericPin<MODE> {
-                    $GenericPin::$PortEnum($i, ::core::marker::PhantomData)
-                }
-            }
-        )+
-        // -------------------------------------------------------- }}}
-    };
-    // Without a generic pin
-    (
-        pub mod $portx:ident {
-            #[port_ext]
-            use $portext_use:path;
-
-            impl $PortExt:ident for $PORTX:ty {
-                regs: ($reg_pin:ident, $reg_ddr:ident, $reg_port:ident),
-                $($pxi:ident: ($PXi:ident, $i:expr),)+
-            }
-        }
-    ) => {
-        pub mod $portx {
-            use core::marker;
-            use $crate::void::Void;
-            use $crate::hal::digital::v2 as digital;
-            use $crate::port::mode;
-
-            // We have to "use" the port-ext trait so we can implement it inside
-            // the macro.
-            use $portext_use;
-
-            pub struct Parts {
-                pub ddr: DDR,
-                $(
-                    pub $pxi: $PXi<mode::Input<mode::Floating>>,
-                )+
-            }
-
-            impl $PortExt for $PORTX {
-                type Parts = Parts;
-
-                fn split(self) -> Parts {
-                    Parts {
-                        ddr: DDR { _0: () },
-                        $($pxi: $PXi { _mode: marker::PhantomData },)+
-                    }
-                }
-            }
-
-            /// Marker trait for types that can be used as DDR
-            pub trait AsDDR {
-                fn as_ddr(&self) -> &DDR;
-            }
-
-            pub struct DDR {
-                _0: (),
-            }
-
-            impl AsDDR for DDR {
-                fn as_ddr(&self) -> &DDR { self }
-            }
-
-            $(
-                /// Type representing a specific pin.
-                ///
-                /// See the [general Digital IO documentation][1] for more info.  In short:
-                ///
-                /// - Mode is changed with
-                ///   - `.into_output()`
-                ///   - `.into_floating_input()`
-                ///   - `.into_pull_up_input()`
-                /// - Input pins are sampled with
-                ///   - `.is_high().void_unwrap()`
-                ///   - `.is_low().void_unwrap()`
-                /// - Output pins are set with
-                ///   - `.set_high().void_unwrap()`
-                ///   - `.set_low().void_unwrap()`
-                ///
-                ///   and can be checked with
-                ///   - `.is_set_high().void_unwrap()`
-                ///   - `.is_set_low().void_unwrap()`
-                /// - Pins can be downgraded into a generic type using `.downgrade()`.
-                ///
-                /// [1]: ../../../avr_hal_generic/port/index.html
-                pub struct $PXi<MODE> {
-                    pub(crate)_mode: marker::PhantomData<MODE>,
-                }
-
-                // Mode Switch implementations ---------------------------- {{{
-                // - Unsafe:  The unsafe blocks in here are ok, because these
-                //            operations will compile down to single, atomic
-                //            `sbi`, `cbi`, `sbic`, `sbis` instructions.
-                impl<MODE: mode::DigitalIO> $PXi<MODE> {
-                    // The following methods are only defined if the pin is in
-                    // a digital-io mode.  This ensures that a pin used by another
-                    // peripheral can't be converted back (because that would
-                    // not be universally possible).
-
-                    /// Make this pin a digital output.
-                    pub fn into_output<D: AsDDR>(self, ddr: &D) -> $PXi<mode::Output> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_ddr.modify(|r, w| {
-                                w.bits(r.bits() | (1 << $i))
-                            });
-                        }
-                        $PXi { _mode: marker::PhantomData }
-                    }
-
-                    /// Make this pin a digital input **without** enabling the internal pull-up.
-                    pub fn into_floating_input<D: AsDDR>(self, ddr: &D) -> $PXi<mode::Input<mode::Floating>> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_ddr.modify(|r, w| {
-                                w.bits(r.bits() & !(1 << $i))
-                            });
-                            (*<$PORTX>::ptr()).$reg_port.modify(|r, w| {
-                                w.bits(r.bits() & !(1 << $i))
-                            });
-                        }
-                        $PXi { _mode: marker::PhantomData }
-                    }
-
-                    /// Make this pin a digital input and enable the internal pull-up.
-                    pub fn into_pull_up_input<D: AsDDR>(self, ddr: &D) -> $PXi<mode::Input<mode::PullUp>> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_ddr.modify(|r, w| {
-                                w.bits(r.bits() & !(1 << $i))
-                            });
-                            (*<$PORTX>::ptr()).$reg_port.modify(|r, w| {
-                                w.bits(r.bits() | (1 << $i))
-                            });
-                        }
-                        $PXi { _mode: marker::PhantomData }
-                    }
-
-                    /// Make this pin a tri-state pin. Default state is released (high) mode.
-                    /// Internal pull-up is not used.
-                    ///
-                    /// Note that, as always, it is ***not safe*** to connect the external
-                    /// pull-up to a voltage higher than VCC + 0.5.  See your chip's
-                    /// datasheet for more details.
-                    pub fn into_tri_state<D: AsDDR>(self, ddr: &D) -> $PXi<mode::TriState> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_ddr.modify(|r, w| {
-                                w.bits(r.bits() & !(1 << $i))
-                            });
-                            (*<$PORTX>::ptr()).$reg_port.modify(|r, w| {
-                                w.bits(r.bits() & !(1 << $i))
-                            });
-                        }
-                        $PXi { _mode: marker::PhantomData }
-                    }
-                }
-                // -------------------------------------------------------- }}}
-
-                // Input & Output implementations ------------------------- {{{
-                // - Unsafe:  The unsafe blocks in here are ok, because these
-                //            operations will compile down to single, atomic
-                //            `sbi`, `cbi`, `sbic`, `sbis` instructions.
-                impl digital::OutputPin for $PXi<mode::Output> {
-                    type Error = Void;
-
-                    fn set_high(&mut self) -> Result<(), Self::Error> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_port.modify(|r, w| {
-                                w.bits(r.bits() | (1 << $i))
-                            });
-                        }
-                        Ok(())
-                    }
-
-                    fn set_low(&mut self) -> Result<(), Self::Error> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_port.modify(|r, w| {
-                                w.bits(r.bits() & !(1 << $i))
-                            });
-                        }
-                        Ok(())
-                    }
-                }
-
-                impl digital::StatefulOutputPin for $PXi<mode::Output> {
-                    fn is_set_high(&self) -> Result<bool, Self::Error> {
-                        Ok(unsafe {
-                            (*<$PORTX>::ptr()).$reg_port.read().bits()
-                        } & (1 << $i) != 0)
-                    }
-
-                    fn is_set_low(&self) -> Result<bool, Self::Error> {
-                        self.is_set_high().map(|b| !b)
-                    }
-                }
-
-                impl digital::ToggleableOutputPin for $PXi<mode::Output> {
-                    type Error = Void;
-
-                    fn toggle(&mut self) -> Result<(), Self::Error> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_pin.write(|w| {
-                                w.bits(1 << $i)
-                            });
-                        }
-                        Ok(())
-                    }
-                }
-
-                impl<MODE: mode::InputMode> digital::InputPin for $PXi<mode::Input<MODE>> {
-                    type Error = Void;
-
-                    fn is_high(&self) -> Result<bool, Self::Error> {
-                        Ok(unsafe {
-                            (*<$PORTX>::ptr()).$reg_pin.read().bits()
-                        } & (1 << $i) != 0)
-                    }
-
-                    fn is_low(&self) -> Result<bool, Self::Error> {
-                        Ok(unsafe {
-                            (*<$PORTX>::ptr()).$reg_pin.read().bits()
-                        } & (1 << $i) == 0)
-                    }
-                }
-
-                impl digital::OutputPin for $PXi<mode::TriState> {
-                    type Error = Void;
-
-                    fn set_high(&mut self) -> Result<(), Self::Error> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_ddr.modify(|r, w| {
-                                w.bits(r.bits() & !(1 << $i))
-                            });
-                        }
-                        Ok(())
-                    }
-
-                    fn set_low(&mut self) -> Result<(), Self::Error> {
-                        unsafe {
-                            (*<$PORTX>::ptr()).$reg_ddr.modify(|r, w| {
-                                w.bits(r.bits() | (1 << $i))
-                            });
-                        }
-                        Ok(())
-                    }
-                }
-
-                impl digital::InputPin for $PXi<mode::TriState> {
-                    type Error = Void;
-
-                    fn is_high(&self) -> Result<bool, Self::Error> {
-                        Ok(unsafe {
-                            (*<$PORTX>::ptr()).$reg_pin.read().bits()
-                        } & (1 << $i) != 0)
-                    }
-
-                    fn is_low(&self) -> Result<bool, Self::Error> {
-                        Ok(unsafe {
-                            (*<$PORTX>::ptr()).$reg_pin.read().bits()
-                        } & (1 << $i) == 0)
-                    }
-                }
-
-                // -------------------------------------------------------- }}}
-            )+
-        }
-    };
+    }
 }
 
-/// Create a pin reexport struct for convenient access
-#[macro_export]
-macro_rules! impl_board_pins {
-    (
-        #[port_defs]
-        use $portpath:path;
+/// # Digital Output
+impl<PIN: PinOps> Pin<mode::Output, PIN> {
+    /// Set pin high (pull it to supply voltage).
+    #[inline]
+    pub fn set_high(&mut self) {
+        unsafe { self.pin.out_set() }
+    }
 
-        $(#[$ddr_attr:meta])*
-        pub struct $DDR:ident {
-            $($portx:ident: $PORTX:ty,)+
+    /// Set pin low (pull it to GND).
+    #[inline]
+    pub fn set_low(&mut self) {
+        unsafe { self.pin.out_clear() }
+    }
+
+    /// Toggle a high pin to low and a low pin to high.
+    #[inline]
+    pub fn toggle(&mut self) {
+        unsafe { self.pin.out_toggle() }
+    }
+
+    /// Check whether the pin is set high.
+    ///
+    /// *Note*: The electrical state of the pin might differ due to external circuitry.
+    #[inline]
+    pub fn is_set_high(&self) -> bool {
+        unsafe { self.pin.out_get() }
+    }
+
+    /// Check whether the pin is set low.
+    ///
+    /// *Note*: The electrical state of the pin might differ due to external circuitry.
+    #[inline]
+    pub fn is_set_low(&self) -> bool {
+        !unsafe { self.pin.out_get() }
+    }
+}
+
+/// # Digital Input
+impl<PIN: PinOps, IMODE: mode::InputMode> Pin<mode::Input<IMODE>, PIN> {
+    /// Check whether the pin is driven high.
+    #[inline]
+    pub fn is_high(&self) -> bool {
+        unsafe { self.pin.in_get() }
+    }
+
+    /// Check whether the pin is driven low.
+    #[inline]
+    pub fn is_low(&self) -> bool {
+        !unsafe { self.pin.in_get() }
+    }
+}
+
+#[macro_export]
+macro_rules! impl_port_traditional {
+    (
+        enum Ports {
+            $($PortName:ident: ($Port:ty, $port_port_reg:ident, $port_pin_reg:ident, $port_ddr_reg:ident),)+
         }
 
         $(#[$pins_attr:meta])*
-        pub struct $Pins:ident {
-            $(
-                $(#[$pin_attr:meta])*
-                pub $name:ident: $pinport:ident::$pin:ident::$Pin:ident,
-            )+
+        pub struct Pins {
+            $($pin:ident: $Pin:ident = ($PinPort:ty, $PinPortName:ident, $pin_num:expr,
+                                        $pin_port_reg:ident, $pin_pin_reg:ident,
+                                        $pin_ddr_reg:ident),)+
         }
     ) => {
-        use $portpath::{$($portx),+};
+        pub use $crate::port::mode;
+        pub type Pin<MODE, PIN = Dynamic> = $crate::port::Pin<MODE, PIN>;
 
-        $(#[$ddr_attr])*
-        pub struct $DDR {
-            $($portx: $portx::DDR,)+
+        $(#[$pins_attr])*
+        pub struct Pins {
+            $(pub $pin: Pin<
+                mode::Input<mode::Floating>,
+                $Pin,
+            >,)+
+        }
+
+        impl Pins {
+            pub fn new(
+                $(_: $Port,)+
+            ) -> Self {
+                Self {
+                    $($pin: $crate::port::Pin::new(
+                        $Pin { _private: (), }
+                    ),)+
+                }
+            }
+        }
+
+        #[repr(u8)]
+        pub enum DynamicPort {
+            $($PortName,)+
+        }
+
+        pub struct Dynamic {
+            port: DynamicPort,
+            // We'll store the mask instead of the pin number because this allows much less code to
+            // be generated for the trait method implementations.
+            mask: u8,
+        }
+
+        impl Dynamic {
+            fn new(port: DynamicPort, pin_num: u8) -> Self {
+                Self {
+                    port,
+                    mask: 1 << pin_num,
+                }
+            }
+        }
+
+        impl $crate::port::PinOps for Dynamic {
+            type Dynamic = Self;
+
+            #[inline]
+            fn into_dynamic(self) -> Self::Dynamic {
+                self
+            }
+
+            #[inline]
+            unsafe fn out_set(&mut self) {
+                match self.port {
+                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_port_reg.modify(|r, w| {
+                        w.bits(r.bits() | self.mask)
+                    }),)+
+                }
+            }
+
+            #[inline]
+            unsafe fn out_clear(&mut self) {
+                match self.port {
+                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_port_reg.modify(|r, w| {
+                        w.bits(r.bits() & !self.mask)
+                    }),)+
+                }
+            }
+
+            #[inline]
+            unsafe fn out_toggle(&mut self) {
+                match self.port {
+                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_pin_reg.modify(|r, w| {
+                        w.bits(r.bits() | self.mask)
+                    }),)+
+                }
+            }
+
+            #[inline]
+            unsafe fn out_get(&self) -> bool {
+                match self.port {
+                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_port_reg.read().bits()
+                        & self.mask != 0,)+
+                }
+            }
+
+            #[inline]
+            unsafe fn in_get(&self) -> bool {
+                match self.port {
+                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_pin_reg.read().bits()
+                        & self.mask != 0,)+
+                }
+            }
+
+            #[inline]
+            unsafe fn make_output(&mut self) {
+                match self.port {
+                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_ddr_reg.modify(|r, w| {
+                        w.bits(r.bits() | self.mask)
+                    }),)+
+                }
+            }
+
+            #[inline]
+            unsafe fn make_input(&mut self, pull_up: bool) {
+                match self.port {
+                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_ddr_reg.modify(|r, w| {
+                        w.bits(r.bits() & !self.mask)
+                    }),)+
+                }
+                if pull_up {
+                    self.out_clear()
+                } else {
+                    self.out_set()
+                }
+            }
         }
 
         $(
-            impl $portx::AsDDR for $DDR {
-                fn as_ddr(&self) -> &$portx::DDR {
-                    &self.$portx
+            pub struct $Pin {
+                _private: ()
+            }
+
+            impl $crate::port::PinOps for $Pin {
+                type Dynamic = Dynamic;
+
+                #[inline]
+                fn into_dynamic(self) -> Self::Dynamic {
+                    Dynamic::new(DynamicPort::$PinPortName, $pin_num)
+                }
+
+                #[inline]
+                unsafe fn out_set(&mut self) {
+                    (*<$PinPort>::ptr()).$pin_port_reg.modify(|r, w| {
+                        w.bits(r.bits() | (1 << $pin_num))
+                    })
+                }
+
+                #[inline]
+                unsafe fn out_clear(&mut self) {
+                    (*<$PinPort>::ptr()).$pin_port_reg.modify(|r, w| {
+                        w.bits(r.bits() & !(1 << $pin_num))
+                    })
+                }
+
+                #[inline]
+                unsafe fn out_toggle(&mut self) {
+                    (*<$PinPort>::ptr()).$pin_pin_reg.modify(|r, w| {
+                        w.bits(r.bits() | (1 << $pin_num))
+                    })
+                }
+
+                #[inline]
+                unsafe fn out_get(&self) -> bool {
+                    (*<$PinPort>::ptr()).$pin_port_reg.read().bits() & (1 << $pin_num) != 0
+                }
+
+                #[inline]
+                unsafe fn in_get(&self) -> bool {
+                    (*<$PinPort>::ptr()).$pin_pin_reg.read().bits() & (1 << $pin_num) != 0
+                }
+
+                #[inline]
+                unsafe fn make_output(&mut self) {
+                    (*<$PinPort>::ptr()).$pin_ddr_reg.modify(|r, w| {
+                        w.bits(r.bits() | (1 << $pin_num))
+                    })
+                }
+
+                #[inline]
+                unsafe fn make_input(&mut self, pull_up: bool) {
+                    (*<$PinPort>::ptr()).$pin_ddr_reg.modify(|r, w| {
+                        w.bits(r.bits() & !(1 << $pin_num))
+                    });
+                    if pull_up {
+                        self.out_clear()
+                    } else {
+                        self.out_set()
+                    }
                 }
             }
         )+
+    };
+}
 
+#[macro_export]
+macro_rules! renamed_pins {
+    (
+        type Pin = $PinType:ident;
+
+        $(#[$pins_attr:meta])*
+        pub struct Pins from $McuPins:ty {
+            $($(#[$pin_attr:meta])* pub $pin:ident: $Pin:ty = $pin_orig:ident,)+
+        }
+    ) => {
         $(#[$pins_attr])*
-        pub struct $Pins {
-            pub ddr: $DDR,
-            $(
-                $(#[$pin_attr])*
-                pub $name: $pinport::$Pin<
-                    $crate::port::mode::Input<$crate::port::mode::Floating>
-                >,
-            )+
+        pub struct Pins {
+            $($(#[$pin_attr])*
+            pub $pin: $PinType<
+                $crate::port::mode::Input<$crate::port::mode::Floating>,
+                $Pin,
+            >,)+
         }
 
-        impl $Pins {
-            pub fn new($($portx: $PORTX),+) -> $Pins {
-                $(let $portx = $portx.split();)+
-
-                $Pins {
-                    ddr: $DDR {
-                        $($portx: $portx.ddr,)+
-                    },
-                    $($name: $pinport.$pin,)+
+        impl Pins {
+            pub fn with_mcu_pins(pins: $McuPins) -> Self {
+                Self {
+                    $($pin: pins.$pin_orig,)+
                 }
             }
         }

--- a/avr-hal-generic/src/usart.rs
+++ b/avr-hal-generic/src/usart.rs
@@ -428,27 +428,27 @@ macro_rules! impl_usart_traditional {
     (
         peripheral: $USART:ty,
         register_suffix: $n:expr,
-        rx: $rxmod:ident::$RX:ident,
-        tx: $txmod:ident::$TX:ident,
+        rx: $rxpin:ty,
+        tx: $txpin:ty,
     ) => {
         $crate::paste::paste! {
             impl $crate::usart::UsartOps<
-                $rxmod::$RX<$crate::port::mode::Input<$crate::port::mode::Floating>>,
-                $txmod::$TX<$crate::port::mode::Output>,
+                $crate::port::Pin<$crate::port::mode::Input<$crate::port::mode::Floating>, $rxpin>,
+                $crate::port::Pin<$crate::port::mode::Output, $txpin>,
             > for $USART {
                 fn raw_init<CLOCK>(&mut self, baudrate: $crate::usart::Baudrate<CLOCK>) {
-                    self.[<ubrr $n>].write(|w| unsafe { w.bits(baudrate.ubrr) });
-                    self.[<ucsr $n a>].write(|w| w.[<u2x $n>]().bit(baudrate.u2x));
+                    self.0.[<ubrr $n>].write(|w| unsafe { w.bits(baudrate.ubrr) });
+                    self.0.[<ucsr $n a>].write(|w| w.[<u2x $n>]().bit(baudrate.u2x));
 
                     // Enable receiver and transmitter but leave interrupts disabled.
-                    self.[<ucsr $n b>].write(|w| w
+                    self.0.[<ucsr $n b>].write(|w| w
                         .[<txen $n>]().set_bit()
                         .[<rxen $n>]().set_bit()
                     );
 
                     // Set frame format to 8n1 for now.  At some point, this should be made
                     // configurable, similar to what is done in other HALs.
-                    self.[<ucsr $n c>].write(|w| w
+                    self.0.[<ucsr $n c>].write(|w| w
                         .[<umsel $n>]().usart_async()
                         .[<ucsz $n>]().chr8()
                         .[<usbs $n>]().stop1()
@@ -459,11 +459,11 @@ macro_rules! impl_usart_traditional {
                 fn raw_deinit(&mut self) {
                     // Wait for any ongoing transfer to finish.
                     $crate::nb::block!(self.raw_flush()).ok();
-                    self.[<ucsr $n b>].reset();
+                    self.0.[<ucsr $n b>].reset();
                 }
 
                 fn raw_flush(&mut self) -> $crate::nb::Result<(), $crate::void::Void> {
-                    if self.[<ucsr $n a>].read().[<udre $n>]().bit_is_clear() {
+                    if self.0.[<ucsr $n a>].read().[<udre $n>]().bit_is_clear() {
                         Err($crate::nb::Error::WouldBlock)
                     } else {
                         Ok(())
@@ -474,24 +474,24 @@ macro_rules! impl_usart_traditional {
                     // Call flush to make sure the data-register is empty
                     self.raw_flush()?;
 
-                    self.[<udr $n>].write(|w| unsafe { w.bits(byte) });
+                    self.0.[<udr $n>].write(|w| unsafe { w.bits(byte) });
                     Ok(())
                 }
 
                 fn raw_read(&mut self) -> $crate::nb::Result<u8, $crate::void::Void> {
-                    if self.[<ucsr $n a>].read().[<rxc $n>]().bit_is_clear() {
+                    if self.0.[<ucsr $n a>].read().[<rxc $n>]().bit_is_clear() {
                         return Err($crate::nb::Error::WouldBlock);
                     }
 
-                    Ok(self.[<udr $n>].read().bits())
+                    Ok(self.0.[<udr $n>].read().bits())
                 }
 
                 fn raw_interrupt(&mut self, event: $crate::usart::Event, state: bool) {
                     match event {
                         $crate::usart::Event::RxComplete =>
-                            self.[<ucsr $n b>].modify(|_, w| w.[<rxcie $n>]().bit(state)),
+                            self.0.[<ucsr $n b>].modify(|_, w| w.[<rxcie $n>]().bit(state)),
                         $crate::usart::Event::DataRegisterEmpty =>
-                            self.[<ucsr $n b>].modify(|_, w| w.[<txcie $n>]().bit(state)),
+                            self.0.[<ucsr $n b>].modify(|_, w| w.[<txcie $n>]().bit(state)),
                     }
                 }
             }

--- a/examples/arduino-leonardo/.cargo/config.toml
+++ b/examples/arduino-leonardo/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-atmega32u4.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "../../boards/arduino-leonardo/leonardo-runner.sh"
+
+[unstable]
+build-std = ["core"]

--- a/examples/arduino-leonardo/Cargo.toml
+++ b/examples/arduino-leonardo/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "arduino-leonardo-examples"
+version = "0.0.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+ufmt = "0.1.0"
+nb = "0.1.2"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["arduino-leonardo"]

--- a/examples/arduino-leonardo/src/bin/leonardo-blink.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-blink.rs
@@ -1,0 +1,29 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+
+    let mut leds = [
+        dp.pins.led_rx.into_output().downgrade(),
+        dp.pins.led_tx.into_output().downgrade(),
+        dp.pins.d13.into_output().downgrade(),
+    ];
+
+    // RX & TX LEDs are active low and the LED on D13 is active high.  Thus invert LED13 here so
+    // they are all in the same "state":
+    leds[0].set_high();
+    leds[1].set_high();
+    leds[2].set_low();
+
+    loop {
+        for i in 0..3 {
+            leds[i].toggle();
+            arduino_hal::delay_ms(100);
+            leds[i].toggle();
+        }
+    }
+}

--- a/examples/arduino-leonardo/src/bin/leonardo-usart.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-usart.rs
@@ -1,0 +1,29 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+use embedded_hal::serial::Read;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+
+    let mut serial = arduino_hal::Usart::new(
+        dp.USART1,
+        dp.pins.d0,
+        dp.pins.d1.into_output(),
+        57600.into_baudrate(),
+    );
+
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+
+    loop {
+        // Read a byte from the serial connection
+        let b = nb::block!(serial.read()).void_unwrap();
+
+        // Answer
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+    }
+}

--- a/examples/arduino-uno/.cargo/config.toml
+++ b/examples/arduino-uno/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-atmega328p.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "../../boards/arduino-uno/uno-runner.sh"
+
+[unstable]
+build-std = ["core"]

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "arduino-uno-examples"
+version = "0.0.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+ufmt = "0.1.0"
+nb = "0.1.2"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["arduino-uno"]

--- a/examples/arduino-uno/src/bin/uno-blink.rs
+++ b/examples/arduino-uno/src/bin/uno-blink.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+
+    // Digital pin 13 is also connected to an onboard LED marked "L"
+    let mut led = dp.pins.d13.into_output();
+    led.set_high();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(800);
+    }
+}

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -1,0 +1,29 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+use embedded_hal::serial::Read;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+
+    let mut serial = arduino_hal::Usart::new(
+        dp.USART0,
+        dp.pins.d0,
+        dp.pins.d1.into_output(),
+        57600.into_baudrate(),
+    );
+
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+
+    loop {
+        // Read a byte from the serial connection
+        let b = nb::block!(serial.read()).void_unwrap();
+
+        // Answer
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+    }
+}

--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "atmega-hal"
+version = "0.1.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
+
+[features]
+rt = ["avr-device/rt"]
+device-selected = []
+atmega328p = ["avr-device/atmega328p", "device-selected"]
+atmega328pb = ["avr-device/atmega328pb", "device-selected"]
+
+# Allow certain downstream crates to overwrite the device selection error by themselves.
+disable-device-selection-error = []
+
+[dependencies]
+avr-hal-generic = { path = "../../avr-hal-generic/" }
+
+[dependencies.avr-device]
+version = "0.3"
+
+# Because this crate has its own check that at least one device is selected, we
+# can safely "circumvent" the check in `avr-device`.
+#
+# Why would we want that?  Otherwise, as `avr-device` is compiled first, its
+# error will be shown and ours won't which leads to a degraded user experience
+# as the displayed error message does not really tell what needs to be done...
+features = ["device-selected"]

--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -9,6 +9,7 @@ rt = ["avr-device/rt"]
 device-selected = []
 atmega328p = ["avr-device/atmega328p", "device-selected"]
 atmega328pb = ["avr-device/atmega328pb", "device-selected"]
+atmega32u4 = ["avr-device/atmega32u4", "device-selected"]
 
 # Allow certain downstream crates to overwrite the device selection error by themselves.
 disable-device-selection-error = []

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -16,6 +16,9 @@ compile_error!(
 /// Reexport of `atmega328p` from `avr-device`
 #[cfg(feature = "atmega328p")]
 pub use avr_device::atmega328p as pac;
+/// Reexport of `atmega32u4` from `avr-device`
+#[cfg(feature = "atmega32u4")]
+pub use avr_device::atmega32u4 as pac;
 
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
@@ -42,6 +45,8 @@ pub struct Peripherals {
     pub pins: Pins,
     #[cfg(feature = "atmega328p")]
     pub USART0: RawPeripheral<pac::USART0>,
+    #[cfg(feature = "atmega32u4")]
+    pub USART1: RawPeripheral<pac::USART1>,
 }
 
 #[cfg(feature = "device-selected")]
@@ -50,8 +55,13 @@ impl Peripherals {
         Self {
             #[cfg(feature = "atmega328p")]
             pins: Pins::new(dp.PORTB, dp.PORTC, dp.PORTD),
+            #[cfg(feature = "atmega32u4")]
+            pins: Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF),
+
             #[cfg(feature = "atmega328p")]
             USART0: RawPeripheral(dp.USART0),
+            #[cfg(feature = "atmega32u4")]
+            USART1: RawPeripheral(dp.USART1),
         }
     }
 

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -1,0 +1,61 @@
+#![no_std]
+
+#[cfg(all(
+    not(feature = "device-selected"),
+    not(feature = "disable-device-selection-error")
+))]
+compile_error!(
+    "This crate requires you to specify your target chip as a feature.
+
+    Please select one of the following
+
+    * atmega328p
+    "
+);
+
+/// Reexport of `atmega328p` from `avr-device`
+#[cfg(feature = "atmega328p")]
+pub use avr_device::atmega328p as pac;
+
+/// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
+#[cfg(feature = "rt")]
+pub use avr_device::entry;
+
+pub use avr_hal_generic::clock;
+pub use avr_hal_generic::delay;
+
+#[cfg(feature = "device-selected")]
+pub mod port;
+#[cfg(feature = "device-selected")]
+pub use port::Pins;
+
+#[cfg(feature = "device-selected")]
+pub mod usart;
+#[cfg(feature = "device-selected")]
+pub use usart::Usart;
+
+pub struct RawPeripheral<P>(pub(crate) P);
+
+#[allow(non_snake_case)]
+#[cfg(feature = "device-selected")]
+pub struct Peripherals {
+    pub pins: Pins,
+    #[cfg(feature = "atmega328p")]
+    pub USART0: RawPeripheral<pac::USART0>,
+}
+
+#[cfg(feature = "device-selected")]
+impl Peripherals {
+    fn new(dp: pac::Peripherals) -> Self {
+        Self {
+            #[cfg(feature = "atmega328p")]
+            pins: Pins::new(dp.PORTB, dp.PORTC, dp.PORTD),
+            #[cfg(feature = "atmega328p")]
+            USART0: RawPeripheral(dp.USART0),
+        }
+    }
+
+    pub fn take() -> Option<Self> {
+        pac::Peripherals::take().map(Self::new)
+    }
+}

--- a/mcu/atmega-hal/src/port.rs
+++ b/mcu/atmega-hal/src/port.rs
@@ -1,0 +1,34 @@
+#[cfg(feature = "atmega328p")]
+avr_hal_generic::impl_port_traditional! {
+    enum Ports {
+        PORTB: (crate::pac::PORTB, portb, pinb, ddrb),
+        PORTC: (crate::pac::PORTC, portc, pinc, ddrc),
+        PORTD: (crate::pac::PORTD, portd, pind, ddrd),
+    }
+
+    pub struct Pins {
+        pb0: PB0 = (crate::pac::PORTB, PORTB, 0, portb, pinb, ddrb),
+        pb1: PB1 = (crate::pac::PORTB, PORTB, 1, portb, pinb, ddrb),
+        pb2: PB2 = (crate::pac::PORTB, PORTB, 2, portb, pinb, ddrb),
+        pb3: PB3 = (crate::pac::PORTB, PORTB, 3, portb, pinb, ddrb),
+        pb4: PB4 = (crate::pac::PORTB, PORTB, 4, portb, pinb, ddrb),
+        pb5: PB5 = (crate::pac::PORTB, PORTB, 5, portb, pinb, ddrb),
+        pb6: PB6 = (crate::pac::PORTB, PORTB, 6, portb, pinb, ddrb),
+        pb7: PB7 = (crate::pac::PORTB, PORTB, 7, portb, pinb, ddrb),
+        pc0: PC0 = (crate::pac::PORTC, PORTC, 0, portc, pinc, ddrc),
+        pc1: PC1 = (crate::pac::PORTC, PORTC, 1, portc, pinc, ddrc),
+        pc2: PC2 = (crate::pac::PORTC, PORTC, 2, portc, pinc, ddrc),
+        pc3: PC3 = (crate::pac::PORTC, PORTC, 3, portc, pinc, ddrc),
+        pc4: PC4 = (crate::pac::PORTC, PORTC, 4, portc, pinc, ddrc),
+        pc5: PC5 = (crate::pac::PORTC, PORTC, 5, portc, pinc, ddrc),
+        pc6: PC6 = (crate::pac::PORTC, PORTC, 6, portc, pinc, ddrc),
+        pd0: PD0 = (crate::pac::PORTD, PORTD, 0, portd, pind, ddrd),
+        pd1: PD1 = (crate::pac::PORTD, PORTD, 1, portd, pind, ddrd),
+        pd2: PD2 = (crate::pac::PORTD, PORTD, 2, portd, pind, ddrd),
+        pd3: PD3 = (crate::pac::PORTD, PORTD, 3, portd, pind, ddrd),
+        pd4: PD4 = (crate::pac::PORTD, PORTD, 4, portd, pind, ddrd),
+        pd5: PD5 = (crate::pac::PORTD, PORTD, 5, portd, pind, ddrd),
+        pd6: PD6 = (crate::pac::PORTD, PORTD, 6, portd, pind, ddrd),
+        pd7: PD7 = (crate::pac::PORTD, PORTD, 7, portd, pind, ddrd),
+    }
+}

--- a/mcu/atmega-hal/src/port.rs
+++ b/mcu/atmega-hal/src/port.rs
@@ -32,3 +32,43 @@ avr_hal_generic::impl_port_traditional! {
         pd7: PD7 = (crate::pac::PORTD, PORTD, 7, portd, pind, ddrd),
     }
 }
+
+#[cfg(feature = "atmega32u4")]
+avr_hal_generic::impl_port_traditional! {
+    enum Ports {
+        PORTB: (crate::pac::PORTB, portb, pinb, ddrb),
+        PORTC: (crate::pac::PORTC, portc, pinc, ddrc),
+        PORTD: (crate::pac::PORTD, portd, pind, ddrd),
+        PORTE: (crate::pac::PORTE, porte, pine, ddre),
+        PORTF: (crate::pac::PORTF, portf, pinf, ddrf),
+    }
+
+    pub struct Pins {
+        pb0: PB0 = (crate::pac::PORTB, PORTB, 0, portb, pinb, ddrb),
+        pb1: PB1 = (crate::pac::PORTB, PORTB, 1, portb, pinb, ddrb),
+        pb2: PB2 = (crate::pac::PORTB, PORTB, 2, portb, pinb, ddrb),
+        pb3: PB3 = (crate::pac::PORTB, PORTB, 3, portb, pinb, ddrb),
+        pb4: PB4 = (crate::pac::PORTB, PORTB, 4, portb, pinb, ddrb),
+        pb5: PB5 = (crate::pac::PORTB, PORTB, 5, portb, pinb, ddrb),
+        pb6: PB6 = (crate::pac::PORTB, PORTB, 6, portb, pinb, ddrb),
+        pb7: PB7 = (crate::pac::PORTB, PORTB, 7, portb, pinb, ddrb),
+        pc6: PC6 = (crate::pac::PORTC, PORTC, 6, portc, pinc, ddrc),
+        pc7: PC7 = (crate::pac::PORTC, PORTC, 7, portc, pinc, ddrc),
+        pd0: PD0 = (crate::pac::PORTD, PORTD, 0, portd, pind, ddrd),
+        pd1: PD1 = (crate::pac::PORTD, PORTD, 1, portd, pind, ddrd),
+        pd2: PD2 = (crate::pac::PORTD, PORTD, 2, portd, pind, ddrd),
+        pd3: PD3 = (crate::pac::PORTD, PORTD, 3, portd, pind, ddrd),
+        pd4: PD4 = (crate::pac::PORTD, PORTD, 4, portd, pind, ddrd),
+        pd5: PD5 = (crate::pac::PORTD, PORTD, 5, portd, pind, ddrd),
+        pd6: PD6 = (crate::pac::PORTD, PORTD, 6, portd, pind, ddrd),
+        pd7: PD7 = (crate::pac::PORTD, PORTD, 7, portd, pind, ddrd),
+        pe2: PE2 = (crate::pac::PORTE, PORTE, 2, porte, pine, ddre),
+        pe6: PE6 = (crate::pac::PORTE, PORTE, 6, porte, pine, ddre),
+        pf0: PF0 = (crate::pac::PORTF, PORTF, 0, portf, pinf, ddrf),
+        pf1: PF1 = (crate::pac::PORTF, PORTF, 1, portf, pinf, ddrf),
+        pf4: PF4 = (crate::pac::PORTF, PORTF, 4, portf, pinf, ddrf),
+        pf5: PF5 = (crate::pac::PORTF, PORTF, 5, portf, pinf, ddrf),
+        pf6: PF6 = (crate::pac::PORTF, PORTF, 6, portf, pinf, ddrf),
+        pf7: PF7 = (crate::pac::PORTF, PORTF, 7, portf, pinf, ddrf),
+    }
+}

--- a/mcu/atmega-hal/src/usart.rs
+++ b/mcu/atmega-hal/src/usart.rs
@@ -16,3 +16,18 @@ avr_hal_generic::impl_usart_traditional! {
     rx: port::PD0,
     tx: port::PD1,
 }
+
+#[cfg(feature = "atmega32u4")]
+pub type Usart1<CLOCK, IMODE> = Usart<
+    crate::RawPeripheral<crate::pac::USART1>,
+    port::Pin<port::mode::Input<IMODE>, port::PD2>,
+    port::Pin<port::mode::Output, port::PD3>,
+    CLOCK,
+>;
+#[cfg(feature = "atmega32u4")]
+avr_hal_generic::impl_usart_traditional! {
+    peripheral: crate::RawPeripheral<crate::pac::USART1>,
+    register_suffix: 1,
+    rx: port::PD2,
+    tx: port::PD3,
+}

--- a/mcu/atmega-hal/src/usart.rs
+++ b/mcu/atmega-hal/src/usart.rs
@@ -1,0 +1,18 @@
+pub use avr_hal_generic::usart::*;
+#[allow(unused_imports)]
+use crate::port;
+
+#[cfg(feature = "atmega328p")]
+pub type Usart0<CLOCK, IMODE> = Usart<
+    crate::RawPeripheral<crate::pac::USART0>,
+    port::Pin<port::mode::Input<IMODE>, port::PD0>,
+    port::Pin<port::mode::Output, port::PD1>,
+    CLOCK,
+>;
+#[cfg(feature = "atmega328p")]
+avr_hal_generic::impl_usart_traditional! {
+    peripheral: crate::RawPeripheral<crate::pac::USART0>,
+    register_suffix: 0,
+    rx: port::PD0,
+    tx: port::PD1,
+}


### PR DESCRIPTION
So, it's finally time:  I've gotten around to starting work on the big refactor that got more and more inevitable from issues like #114, #94, and #117.

Right now, the state is just barely enough to blink an LED on Arduino Uno.  I wanted to get this out as quickly as possible to initiate discussions on the design.  As this work will take a while to complete, we will go about it like this:  `master` stays with the current architecture for now until the new design reaches feature-parity.  Until then, we will use the `next` branch to get it there.  Thus, this PR will be merged into `next` instead of `master`.

#### TODO
- [x] Re-write documentation for the `port` module.
- [x] Test integration with the already refactored USART.
- [x] Add basic Arduino Leonardo support to see how that works out.