### PR TITLE
Fixes serial port number on macos

### DIFF
--- a/boards/arduino-leonardo/leonardo-runner.sh
+++ b/boards/arduino-leonardo/leonardo-runner.sh
@@ -24,7 +24,7 @@ fi
 if [ $OS = "Linux" ]; then
     SERIAL_PORT="/dev/ttyACM0"
 elif [ $OS = "Mac" ]; then
-    SERIAL_PORT="/dev/cu.usbmodem146201"
+    SERIAL_PORT="/dev/cu.usbmodem14201"
 else
     echo "unsupported OS, things might not work" >&2
     SERIAL_PORT="/dev/ttyACM0"

--- a/boards/arduino-uno/uno-runner.sh
+++ b/boards/arduino-uno/uno-runner.sh
@@ -24,7 +24,7 @@ fi
 if [ $OS = "Linux" ]; then
     SERIAL_PORT="/dev/ttyACM0"
 elif [ $OS = "Mac" ]; then
-    SERIAL_PORT="/dev/cu.usbmodem146201"
+    SERIAL_PORT="/dev/cu.usbmodem14201"
 else
     echo "unsupported OS, things might not work" >&2
     SERIAL_PORT="/dev/ttyACM0"

--- a/boards/sparkfun-pro-micro/pro-micro-runner.sh
+++ b/boards/sparkfun-pro-micro/pro-micro-runner.sh
@@ -24,7 +24,7 @@ fi
 if [ $OS = "Linux" ]; then
     SERIAL_PORT="/dev/ttyACM0"
 elif [ $OS = "Mac" ]; then
-    SERIAL_PORT="/dev/cu.usbmodem146201"
+    SERIAL_PORT="/dev/cu.usbmodem14201"
 else
     echo "unsupported OS, things might not work" >&2
     SERIAL_PORT="/dev/ttyACM0"


### PR DESCRIPTION
I was not able to build my project using the default runner:

```
» cargo +nightly-2021-01-07 run --example uno-blink  
    Finished dev [optimized + debuginfo] target(s) in 0.20s
     Running `/Users/sobolev/Desktop/avr-hal/boards/arduino-uno/./uno-runner.sh /Users/sobolev/Desktop/avr-hal/target/avr-atmega328p/debug/examples/uno-blink.elf`

Program:             uno-blink.elf
Size:
   .text         486 (exact: 486)
   .data          44 (exact: 44)
   .bss            1 (exact: 1)

Attempting to flash ...

avrdude: ser_open(): can't open device "/dev/cu.usbmodem146201": No such file or directory

avrdude done.  Thank you.
```

I guess it is a typo:

```
» arduino-cli board list 
Port                            Type              Board Name  FQBN            Core       
/dev/cu.Bluetooth-Incoming-Port Serial Port       Unknown                                
/dev/cu.usbmodem14201           Serial Port (USB) Arduino Uno arduino:avr:uno arduino:avr
```