### PR TITLE
Adds parametrized duty for `impl_pwm` macro

### DIFF
--- a/avr-hal-generic/src/pwm.rs
+++ b/avr-hal-generic/src/pwm.rs
@@ -36,6 +36,7 @@ macro_rules! impl_pwm {
     (
         $(#[$timer_pwm_attr:meta])*
         pub struct $TimerPwm:ident {
+            type Duty: $Duty:ty,
             timer: $TIMER:ty,
             init: |$init_timer:ident, $prescaler:ident| $init_block:block,
             pins: {$(
@@ -76,7 +77,7 @@ macro_rules! impl_pwm {
             }
 
             impl $crate::hal::PwmPin for $port::$PXi<$crate::port::mode::Pwm<$TimerPwm>> {
-                type Duty = u8;
+                type Duty = $Duty;
 
                 fn enable(&mut self) {
                     // SAFETY: This block will usually result in a read-modify-write sequence which
@@ -103,7 +104,7 @@ macro_rules! impl_pwm {
                 }
 
                 fn get_max_duty(&self) -> Self::Duty {
-                    u8::MAX
+                    Self::Duty::MAX
                 }
 
                 fn set_duty(&mut self, duty: Self::Duty) {

--- a/chips/atmega168-hal/src/pwm.rs
+++ b/chips/atmega168-hal/src/pwm.rs
@@ -43,6 +43,7 @@ avr_hal_generic::impl_pwm! {
     /// pd5.enable();
     /// ```
     pub struct Timer0Pwm {
+        type Duty: u8,
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
@@ -90,6 +91,7 @@ avr_hal_generic::impl_pwm! {
     /// pb1.enable();
     /// ```
     pub struct Timer1Pwm {
+        type Duty: u16,
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
@@ -141,6 +143,7 @@ avr_hal_generic::impl_pwm! {
     /// pb3.enable();
     /// ```
     pub struct Timer2Pwm {
+        type Duty: u8,
         timer: crate::pac::TC2,
         init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().pwm_fast());

--- a/chips/atmega2560-hal/src/pwm.rs
+++ b/chips/atmega2560-hal/src/pwm.rs
@@ -53,6 +53,7 @@ avr_hal_generic::impl_pwm! {
     /// pb7.enable();
     /// ```
     pub struct Timer0Pwm {
+        type Duty: u8,
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
@@ -103,6 +104,7 @@ avr_hal_generic::impl_pwm! {
     ///
     /// **Note**: For `PB7` the method is called `into_pwm1()`!
     pub struct Timer1Pwm {
+        type Duty: u16,
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
@@ -162,6 +164,7 @@ avr_hal_generic::impl_pwm! {
     /// pb4.enable();
     /// ```
     pub struct Timer2Pwm {
+        type Duty: u8,
         timer: crate::pac::TC2,
         init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().bits(0b01));
@@ -213,6 +216,7 @@ avr_hal_generic::impl_pwm! {
     /// pe3.enable();
     /// ```
     pub struct Timer3Pwm {
+        type Duty: u16,
         timer: crate::pac::TC3,
         init: |tim, prescaler| {
             tim.tccr3a.modify(|_, w| w.wgm3().bits(0b01));
@@ -272,6 +276,7 @@ avr_hal_generic::impl_pwm! {
     /// ph3.enable();
     /// ```
     pub struct Timer4Pwm {
+        type Duty: u16,
         timer: crate::pac::TC4,
         init: |tim, prescaler| {
             tim.tccr4a.modify(|_, w| w.wgm4().bits(0b01));
@@ -331,6 +336,7 @@ avr_hal_generic::impl_pwm! {
     /// pl3.enable();
     /// ```
     pub struct Timer5Pwm {
+        type Duty: u16,
         timer: crate::pac::TC5,
         init: |tim, prescaler| {
             tim.tccr5a.modify(|_, w| w.wgm5().bits(0b01));

--- a/chips/atmega328p-hal/src/pwm.rs
+++ b/chips/atmega328p-hal/src/pwm.rs
@@ -43,6 +43,7 @@ avr_hal_generic::impl_pwm! {
     /// pd5.enable();
     /// ```
     pub struct Timer0Pwm {
+        type Duty: u8,
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
@@ -90,6 +91,7 @@ avr_hal_generic::impl_pwm! {
     /// pb1.enable();
     /// ```
     pub struct Timer1Pwm {
+        type Duty: u16,
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
@@ -141,6 +143,7 @@ avr_hal_generic::impl_pwm! {
     /// pb3.enable();
     /// ```
     pub struct Timer2Pwm {
+        type Duty: u8,
         timer: crate::pac::TC2,
         init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().pwm_fast());
@@ -189,6 +192,7 @@ avr_hal_generic::impl_pwm! {
     /// pd1.enable();
     /// ```
     pub struct Timer3Pwm {
+        type Duty: u16,
         timer: crate::pac::TC3,
         init: |tim, prescaler| {
             tim.tccr3a.modify(|_, w| w.wgm3().bits(0b01));
@@ -241,6 +245,7 @@ avr_hal_generic::impl_pwm! {
     /// pd1.enable();
     /// ```
     pub struct Timer4Pwm {
+        type Duty: u16,
         timer: crate::pac::TC4,
         init: |tim, prescaler| {
             tim.tccr4a.modify(|_, w| w.wgm4().bits(0b01));

--- a/chips/atmega32u4-hal/src/pwm.rs
+++ b/chips/atmega32u4-hal/src/pwm.rs
@@ -45,6 +45,7 @@ avr_hal_generic::impl_pwm! {
     /// pb7.enable();
     /// ```
     pub struct Timer0Pwm {
+        type Duty: u8,
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
@@ -95,6 +96,7 @@ avr_hal_generic::impl_pwm! {
     ///
     /// **Note**: For `PB7` the method is called `into_pwm1()`!
     pub struct Timer1Pwm {
+        type Duty: u16,
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
@@ -152,6 +154,7 @@ avr_hal_generic::impl_pwm! {
     /// pc6.enable();
     /// ```
     pub struct Timer3Pwm {
+        type Duty: u16,
         timer: crate::pac::TC3,
         init: |tim, prescaler| {
             tim.tccr3a.modify(|_, w| w.wgm3().bits(0b01));
@@ -199,6 +202,7 @@ avr_hal_generic::impl_pwm! {
     ///
     /// **Note**: For `PB6` the method is called `into_pwm6()`!
     pub struct Timer4Pwm {
+        type Duty: u8,
         timer: crate::pac::TC4,
         init: |tim, prescaler| {
             tim.tccr4b.modify(|_, w| match prescaler {

--- a/chips/atmega48p-hal/src/pwm.rs
+++ b/chips/atmega48p-hal/src/pwm.rs
@@ -43,6 +43,7 @@ avr_hal_generic::impl_pwm! {
     /// pd5.enable();
     /// ```
     pub struct Timer0Pwm {
+        type Duty: u8,
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
             tim.tccr0a.modify(|_, w| w.wgm0().pwm_fast());
@@ -90,6 +91,7 @@ avr_hal_generic::impl_pwm! {
     /// pb1.enable();
     /// ```
     pub struct Timer1Pwm {
+        type Duty: u16,
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
             tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
@@ -141,6 +143,7 @@ avr_hal_generic::impl_pwm! {
     /// pb3.enable();
     /// ```
     pub struct Timer2Pwm {
+        type Duty: u8,
         timer: crate::pac::TC2,
         init: |tim, prescaler| {
             tim.tccr2a.modify(|_, w| w.wgm2().pwm_fast());


### PR DESCRIPTION
32u4 require closer look. Not sure what to do with10 bit counter. Other chips verified with datasheets, at least timer1 on 328p works like a charm with 16 bit counter.