### PR TITLE
atmega-hal: Add support for ATmega48p

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
           - name: atmega328pb
             spec: atmega328p
             crate: atmega-hal
+          - name: atmega48p
+            spec: atmega48p
+            crate: atmega-hal
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 rt = ["avr-device/rt"]
 device-selected = []
+atmega48p = ["avr-device/atmega48p", "device-selected"]
 atmega168 = ["avr-device/atmega168", "device-selected"]
 atmega328p = ["avr-device/atmega328p", "device-selected"]
 atmega328pb = ["avr-device/atmega328pb", "device-selected"]

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -9,6 +9,7 @@ compile_error!(
 
     Please select one of the following
 
+    * atmega48p
     * atmega168
     * atmega328p
     * atmega328pb
@@ -36,6 +37,9 @@ pub use avr_device::atmega328pb as pac;
 /// Reexport of `atmega32u4` from `avr-device`
 #[cfg(feature = "atmega32u4")]
 pub use avr_device::atmega32u4 as pac;
+/// Reexport of `atmega48p` from `avr-device`
+#[cfg(feature = "atmega48p")]
+pub use avr_device::atmega48p as pac;
 
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
@@ -61,6 +65,7 @@ pub struct RawPeripheral<P>(pub(crate) P);
 pub struct Peripherals {
     pub pins: Pins,
     #[cfg(any(
+        feature = "atmega48p",
         feature = "atmega168",
         feature = "atmega328p",
         feature = "atmega328pb",
@@ -85,7 +90,7 @@ pub struct Peripherals {
 impl Peripherals {
     fn new(dp: pac::Peripherals) -> Self {
         Self {
-            #[cfg(any(feature = "atmega168", feature = "atmega328p"))]
+            #[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
             pins: Pins::new(dp.PORTB, dp.PORTC, dp.PORTD),
             #[cfg(feature = "atmega328pb")]
             pins: Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE),
@@ -98,6 +103,7 @@ impl Peripherals {
             ),
 
             #[cfg(any(
+                feature = "atmega48p",
                 feature = "atmega168",
                 feature = "atmega328p",
                 feature = "atmega328pb",

--- a/mcu/atmega-hal/src/port.rs
+++ b/mcu/atmega-hal/src/port.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "atmega168", feature = "atmega328p"))]
+#[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
 avr_hal_generic::impl_port_traditional! {
     enum Ports {
         PORTB: (crate::pac::PORTB, portb, pinb, ddrb),


### PR DESCRIPTION
atmega48p mcu support like https://github.com/Rahix/avr-hal/commit/356090d155e2ab02599b61a0f0cd2f330c8cd4
