### PR TITLE
i2c: Reimplement with new HAL API design

### DIFF
--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -38,6 +38,15 @@ pub mod port;
 pub use port::Pins;
 
 #[cfg(feature = "board-selected")]
+pub mod i2c {
+    pub use crate::hal::i2c::*;
+
+    pub type I2c = crate::hal::i2c::I2c<crate::DefaultClock>;
+}
+#[cfg(feature = "board-selected")]
+pub use i2c::I2c;
+
+#[cfg(feature = "board-selected")]
 pub mod usart {
     pub use crate::hal::usart::{Baudrate, UsartOps};
 

--- a/examples/arduino-leonardo/src/bin/leonardo-i2cdetect.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-i2cdetect.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    let mut i2c = arduino_hal::I2c::new(
+        dp.TWI,
+        pins.d2.into_pull_up_input(),
+        pins.d3.into_pull_up_input(),
+        50000,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+
+    loop {}
+}

--- a/examples/arduino-mega2560/src/bin/mega2560-i2cdetect.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-i2cdetect.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    let mut i2c = arduino_hal::I2c::new(
+        dp.TWI,
+        pins.d20.into_pull_up_input(),
+        pins.d21.into_pull_up_input(),
+        50000,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+
+    loop {}
+}

--- a/examples/arduino-uno/src/bin/uno-i2cdetect.rs
+++ b/examples/arduino-uno/src/bin/uno-i2cdetect.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    let mut i2c = arduino_hal::I2c::new(
+        dp.TWI,
+        pins.a4.into_pull_up_input(),
+        pins.a5.into_pull_up_input(),
+        50000,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+
+    loop {}
+}

--- a/mcu/atmega-hal/src/i2c.rs
+++ b/mcu/atmega-hal/src/i2c.rs
@@ -1,0 +1,66 @@
+#[allow(unused_imports)]
+use crate::port;
+pub use avr_hal_generic::i2c::*;
+
+#[cfg(any(feature = "atmega1280", feature = "atmega2560", feature = "atmega32u4"))]
+pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
+    crate::Atmega,
+    crate::pac::TWI,
+    port::Pin<port::mode::Input, port::PD1>,
+    port::Pin<port::mode::Input, port::PD0>,
+    CLOCK,
+>;
+#[cfg(any(feature = "atmega1280", feature = "atmega2560", feature = "atmega32u4"))]
+avr_hal_generic::impl_i2c_twi! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::TWI,
+    sda: port::PD1,
+    scl: port::PD0,
+}
+
+#[cfg(any(feature = "atmega328p", feature = "atmega168", feature = "atmega48p"))]
+pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
+    crate::Atmega,
+    crate::pac::TWI,
+    port::Pin<port::mode::Input, port::PC4>,
+    port::Pin<port::mode::Input, port::PC5>,
+    CLOCK,
+>;
+#[cfg(any(feature = "atmega328p", feature = "atmega168", feature = "atmega48p"))]
+avr_hal_generic::impl_i2c_twi! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::TWI,
+    sda: port::PC4,
+    scl: port::PC5,
+}
+
+#[cfg(any(feature = "atmega328pb"))]
+pub type I2c0<CLOCK> = avr_hal_generic::i2c::I2c<
+    crate::Atmega,
+    crate::pac::TWI0,
+    port::Pin<port::mode::Input, port::PC4>,
+    port::Pin<port::mode::Input, port::PC5>,
+    CLOCK,
+>;
+#[cfg(any(feature = "atmega328pb"))]
+avr_hal_generic::impl_i2c_twi! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::TWI0,
+    sda: port::PC4,
+    scl: port::PC5,
+}
+#[cfg(any(feature = "atmega328pb"))]
+pub type I2c1<CLOCK> = avr_hal_generic::i2c::I2c<
+    crate::Atmega,
+    crate::pac::TWI1,
+    port::Pin<port::mode::Input, port::PE0>,
+    port::Pin<port::mode::Input, port::PE1>,
+    CLOCK,
+>;
+#[cfg(any(feature = "atmega328pb"))]
+avr_hal_generic::impl_i2c_twi! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::TWI1,
+    sda: port::PE0,
+    scl: port::PE1,
+}

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -61,6 +61,11 @@ pub mod usart;
 #[cfg(feature = "device-selected")]
 pub use usart::Usart;
 
+#[cfg(feature = "device-selected")]
+pub mod i2c;
+#[cfg(feature = "device-selected")]
+pub use i2c::I2c;
+
 pub struct Atmega;
 
 #[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]


### PR DESCRIPTION
Pull off the same design that the USART module is using now in the I2C HAL as well.  The key points are:

- `avr-hal-generic` defines the user facing API type (e.g. `I2c<>` or `Usart<>`).  This type implements `embedded-hal` traits and provides all API which we want to expose.
- There is a trait defining the lower-level API, called `I2cOps` (or `UsartOps`).  This trait is "consumed" by the `I2c<>` type to access the peripheral.
  - The methods of this trait have the prefix `raw_` and are not meant to be used directly by the user.
- A macro exists which implements this trait for a peripheral.  E.g. `impl_i2c_twi!{}` in this case.
- Because the HAL crate neither "owns" the `I2cOps` trait nor the peripheral type (it comes from `avr-device`), we run into the "orphan rule".  To "fix" this, the `I2cOps` trait and `I2c<>` type have a type-parameter called `H` which is substituted by a local type from e.g. `atmega-hal`.

Cc: @explicite 