### PR TITLE
Improve USART driver API

### DIFF
--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -72,3 +72,40 @@ macro_rules! pins {
         $crate::Pins::with_mcu_pins($crate::hal::pins!($p))
     };
 }
+
+#[cfg(any(feature = "arduino-uno"))]
+#[macro_export]
+macro_rules! default_serial {
+    ($p:expr, $pins:expr, $baud:expr) => {
+        $crate::Usart::new(
+            $p.USART0,
+            $pins.d0,
+            $pins.d1.into_output(),
+            $crate::hal::usart::BaudrateArduinoExt::into_baudrate($baud),
+        )
+    };
+}
+#[cfg(any(feature = "arduino-leonardo"))]
+#[macro_export]
+macro_rules! default_serial {
+    ($p:expr, $pins:expr, $baud:expr) => {
+        $crate::Usart::new(
+            $p.USART1,
+            $pins.d0,
+            $pins.d1.into_output(),
+            $crate::hal::usart::BaudrateExt::into_baudrate($baud),
+        )
+    };
+}
+#[cfg(any(feature = "arduino-mega2560"))]
+#[macro_export]
+macro_rules! default_serial {
+    ($p:expr, $pins:expr, $baud:expr) => {
+        $crate::Usart::new(
+            $p.USART0,
+            $pins.d0,
+            $pins.d1.into_output(),
+            $crate::hal::usart::BaudrateExt::into_baudrate($baud),
+        )
+    };
+}

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -76,8 +76,9 @@ pub trait PinOps {
 /// use atmega_hal::port::{Pin, mode, self};
 ///
 /// let dp = atmega_hal::Peripherals::take().unwrap();
+/// let pins = atmega_hal::pins!(dp);
 ///
-/// let output: Pin<mode::Output, port::PD3> = dp.pins.pd3.into_output();
+/// let output: Pin<mode::Output, port::PD3> = pins.pd3.into_output();
 /// ```
 pub struct Pin<MODE, PIN> {
     pub(crate) pin: PIN,
@@ -141,9 +142,10 @@ impl<PIN: PinOps, MODE: mode::Io> Pin<MODE, PIN> {
 /// use atmega_hal::port::{Pin, mode};
 ///
 /// let dp = atmega_hal::Peripherals::take().unwrap();
+/// let pins = atmega_hal::pins!(dp);
 ///
-/// let any_output_pin1: Pin<mode::Output> = dp.pins.pd0.into_output().downgrade();
-/// let any_output_pin2: Pin<mode::Output> = dp.pins.pd1.into_output().downgrade();
+/// let any_output_pin1: Pin<mode::Output> = pins.pd0.into_output().downgrade();
+/// let any_output_pin2: Pin<mode::Output> = pins.pd1.into_output().downgrade();
 ///
 /// // Because they now have the same type, you can, for example, stuff them into an array:
 /// let pins: [Pin<mode::Output>; 2] = [any_output_pin1, any_output_pin2];

--- a/examples/arduino-leonardo/src/bin/leonardo-usart.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-usart.rs
@@ -10,13 +10,7 @@ use embedded_hal::serial::Read;
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
     let pins = arduino_hal::pins!(dp);
-
-    let mut serial = arduino_hal::Usart::new(
-        dp.USART1,
-        pins.d0,
-        pins.d1.into_output(),
-        57600.into_baudrate(),
-    );
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 

--- a/examples/arduino-mega2560/src/bin/mega2560-usart.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-usart.rs
@@ -10,13 +10,7 @@ use embedded_hal::serial::Read;
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
     let pins = arduino_hal::pins!(dp);
-
-    let mut serial = arduino_hal::Usart::new(
-        dp.USART0,
-        pins.d0,
-        pins.d1.into_output(),
-        57600.into_baudrate(),
-    );
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -10,13 +10,7 @@ use embedded_hal::serial::Read;
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
     let pins = arduino_hal::pins!(dp);
-
-    let mut serial = arduino_hal::Usart::new(
-        dp.USART0,
-        pins.d0,
-        pins.d1.into_output(),
-        57600.into_baudrate(),
-    );
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 

--- a/mcu/atmega-hal/src/usart.rs
+++ b/mcu/atmega-hal/src/usart.rs
@@ -10,9 +10,9 @@ pub type UsartReader<USART, RX, TX, CLOCK> =
     avr_hal_generic::usart::UsartReader<crate::Atmega, USART, RX, TX, CLOCK>;
 
 #[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb"))]
-pub type Usart0<CLOCK, IMODE> = Usart<
+pub type Usart0<CLOCK> = Usart<
     crate::pac::USART0,
-    port::Pin<port::mode::Input<IMODE>, port::PD0>,
+    port::Pin<port::mode::Input, port::PD0>,
     port::Pin<port::mode::Output, port::PD1>,
     CLOCK,
 >;
@@ -26,9 +26,9 @@ avr_hal_generic::impl_usart_traditional! {
 }
 
 #[cfg(feature = "atmega328pb")]
-pub type Usart1<CLOCK, IMODE> = Usart<
+pub type Usart1<CLOCK> = Usart<
     crate::pac::USART1,
-    port::Pin<port::mode::Input<IMODE>, port::PB4>,
+    port::Pin<port::mode::Input, port::PB4>,
     port::Pin<port::mode::Output, port::PB3>,
     CLOCK,
 >;
@@ -42,9 +42,9 @@ avr_hal_generic::impl_usart_traditional! {
 }
 
 #[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560"))]
-pub type Usart1<CLOCK, IMODE> = Usart<
+pub type Usart1<CLOCK> = Usart<
     crate::pac::USART1,
-    port::Pin<port::mode::Input<IMODE>, port::PD2>,
+    port::Pin<port::mode::Input, port::PD2>,
     port::Pin<port::mode::Output, port::PD3>,
     CLOCK,
 >;
@@ -58,9 +58,9 @@ avr_hal_generic::impl_usart_traditional! {
 }
 
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-pub type Usart0<CLOCK, IMODE> = Usart<
+pub type Usart0<CLOCK> = Usart<
     crate::pac::USART0,
-    port::Pin<port::mode::Input<IMODE>, port::PE0>,
+    port::Pin<port::mode::Input, port::PE0>,
     port::Pin<port::mode::Output, port::PE1>,
     CLOCK,
 >;
@@ -74,9 +74,9 @@ avr_hal_generic::impl_usart_traditional! {
 }
 
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-pub type Usart2<CLOCK, IMODE> = Usart<
+pub type Usart2<CLOCK> = Usart<
     crate::pac::USART2,
-    port::Pin<port::mode::Input<IMODE>, port::PH0>,
+    port::Pin<port::mode::Input, port::PH0>,
     port::Pin<port::mode::Output, port::PH1>,
     CLOCK,
 >;
@@ -90,9 +90,9 @@ avr_hal_generic::impl_usart_traditional! {
 }
 
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-pub type Usart3<CLOCK, IMODE> = Usart<
+pub type Usart3<CLOCK> = Usart<
     crate::pac::USART3,
-    port::Pin<port::mode::Input<IMODE>, port::PJ0>,
+    port::Pin<port::mode::Input, port::PJ0>,
     port::Pin<port::mode::Output, port::PJ1>,
     CLOCK,
 >;


### PR DESCRIPTION
This PR contains some fixes to make the USART module easier to use.  Most notably, I added a `default_serial!()` macro to the `arduino-hal`.  This abstracts away all differences between the different arduino boards for simple code that uses the serial console:  The example is now exactly the same for all three boards and looks like this:

```rust
#![no_std]
#![no_main]

use arduino_hal::prelude::*;
use panic_halt as _;

#[arduino_hal::entry]
fn main() -> ! {
    let dp = arduino_hal::Peripherals::take().unwrap();
    let pins = arduino_hal::pins!(dp);
    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);

    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
}
```