### PR TITLE
Drop custom `Peripherals` structs and `RawPeripheral` newtype wrapper

### DIFF
--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -20,6 +20,9 @@ pub use atmega_hal::entry;
 pub use atmega_hal::pac;
 
 #[cfg(feature = "board-selected")]
+pub use hal::Peripherals;
+
+#[cfg(feature = "board-selected")]
 pub mod clock;
 #[cfg(feature = "board-selected")]
 pub use clock::default::DefaultClock;
@@ -62,39 +65,10 @@ pub mod prelude {
     pub use void::ResultVoidExt as _;
 }
 
-#[allow(non_snake_case)]
 #[cfg(feature = "board-selected")]
-pub struct Peripherals {
-    pub pins: Pins,
-    #[cfg(any(feature = "arduino-uno", feature = "arduino-mega2560"))]
-    pub USART0: hal::RawPeripheral<pac::USART0>,
-    #[cfg(any(feature = "arduino-leonardo", feature = "arduino-mega2560"))]
-    pub USART1: hal::RawPeripheral<pac::USART1>,
-    #[cfg(feature = "arduino-mega2560")]
-    pub USART2: hal::RawPeripheral<pac::USART2>,
-    #[cfg(feature = "arduino-mega2560")]
-    pub USART3: hal::RawPeripheral<pac::USART3>,
-}
-
-#[cfg(feature = "board-selected")]
-impl Peripherals {
-    fn new(dp: hal::Peripherals) -> Self {
-        Self {
-            #[cfg(feature = "atmega-hal")]
-            pins: Pins::with_mcu_pins(dp.pins),
-
-            #[cfg(any(feature = "arduino-uno", feature = "arduino-mega2560"))]
-            USART0: dp.USART0,
-            #[cfg(any(feature = "arduino-leonardo", feature = "arduino-mega2560"))]
-            USART1: dp.USART1,
-            #[cfg(feature = "arduino-mega2560")]
-            USART2: dp.USART2,
-            #[cfg(feature = "arduino-mega2560")]
-            USART3: dp.USART3,
-        }
-    }
-
-    pub fn take() -> Option<Self> {
-        hal::Peripherals::take().map(Self::new)
-    }
+#[macro_export]
+macro_rules! pins {
+    ($p:expr) => {
+        $crate::Pins::with_mcu_pins($crate::hal::pins!($p))
+    };
 }

--- a/avr-hal-generic/src/usart.rs
+++ b/avr-hal-generic/src/usart.rs
@@ -457,18 +457,18 @@ macro_rules! impl_usart_traditional {
                 $crate::port::Pin<$crate::port::mode::Output, $txpin>,
             > for $USART {
                 fn raw_init<CLOCK>(&mut self, baudrate: $crate::usart::Baudrate<CLOCK>) {
-                    self.0.[<ubrr $n>].write(|w| unsafe { w.bits(baudrate.ubrr) });
-                    self.0.[<ucsr $n a>].write(|w| w.[<u2x $n>]().bit(baudrate.u2x));
+                    self.[<ubrr $n>].write(|w| unsafe { w.bits(baudrate.ubrr) });
+                    self.[<ucsr $n a>].write(|w| w.[<u2x $n>]().bit(baudrate.u2x));
 
                     // Enable receiver and transmitter but leave interrupts disabled.
-                    self.0.[<ucsr $n b>].write(|w| w
+                    self.[<ucsr $n b>].write(|w| w
                         .[<txen $n>]().set_bit()
                         .[<rxen $n>]().set_bit()
                     );
 
                     // Set frame format to 8n1 for now.  At some point, this should be made
                     // configurable, similar to what is done in other HALs.
-                    self.0.[<ucsr $n c>].write(|w| w
+                    self.[<ucsr $n c>].write(|w| w
                         .[<umsel $n>]().usart_async()
                         .[<ucsz $n>]().chr8()
                         .[<usbs $n>]().stop1()
@@ -479,11 +479,11 @@ macro_rules! impl_usart_traditional {
                 fn raw_deinit(&mut self) {
                     // Wait for any ongoing transfer to finish.
                     $crate::nb::block!(self.raw_flush()).ok();
-                    self.0.[<ucsr $n b>].reset();
+                    self.[<ucsr $n b>].reset();
                 }
 
                 fn raw_flush(&mut self) -> $crate::nb::Result<(), $crate::void::Void> {
-                    if self.0.[<ucsr $n a>].read().[<udre $n>]().bit_is_clear() {
+                    if self.[<ucsr $n a>].read().[<udre $n>]().bit_is_clear() {
                         Err($crate::nb::Error::WouldBlock)
                     } else {
                         Ok(())
@@ -494,24 +494,24 @@ macro_rules! impl_usart_traditional {
                     // Call flush to make sure the data-register is empty
                     self.raw_flush()?;
 
-                    self.0.[<udr $n>].write(|w| unsafe { w.bits(byte) });
+                    self.[<udr $n>].write(|w| unsafe { w.bits(byte) });
                     Ok(())
                 }
 
                 fn raw_read(&mut self) -> $crate::nb::Result<u8, $crate::void::Void> {
-                    if self.0.[<ucsr $n a>].read().[<rxc $n>]().bit_is_clear() {
+                    if self.[<ucsr $n a>].read().[<rxc $n>]().bit_is_clear() {
                         return Err($crate::nb::Error::WouldBlock);
                     }
 
-                    Ok(self.0.[<udr $n>].read().bits())
+                    Ok(self.[<udr $n>].read().bits())
                 }
 
                 fn raw_interrupt(&mut self, event: $crate::usart::Event, state: bool) {
                     match event {
                         $crate::usart::Event::RxComplete =>
-                            self.0.[<ucsr $n b>].modify(|_, w| w.[<rxcie $n>]().bit(state)),
+                            self.[<ucsr $n b>].modify(|_, w| w.[<rxcie $n>]().bit(state)),
                         $crate::usart::Event::DataRegisterEmpty =>
-                            self.0.[<ucsr $n b>].modify(|_, w| w.[<txcie $n>]().bit(state)),
+                            self.[<ucsr $n b>].modify(|_, w| w.[<txcie $n>]().bit(state)),
                     }
                 }
             }

--- a/examples/arduino-leonardo/src/bin/leonardo-blink.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-blink.rs
@@ -6,11 +6,12 @@ use panic_halt as _;
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
 
     let mut leds = [
-        dp.pins.led_rx.into_output().downgrade(),
-        dp.pins.led_tx.into_output().downgrade(),
-        dp.pins.d13.into_output().downgrade(),
+        pins.led_rx.into_output().downgrade(),
+        pins.led_tx.into_output().downgrade(),
+        pins.d13.into_output().downgrade(),
     ];
 
     // RX & TX LEDs are active low and the LED on D13 is active high.  Thus invert LED13 here so

--- a/examples/arduino-leonardo/src/bin/leonardo-usart.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-usart.rs
@@ -9,11 +9,12 @@ use embedded_hal::serial::Read;
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
 
     let mut serial = arduino_hal::Usart::new(
         dp.USART1,
-        dp.pins.d0,
-        dp.pins.d1.into_output(),
+        pins.d0,
+        pins.d1.into_output(),
         57600.into_baudrate(),
     );
 

--- a/examples/arduino-mega2560/src/bin/mega2560-blink.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-blink.rs
@@ -6,7 +6,9 @@ use panic_halt as _;
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
-    let mut led  = dp.pins.d13.into_output().downgrade(); 
+    let pins = arduino_hal::pins!(dp);
+
+    let mut led = pins.d13.into_output().downgrade();
 
     loop {
         led.toggle();

--- a/examples/arduino-mega2560/src/bin/mega2560-usart.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-usart.rs
@@ -9,11 +9,12 @@ use embedded_hal::serial::Read;
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
 
     let mut serial = arduino_hal::Usart::new(
         dp.USART0,
-        dp.pins.d0,
-        dp.pins.d1.into_output(),
+        pins.d0,
+        pins.d1.into_output(),
         57600.into_baudrate(),
     );
 

--- a/examples/arduino-uno/src/bin/uno-blink.rs
+++ b/examples/arduino-uno/src/bin/uno-blink.rs
@@ -6,9 +6,10 @@ use panic_halt as _;
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
 
     // Digital pin 13 is also connected to an onboard LED marked "L"
-    let mut led = dp.pins.d13.into_output();
+    let mut led = pins.d13.into_output();
     led.set_high();
 
     loop {

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -9,11 +9,12 @@ use embedded_hal::serial::Read;
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
 
     let mut serial = arduino_hal::Usart::new(
         dp.USART0,
-        dp.pins.d0,
-        dp.pins.d1.into_output(),
+        pins.d0,
+        pins.d1.into_output(),
         57600.into_baudrate(),
     );
 

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -45,6 +45,9 @@ pub use avr_device::atmega48p as pac;
 #[cfg(feature = "rt")]
 pub use avr_device::entry;
 
+#[cfg(feature = "device-selected")]
+pub use pac::Peripherals;
+
 pub use avr_hal_generic::clock;
 pub use avr_hal_generic::delay;
 
@@ -60,72 +63,34 @@ pub use usart::Usart;
 
 pub struct RawPeripheral<P>(pub(crate) P);
 
-#[allow(non_snake_case)]
-#[cfg(feature = "device-selected")]
-pub struct Peripherals {
-    pub pins: Pins,
-    #[cfg(any(
-        feature = "atmega48p",
-        feature = "atmega168",
-        feature = "atmega328p",
-        feature = "atmega328pb",
-        feature = "atmega1280",
-        feature = "atmega2560"
-    ))]
-    pub USART0: RawPeripheral<pac::USART0>,
-    #[cfg(any(
-        feature = "atmega328pb",
-        feature = "atmega32u4",
-        feature = "atmega1280",
-        feature = "atmega2560"
-    ))]
-    pub USART1: RawPeripheral<pac::USART1>,
-    #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-    pub USART2: RawPeripheral<pac::USART2>,
-    #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-    pub USART3: RawPeripheral<pac::USART3>,
+#[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
+#[macro_export]
+macro_rules! pins {
+    ($p:expr) => {
+        $crate::Pins::new($p.PORTB, $p.PORTC, $p.PORTD)
+    };
 }
-
-#[cfg(feature = "device-selected")]
-impl Peripherals {
-    fn new(dp: pac::Peripherals) -> Self {
-        Self {
-            #[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
-            pins: Pins::new(dp.PORTB, dp.PORTC, dp.PORTD),
-            #[cfg(feature = "atmega328pb")]
-            pins: Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE),
-            #[cfg(feature = "atmega32u4")]
-            pins: Pins::new(dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF),
-            #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-            pins: Pins::new(
-                dp.PORTA, dp.PORTB, dp.PORTC, dp.PORTD, dp.PORTE, dp.PORTF, dp.PORTG, dp.PORTH,
-                dp.PORTJ, dp.PORTK, dp.PORTL,
-            ),
-
-            #[cfg(any(
-                feature = "atmega48p",
-                feature = "atmega168",
-                feature = "atmega328p",
-                feature = "atmega328pb",
-                feature = "atmega1280",
-                feature = "atmega2560"
-            ))]
-            USART0: RawPeripheral(dp.USART0),
-            #[cfg(any(
-                feature = "atmega328pb",
-                feature = "atmega32u4",
-                feature = "atmega1280",
-                feature = "atmega2560"
-            ))]
-            USART1: RawPeripheral(dp.USART1),
-            #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-            USART2: RawPeripheral(dp.USART2),
-            #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-            USART3: RawPeripheral(dp.USART3),
-        }
-    }
-
-    pub fn take() -> Option<Self> {
-        pac::Peripherals::take().map(Self::new)
-    }
+#[cfg(feature = "atmega328pb")]
+#[macro_export]
+macro_rules! pins {
+    ($p:expr) => {
+        $crate::Pins::new($p.PORTB, $p.PORTC, $p.PORTD, $p.PORTE)
+    };
+}
+#[cfg(feature = "atmega32u4")]
+#[macro_export]
+macro_rules! pins {
+    ($p:expr) => {
+        $crate::Pins::new($p.PORTB, $p.PORTC, $p.PORTD, $p.PORTE, $p.PORTF)
+    };
+}
+#[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
+#[macro_export]
+macro_rules! pins {
+    ($p:expr) => {
+        $crate::Pins::new(
+            $p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD, $p.PORTE, $p.PORTF, $p.PORTG, $p.PORTH,
+            $p.PORTJ, $p.PORTK, $p.PORTL,
+        )
+    };
 }

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -61,7 +61,7 @@ pub mod usart;
 #[cfg(feature = "device-selected")]
 pub use usart::Usart;
 
-pub struct RawPeripheral<P>(pub(crate) P);
+pub struct Atmega;
 
 #[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
 #[macro_export]

--- a/mcu/atmega-hal/src/usart.rs
+++ b/mcu/atmega-hal/src/usart.rs
@@ -2,16 +2,24 @@
 use crate::port;
 pub use avr_hal_generic::usart::*;
 
+pub type Usart<USART, RX, TX, CLOCK> =
+    avr_hal_generic::usart::Usart<crate::Atmega, USART, RX, TX, CLOCK>;
+pub type UsartWriter<USART, RX, TX, CLOCK> =
+    avr_hal_generic::usart::UsartWriter<crate::Atmega, USART, RX, TX, CLOCK>;
+pub type UsartReader<USART, RX, TX, CLOCK> =
+    avr_hal_generic::usart::UsartReader<crate::Atmega, USART, RX, TX, CLOCK>;
+
 #[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb"))]
 pub type Usart0<CLOCK, IMODE> = Usart<
-    crate::RawPeripheral<crate::pac::USART0>,
+    crate::pac::USART0,
     port::Pin<port::mode::Input<IMODE>, port::PD0>,
     port::Pin<port::mode::Output, port::PD1>,
     CLOCK,
 >;
 #[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb"))]
 avr_hal_generic::impl_usart_traditional! {
-    peripheral: crate::RawPeripheral<crate::pac::USART0>,
+    hal: crate::Atmega,
+    peripheral: crate::pac::USART0,
     register_suffix: 0,
     rx: port::PD0,
     tx: port::PD1,
@@ -19,14 +27,15 @@ avr_hal_generic::impl_usart_traditional! {
 
 #[cfg(feature = "atmega328pb")]
 pub type Usart1<CLOCK, IMODE> = Usart<
-    crate::RawPeripheral<crate::pac::USART1>,
+    crate::pac::USART1,
     port::Pin<port::mode::Input<IMODE>, port::PB4>,
     port::Pin<port::mode::Output, port::PB3>,
     CLOCK,
 >;
 #[cfg(feature = "atmega328pb")]
 avr_hal_generic::impl_usart_traditional! {
-    peripheral: crate::RawPeripheral<crate::pac::USART1>,
+    hal: crate::Atmega,
+    peripheral: crate::pac::USART1,
     register_suffix: 1,
     rx: port::PB4,
     tx: port::PB3,
@@ -34,14 +43,15 @@ avr_hal_generic::impl_usart_traditional! {
 
 #[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560"))]
 pub type Usart1<CLOCK, IMODE> = Usart<
-    crate::RawPeripheral<crate::pac::USART1>,
+    crate::pac::USART1,
     port::Pin<port::mode::Input<IMODE>, port::PD2>,
     port::Pin<port::mode::Output, port::PD3>,
     CLOCK,
 >;
 #[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560"))]
 avr_hal_generic::impl_usart_traditional! {
-    peripheral: crate::RawPeripheral<crate::pac::USART1>,
+    hal: crate::Atmega,
+    peripheral: crate::pac::USART1,
     register_suffix: 1,
     rx: port::PD2,
     tx: port::PD3,
@@ -49,14 +59,15 @@ avr_hal_generic::impl_usart_traditional! {
 
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
 pub type Usart0<CLOCK, IMODE> = Usart<
-    crate::RawPeripheral<crate::pac::USART0>,
+    crate::pac::USART0,
     port::Pin<port::mode::Input<IMODE>, port::PE0>,
     port::Pin<port::mode::Output, port::PE1>,
     CLOCK,
 >;
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
 avr_hal_generic::impl_usart_traditional! {
-    peripheral: crate::RawPeripheral<crate::pac::USART0>,
+    hal: crate::Atmega,
+    peripheral: crate::pac::USART0,
     register_suffix: 0,
     rx: port::PE0,
     tx: port::PE1,
@@ -64,14 +75,15 @@ avr_hal_generic::impl_usart_traditional! {
 
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
 pub type Usart2<CLOCK, IMODE> = Usart<
-    crate::RawPeripheral<crate::pac::USART2>,
+    crate::pac::USART2,
     port::Pin<port::mode::Input<IMODE>, port::PH0>,
     port::Pin<port::mode::Output, port::PH1>,
     CLOCK,
 >;
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
 avr_hal_generic::impl_usart_traditional! {
-    peripheral: crate::RawPeripheral<crate::pac::USART2>,
+    hal: crate::Atmega,
+    peripheral: crate::pac::USART2,
     register_suffix: 2,
     rx: port::PH0,
     tx: port::PH1,
@@ -79,14 +91,15 @@ avr_hal_generic::impl_usart_traditional! {
 
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
 pub type Usart3<CLOCK, IMODE> = Usart<
-    crate::RawPeripheral<crate::pac::USART3>,
+    crate::pac::USART3,
     port::Pin<port::mode::Input<IMODE>, port::PJ0>,
     port::Pin<port::mode::Output, port::PJ1>,
     CLOCK,
 >;
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
 avr_hal_generic::impl_usart_traditional! {
-    peripheral: crate::RawPeripheral<crate::pac::USART3>,
+    hal: crate::Atmega,
+    peripheral: crate::pac::USART3,
     register_suffix: 3,
     rx: port::PJ0,
     tx: port::PJ1,


### PR DESCRIPTION
Sadly it seems this approach is not going to work well, so we will have to follow a different route.  Already, the following problems are showing prominently:

- With a custom `Peripherals` struct, we need to manually add fields for _all_ peripherals of _all_ MCUs we support.  This is not going to scale well.
- Because each `Peripherals` will look differently, this is going to look very confusing.

Going back to the svd2rust generated `Peripherals` only, we also have to drop the `RawPeripheral` newtype.  I tried different solutions here and just dropping it entirely does seem to be the best looking.  Instead, I added a special type-parameter in `avr-hal-generic` with the sole purpose of circumventing the orphan rule which seems to work out quite nicely.  See commit 9c33514 for details.