### PR TITLE
Reimplement ADC HAL

### DIFF
--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -47,6 +47,18 @@ pub mod i2c {
 pub use i2c::I2c;
 
 #[cfg(feature = "board-selected")]
+pub mod adc {
+    pub use crate::hal::adc::{
+        channel, AdcChannel, AdcOps, AdcSettings, ClockDivider, ReferenceVoltage,
+    };
+
+    /// Check the [`avr_hal_generic::adc::Adc`] documentation.
+    pub type Adc = crate::hal::Adc<crate::DefaultClock>;
+}
+#[cfg(feature = "board-selected")]
+pub use adc::Adc;
+
+#[cfg(feature = "board-selected")]
 pub mod usart {
     pub use crate::hal::usart::{Baudrate, UsartOps};
 

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -49,7 +49,7 @@ pub use i2c::I2c;
 #[cfg(feature = "board-selected")]
 pub mod adc {
     pub use crate::hal::adc::{
-        channel, AdcChannel, AdcOps, AdcSettings, ClockDivider, ReferenceVoltage,
+        channel, AdcChannel, AdcOps, AdcSettings, Channel, ClockDivider, ReferenceVoltage,
     };
 
     /// Check the [`avr_hal_generic::adc::Adc`] documentation.

--- a/avr-hal-generic/src/adc.rs
+++ b/avr-hal-generic/src/adc.rs
@@ -1,18 +1,24 @@
+/// Analog-to-Digial converter
+use core::marker::PhantomData;
+
 /// The division factor between the system clock frequency and the input clock to the AD converter.
 ///
-/// To get 10bit precision, clock from 50kHz to 200kHz must be supplied. If you need less precision, you can supply higher clock.
+/// To get 10-bit precision, clock from 50kHz to 200kHz must be supplied.  If you need less
+/// precision, you can supply a higher clock.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ClockRateDivision {
+#[repr(u8)]
+pub enum ClockDivider {
     Factor2,
     Factor4,
     Factor8,
     Factor16,
     Factor32,
     Factor64,
+    /// (default)
     Factor128,
 }
 
-impl Default for ClockRateDivision {
+impl Default for ClockDivider {
     fn default() -> Self {
         Self::Factor128
     }
@@ -20,14 +26,16 @@ impl Default for ClockRateDivision {
 
 /// Select the voltage reference for the ADC peripheral
 ///
-/// The internal voltage reference options may not be used if an external reference voltage is being applied to the AREF pin.
+/// The internal voltage reference options may not be used if an external reference voltage is
+/// being applied to the AREF pin.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum ReferenceVoltage {
     /// Voltage applied to AREF pin.
     Aref,
-    /// Default reference voltage.
+    /// Default reference voltage (default).
     AVcc,
-    /// Internal reference voltage
+    /// Internal reference voltage.
     Internal,
 }
 
@@ -37,125 +45,240 @@ impl Default for ReferenceVoltage {
     }
 }
 
+/// Configuration for the ADC peripheral.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AdcSettings {
-    pub clock_divider: ClockRateDivision,
+    pub clock_divider: ClockDivider,
     pub ref_voltage: ReferenceVoltage,
+}
+
+/// Internal trait for the low-level ADC peripheral.
+///
+/// **Prefer using the [`Adc`] API instead of this trait.**
+pub trait AdcOps<H> {
+    /// Channel ID type for this ADC.
+    type Channel: PartialEq + Copy;
+
+    /// Initialize the ADC peripheral with the specified settings.
+    ///
+    /// **Warning**: This is a low-level method and should not be called directly from user code.
+    fn raw_init(&mut self, settings: AdcSettings);
+
+    /// Read out the ADC data register.
+    ///
+    /// This method must only be called after a conversion completed.
+    ///
+    /// **Warning**: This is a low-level method and should not be called directly from user code.
+    fn raw_read_adc(&self) -> u16;
+
+    /// Check whether the ADC is currently converting a signal.
+    ///
+    /// **Warning**: This is a low-level method and should not be called directly from user code.
+    fn raw_is_converting(&self) -> bool;
+
+    /// Start a conversion on the currently selected channel.
+    ///
+    /// **Warning**: This is a low-level method and should not be called directly from user code.
+    fn raw_start_conversion(&mut self);
+
+    /// Set the multiplexer to a certain channel.
+    ///
+    /// **Warning**: This is a low-level method and should not be called directly from user code.
+    fn raw_set_channel(&mut self, channel: Self::Channel);
+
+    /// Set the DIDR (Digital Input Disable) for a certain channel.
+    ///
+    /// This disabled digital logic on the corresponding pin and allows measuring analog signals.
+    ///
+    /// **Warning**: This is a low-level method and should not be called directly from user code.
+    fn raw_enable_channel(&mut self, channel: Self::Channel);
+}
+
+/// Trait marking a type as an ADC channel for a certain ADC.
+pub trait AdcChannel<H, ADC: AdcOps<H>> {
+    fn channel(&self) -> ADC::Channel;
+}
+
+/// Analog-to-Digital Converter
+/// ```
+/// let dp = atmega_hal::Peripherals::take().unwrap();
+/// let pins = atmega_hal::pins!(dp);
+/// let mut adc = atmega_hal::Adc::new(dp.ADC, Default::default());
+///
+/// let a0 = dp.pc0.into_analog_input(&mut adc);
+///
+/// // the following two calls are equivalent
+/// let voltage = a0.analog_read(&mut adc);
+/// let voltage = adc.read_blocking(&a0);
+///
+/// // alternatively, a non-blocking interface exists
+/// let voltage = nb::block!(adc.read_nonblocking(&a0)).void_unwrap();
+/// ```
+pub struct Adc<H, ADC: AdcOps<H>, CLOCK> {
+    p: ADC,
+    reading_channel: Option<ADC::Channel>,
+    _clock: PhantomData<CLOCK>,
+    _h: PhantomData<H>,
+}
+
+impl<H, ADC, CLOCK> Adc<H, ADC, CLOCK>
+where
+    ADC: AdcOps<H>,
+    CLOCK: crate::clock::Clock,
+{
+    pub fn new(p: ADC, settings: AdcSettings) -> Self {
+        let mut adc = Self {
+            p,
+            reading_channel: None,
+            _clock: PhantomData,
+            _h: PhantomData,
+        };
+        adc.initialize(settings);
+        adc
+    }
+
+    pub fn initialize(&mut self, settings: AdcSettings) {
+        self.p.raw_init(settings);
+    }
+
+    #[inline]
+    pub(crate) fn enable_pin<PIN: AdcChannel<H, ADC>>(&mut self, pin: &PIN) {
+        self.p.raw_enable_channel(pin.channel());
+    }
+
+    pub fn read_blocking<PIN: AdcChannel<H, ADC>>(&mut self, pin: &PIN) -> u16 {
+        // assert!(self.reading_channel.is_none());
+        self.p.raw_set_channel(pin.channel());
+        self.p.raw_start_conversion();
+        while self.p.raw_is_converting() {}
+        self.p.raw_read_adc()
+    }
+
+    pub fn read_nonblocking<PIN: AdcChannel<H, ADC>>(
+        &mut self,
+        pin: &PIN,
+    ) -> nb::Result<u16, void::Void> {
+        match (&self.reading_channel, self.p.raw_is_converting()) {
+            // Measurement on current pin is ongoing
+            (Some(channel), true) if *channel == pin.channel() => Err(nb::Error::WouldBlock),
+            // Measurement on current pin completed
+            (Some(channel), false) if *channel == pin.channel() => {
+                self.reading_channel = None;
+                Ok(self.p.raw_read_adc().into())
+            }
+            // Measurement on other pin is ongoing
+            (Some(_), _) => {
+                self.reading_channel = None;
+                Err(nb::Error::WouldBlock)
+            }
+            // Start measurement
+            (None, _) => {
+                self.reading_channel = Some(pin.channel());
+                self.p.raw_set_channel(pin.channel());
+                self.p.raw_start_conversion();
+                Err(nb::Error::WouldBlock)
+            }
+        }
+    }
 }
 
 #[macro_export]
 macro_rules! impl_adc {
     (
-        pub struct $Adc:ident {
-            type ChannelID = $ID:ty;
-            peripheral: $ADC:ty,
-            set_mux: |$periph_var:ident, $id_var:ident| $set_mux:block,
-            pins: {
-                $($pxi:ident: ($PXi:ident, $ChannelID:expr, $didr:ident::$didr_method:ident),)+
-            }
-        }
+        hal: $HAL:ty,
+        peripheral: $ADC:ty,
+        channel_id: $Channel:ty,
+        set_channel: |$periph_var:ident, $chan_var:ident| $set_channel:block,
+        pins: {
+            $(
+                $(#[$pin_attr:meta])*
+                $pin:ty: ($pin_channel:expr, $didr:ident::$didr_method:ident),
+            )+
+        },
+        $(channels: {
+            $(
+                $(#[$channel_attr:meta])*
+                $channel_ty:ty: $channel:expr,
+            )*
+        },)?
     ) => {
+        impl $crate::adc::AdcOps<$HAL> for $ADC {
+            type Channel = $Channel;
 
-        use $crate::void::Void;
-        use $crate::hal::adc::{Channel, OneShot};
-        use $crate::nb;
-        use $crate::port::mode::Analog;
-        pub use $crate::adc::*;
-
-        pub struct $Adc {
-            peripheral: $ADC,
-            reading_channel: Option<$ID>,
-        }
-
-        impl $Adc {
-            pub fn new(peripheral: $ADC, settings: AdcSettings) -> $Adc {
-                let s = Self { peripheral, reading_channel: None } ;
-                s.enable(settings);
-                s
-            }
-
-            fn enable(&self, settings: AdcSettings) {
-                self.peripheral.adcsra.write(|w| {
+            #[inline]
+            fn raw_init(&mut self, settings: $crate::adc::AdcSettings) {
+                self.adcsra.write(|w| {
                     w.aden().set_bit();
                     match settings.clock_divider {
-                        ClockRateDivision::Factor2 => w.adps().prescaler_2(),
-                        ClockRateDivision::Factor4 => w.adps().prescaler_4(),
-                        ClockRateDivision::Factor8 => w.adps().prescaler_8(),
-                        ClockRateDivision::Factor16 => w.adps().prescaler_16(),
-                        ClockRateDivision::Factor32 => w.adps().prescaler_32(),
-                        ClockRateDivision::Factor64 => w.adps().prescaler_64(),
-                        ClockRateDivision::Factor128 => w.adps().prescaler_128(),
-                    }});
-                self.peripheral.admux.write(|w| match settings.ref_voltage {
+                        ClockDivider::Factor2 => w.adps().prescaler_2(),
+                        ClockDivider::Factor4 => w.adps().prescaler_4(),
+                        ClockDivider::Factor8 => w.adps().prescaler_8(),
+                        ClockDivider::Factor16 => w.adps().prescaler_16(),
+                        ClockDivider::Factor32 => w.adps().prescaler_32(),
+                        ClockDivider::Factor64 => w.adps().prescaler_64(),
+                        ClockDivider::Factor128 => w.adps().prescaler_128(),
+                    }
+                });
+                self.admux.write(|w| match settings.ref_voltage {
                     ReferenceVoltage::Aref => w.refs().aref(),
                     ReferenceVoltage::AVcc => w.refs().avcc(),
                     ReferenceVoltage::Internal => w.refs().internal(),
                 });
-
             }
 
-            fn disable(&self) {
-                self.peripheral.adcsra.reset();
+            #[inline]
+            fn raw_read_adc(&self) -> u16 {
+                self.adc.read().bits()
             }
 
-            pub fn release(self) -> $ADC {
-                self.disable();
-                self.peripheral
+            #[inline]
+            fn raw_is_converting(&self) -> bool {
+                self.adcsra.read().adsc().bit_is_set()
             }
-        }
 
-        impl<WORD, PIN> OneShot<$Adc, WORD, PIN> for $Adc
-        where
-            WORD: From<u16>,
-            PIN: Channel<$Adc, ID=$ID>,
-        {
-            type Error = Void;
+            #[inline]
+            fn raw_start_conversion(&mut self) {
+                self.adcsra.modify(|_, w| w.adsc().set_bit());
+            }
 
-            fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
-                match (self.reading_channel, self.peripheral.adcsra.read().adsc().bit_is_set()) {
-                    // Measurement on current pin is ongoing
-                    (Some(channel), true) if channel == PIN::channel() => Err(nb::Error::WouldBlock),
-                    // Measurement on current pin completed
-                    (Some(channel), false) if channel == PIN::channel() => {
-                        self.reading_channel = None;
-                        Ok(self.peripheral.adc.read().bits().into())
-                    },
-                    // Measurement on other pin is ongoing
-                    (Some(_), _) => {
-                        self.reading_channel = None;
-                        Err(nb::Error::WouldBlock)
-                    },
-                    // Start measurement
-                    (None, _) => {
-                        self.reading_channel = Some(PIN::channel());
-                        {
-                            let $periph_var = &mut self.peripheral;
-                            let $id_var = PIN::channel();
+            #[inline]
+            fn raw_set_channel(&mut self, channel: Self::Channel) {
+                let $periph_var = self;
+                let $chan_var = channel;
 
-                            $set_mux
-                        }
-                        self.peripheral.adcsra.modify(|_, w| w.adsc().set_bit());
-                        Err(nb::Error::WouldBlock)
-                    },
+                $set_channel
+            }
+
+            #[inline]
+            fn raw_enable_channel(&mut self, channel: Self::Channel) {
+                match channel {
+                    $(
+                        $(#[$pin_attr])*
+                        x if x == $pin_channel => self.$didr.modify(|_, w| w.$didr_method().set_bit()),
+                    )+
+                    _ => unreachable!(),
                 }
             }
         }
 
         $(
-            impl Channel<$Adc> for $PXi<Analog> {
-                type ID = $ID;
-                fn channel() -> Self::ID {
-                    $ChannelID
-                }
+        $(#[$pin_attr])*
+        impl $crate::adc::AdcChannel<$HAL, $ADC> for $crate::port::Pin<$crate::port::mode::Analog, $pin> {
+            #[inline]
+            fn channel(&self) -> $Channel {
+                $pin_channel
             }
-
-            impl<MODE> $PXi<MODE> {
-                    /// Make this pin a analog input and set the didr register
-                    pub fn into_analog_input(self, adc: &mut $Adc) -> $PXi<Analog> {
-                        adc.peripheral.$didr.modify(|_, w| w.$didr_method().set_bit());
-                        $PXi { _mode: core::marker::PhantomData }
-                    }
-            }
+        }
         )+
-    }
+
+        $($(
+        $(#[$channel_attr])*
+        impl $crate::adc::AdcChannel<$HAL, $ADC> for $channel_ty {
+            #[inline]
+            fn channel(&self) -> $Channel {
+                $channel
+            }
+        }
+        )*)?
+    };
 }

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -304,6 +304,19 @@ impl<PIN: PinOps> Pin<mode::Analog, PIN> {
     {
         adc.read_blocking(self)
     }
+
+    /// Convert this pin into a generic [`Channel`][adc-channel] type.
+    ///
+    /// The generic channel type can be used to store multiple channels in an array.
+    ///
+    /// [adc-channel]: crate::adc::Channel
+    pub fn into_channel<H, ADC>(self) -> crate::adc::Channel<H, ADC>
+    where
+        Pin<mode::Analog, PIN>: crate::adc::AdcChannel<H, ADC>,
+        ADC: crate::adc::AdcOps<H>,
+    {
+        crate::adc::Channel::new(self)
+    }
 }
 
 #[macro_export]

--- a/examples/arduino-leonardo/src/bin/leonardo-adc.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-adc.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+use arduino_hal::adc;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    let mut adc = arduino_hal::Adc::new(dp.ADC, Default::default());
+
+    let (vbg, gnd, tmp) = (
+        adc.read_blocking(&adc::channel::Vbg),
+        adc.read_blocking(&adc::channel::Gnd),
+        adc.read_blocking(&adc::channel::Temperature),
+    );
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).void_unwrap();
+
+    let a0 = pins.a0.into_analog_input(&mut adc);
+    let a1 = pins.a1.into_analog_input(&mut adc);
+    let a2 = pins.a2.into_analog_input(&mut adc);
+    let a3 = pins.a3.into_analog_input(&mut adc);
+    let a4 = pins.a4.into_analog_input(&mut adc);
+    let a5 = pins.a5.into_analog_input(&mut adc);
+
+    loop {
+        let values = [
+            a0.analog_read(&mut adc),
+            a1.analog_read(&mut adc),
+            a2.analog_read(&mut adc),
+            a3.analog_read(&mut adc),
+            a4.analog_read(&mut adc),
+            a5.analog_read(&mut adc),
+        ];
+
+        for (i, v) in values.iter().enumerate() {
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+        }
+
+        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        arduino_hal::delay_ms(1000);
+    }
+}

--- a/examples/arduino-mega2560/src/bin/mega2560-adc.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-adc.rs
@@ -1,0 +1,53 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+use arduino_hal::adc;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    let mut adc = arduino_hal::Adc::new(dp.ADC, Default::default());
+
+    let (vbg, gnd) = (
+        adc.read_blocking(&adc::channel::Vbg),
+        adc.read_blocking(&adc::channel::Gnd),
+    );
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
+
+    // To store multiple channels in an array, we use the `into_channel()` method.
+    let channels: [adc::Channel; 16] = [
+        pins.a0.into_analog_input(&mut adc).into_channel(),
+        pins.a1.into_analog_input(&mut adc).into_channel(),
+        pins.a2.into_analog_input(&mut adc).into_channel(),
+        pins.a3.into_analog_input(&mut adc).into_channel(),
+        pins.a4.into_analog_input(&mut adc).into_channel(),
+        pins.a5.into_analog_input(&mut adc).into_channel(),
+        pins.a6.into_analog_input(&mut adc).into_channel(),
+        pins.a7.into_analog_input(&mut adc).into_channel(),
+        pins.a8.into_analog_input(&mut adc).into_channel(),
+        pins.a9.into_analog_input(&mut adc).into_channel(),
+        pins.a10.into_analog_input(&mut adc).into_channel(),
+        pins.a11.into_analog_input(&mut adc).into_channel(),
+        pins.a12.into_analog_input(&mut adc).into_channel(),
+        pins.a13.into_analog_input(&mut adc).into_channel(),
+        pins.a14.into_analog_input(&mut adc).into_channel(),
+        pins.a15.into_analog_input(&mut adc).into_channel(),
+    ];
+
+    loop {
+        for (i, ch) in channels.iter().enumerate() {
+            let v = adc.read_blocking(ch);
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+        }
+
+        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        arduino_hal::delay_ms(1000);
+    }
+}

--- a/examples/arduino-uno/src/bin/uno-adc.rs
+++ b/examples/arduino-uno/src/bin/uno-adc.rs
@@ -1,0 +1,58 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+use arduino_hal::adc;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    let mut adc = arduino_hal::Adc::new(dp.ADC, Default::default());
+
+    let (vbg, gnd, tmp) = (
+        adc.read_blocking(&adc::channel::Vbg),
+        adc.read_blocking(&adc::channel::Gnd),
+        adc.read_blocking(&adc::channel::Temperature),
+    );
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).void_unwrap();
+
+    let a0 = pins.a0.into_analog_input(&mut adc);
+    let a1 = pins.a1.into_analog_input(&mut adc);
+    let a2 = pins.a2.into_analog_input(&mut adc);
+    let a3 = pins.a3.into_analog_input(&mut adc);
+    let a4 = pins.a4.into_analog_input(&mut adc);
+    let a5 = pins.a5.into_analog_input(&mut adc);
+
+    loop {
+        let values = [
+            a0.analog_read(&mut adc),
+            a1.analog_read(&mut adc),
+            a2.analog_read(&mut adc),
+            a3.analog_read(&mut adc),
+            a4.analog_read(&mut adc),
+            a5.analog_read(&mut adc),
+        ];
+
+        for (i, v) in values.iter().enumerate() {
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+        }
+
+        // Arduino Nano has two more ADC pins A6 and A7.  Accessing them works a bit different from
+        // the other pins as they are not normal IO pins.  The code below shows how it works.
+        let (a6, a7) = (
+            adc.read_blocking(&adc::channel::ADC6),
+            adc.read_blocking(&adc::channel::ADC7),
+        );
+        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).void_unwrap();
+
+        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        arduino_hal::delay_ms(1000);
+    }
+}

--- a/mcu/atmega-hal/src/adc.rs
+++ b/mcu/atmega-hal/src/adc.rs
@@ -6,6 +6,9 @@ pub use avr_hal_generic::adc::{AdcChannel, AdcOps, AdcSettings, ClockDivider, Re
 /// Check the [`avr_hal_generic::adc::Adc`] documentation.
 pub type Adc<CLOCK> = avr_hal_generic::adc::Adc<crate::Atmega, crate::pac::ADC, CLOCK>;
 
+/// Check the [`avr_hal_generic::adc::Channel`] documentation.
+pub type Channel = avr_hal_generic::adc::Channel<crate::Atmega, crate::pac::ADC>;
+
 /// Additional channels
 ///
 /// Some channels are not directly connected to pins.  This module provides types which can be used

--- a/mcu/atmega-hal/src/adc.rs
+++ b/mcu/atmega-hal/src/adc.rs
@@ -1,0 +1,157 @@
+//! Analog-to-Digital Converter
+
+use crate::port;
+pub use avr_hal_generic::adc::{AdcChannel, AdcOps, AdcSettings, ClockDivider, ReferenceVoltage};
+
+/// Check the [`avr_hal_generic::adc::Adc`] documentation.
+pub type Adc<CLOCK> = avr_hal_generic::adc::Adc<crate::Atmega, crate::pac::ADC, CLOCK>;
+
+/// Additional channels
+///
+/// Some channels are not directly connected to pins.  This module provides types which can be used
+/// to access them.
+///
+/// # Example
+/// ```
+/// let dp = atmega_hal::Peripherals::take().unwrap();
+/// let mut adc = atmega_hal::Adc::new(dp.ADC, Default::default());
+///
+/// let value = adc.read_blocking(&channel::Vbg);
+/// ```
+pub mod channel {
+    #[cfg(any(
+        feature = "atmega168",
+        feature = "atmega328p",
+        feature = "atmega328pb",
+        feature = "atmega48p"
+    ))]
+    pub struct ADC6;
+    #[cfg(any(
+        feature = "atmega168",
+        feature = "atmega328p",
+        feature = "atmega328pb",
+        feature = "atmega48p"
+    ))]
+    pub struct ADC7;
+    #[cfg(any(
+        feature = "atmega1280",
+        feature = "atmega168",
+        feature = "atmega2560",
+        feature = "atmega328p",
+        feature = "atmega328pb",
+        feature = "atmega32u4",
+        feature = "atmega48p",
+    ))]
+    pub struct Vbg;
+    #[cfg(any(
+        feature = "atmega1280",
+        feature = "atmega168",
+        feature = "atmega2560",
+        feature = "atmega328p",
+        feature = "atmega328pb",
+        feature = "atmega32u4",
+        feature = "atmega48p",
+    ))]
+    pub struct Gnd;
+    #[cfg(any(
+        feature = "atmega328p",
+        feature = "atmega328pb",
+        feature = "atmega32u4",
+        feature = "atmega48p",
+    ))]
+    pub struct Temperature;
+}
+
+#[cfg(any(
+    feature = "atmega168",
+    feature = "atmega328p",
+    feature = "atmega328pb",
+    feature = "atmega48p",
+))]
+avr_hal_generic::impl_adc! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::ADC,
+    channel_id: crate::pac::adc::admux::MUX_A,
+    set_channel: |peripheral, id| {
+        peripheral.admux.modify(|_, w| w.mux().variant(id));
+    },
+    pins: {
+        port::PC0: (crate::pac::adc::admux::MUX_A::ADC0, didr0::adc0d),
+        port::PC1: (crate::pac::adc::admux::MUX_A::ADC1, didr0::adc1d),
+        port::PC2: (crate::pac::adc::admux::MUX_A::ADC2, didr0::adc2d),
+        port::PC3: (crate::pac::adc::admux::MUX_A::ADC3, didr0::adc3d),
+        port::PC4: (crate::pac::adc::admux::MUX_A::ADC4, didr0::adc4d),
+        port::PC5: (crate::pac::adc::admux::MUX_A::ADC5, didr0::adc5d),
+    },
+    channels: {
+        channel::ADC6: crate::pac::adc::admux::MUX_A::ADC6,
+        channel::ADC7: crate::pac::adc::admux::MUX_A::ADC7,
+        channel::Vbg: crate::pac::adc::admux::MUX_A::ADC_VBG,
+        channel::Gnd: crate::pac::adc::admux::MUX_A::ADC_GND,
+        #[cfg(any(feature = "atmega328p", feature = "atmega328pb", feature = "atmega48p"))]
+        channel::Temperature: crate::pac::adc::admux::MUX_A::TEMPSENS,
+    },
+}
+
+#[cfg(feature = "atmega32u4")]
+avr_hal_generic::impl_adc! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::ADC,
+    channel_id: u8,
+    set_channel: |peripheral, id| {
+        peripheral.admux.modify(|_, w| w.mux().bits(id & 0x1f));
+        peripheral.adcsrb.modify(|_, w| w.mux5().bit(id & 0x20 != 0));
+    },
+    pins: {
+        port::PF0: (0b000000, didr0::adc0d),
+        port::PF1: (0b000001, didr0::adc1d),
+        port::PF4: (0b000100, didr0::adc4d),
+        port::PF5: (0b000101, didr0::adc5d),
+        port::PF6: (0b000110, didr0::adc6d),
+        port::PF7: (0b000111, didr0::adc7d),
+        port::PD4: (0b100000, didr2::adc8d),
+        port::PD6: (0b100001, didr2::adc9d),
+        port::PD7: (0b100010, didr2::adc10d),
+        port::PB4: (0b100011, didr2::adc11d),
+        port::PB5: (0b100100, didr2::adc12d),
+        port::PB6: (0b100101, didr2::adc13d),
+    },
+    channels: {
+        channel::Vbg: 0b011110,
+        channel::Gnd: 0b011111,
+        channel::Temperature: 0b100111,
+    },
+}
+
+#[cfg(any(feature = "atmega2560", feature = "atmega1280"))]
+avr_hal_generic::impl_adc! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::ADC,
+    channel_id: u8,
+    set_channel: |peripheral, id| {
+        peripheral.admux.modify(|_, w| w.mux().bits(id & 0x1f));
+        peripheral.adcsrb.modify(|_, w| w.mux5().bit(id & 0x20 != 0));
+    },
+    pins: {
+        port::PF0: (0b000000, didr0::adc0d),
+        port::PF1: (0b000001, didr0::adc1d),
+        port::PF2: (0b000010, didr0::adc2d),
+        port::PF3: (0b000011, didr0::adc3d),
+        port::PF4: (0b000100, didr0::adc4d),
+        port::PF5: (0b000101, didr0::adc5d),
+        port::PF6: (0b000110, didr0::adc6d),
+        port::PF7: (0b000111, didr0::adc7d),
+        port::PK0: (0b100000, didr2::adc8d),
+        port::PK1: (0b100001, didr2::adc9d),
+        port::PK2: (0b100010, didr2::adc10d),
+        port::PK3: (0b100011, didr2::adc11d),
+        port::PK4: (0b100100, didr2::adc12d),
+        port::PK5: (0b100101, didr2::adc13d),
+        port::PK6: (0b100110, didr2::adc14d),
+        port::PK7: (0b100111, didr2::adc15d),
+    },
+    channels: {
+        channel::Vbg: 0b011110,
+        channel::Gnd: 0b011111,
+    },
+}

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -66,6 +66,11 @@ pub mod i2c;
 #[cfg(feature = "device-selected")]
 pub use i2c::I2c;
 
+#[cfg(feature = "device-selected")]
+pub mod adc;
+#[cfg(feature = "device-selected")]
+pub use adc::Adc;
+
 pub struct Atmega;
 
 #[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]


### PR DESCRIPTION
Re-implementation of the ADC HAL and support for all MCUs in `atmega-hal`.  Also addressed issue #33 already.

Notably, I dropped the implementation of the *embedded-hal* ADC traits for now.  As discussed in #33 they are currently unfit for the purpose and instead of bending over backwards, I dropped them with the intention to re-add an implementation once *embedded-hal* hits 1.0.


Downstream code will look like this now:

- [Arduino Uno Example](https://github.com/Rahix/avr-hal/blob/af926bd1ffbf6804d9556c015103a5e15f1fdded/examples/arduino-uno/src/bin/uno-adc.rs)
- [Arduino Mega 2560 Example](https://github.com/Rahix/avr-hal/blob/af926bd1ffbf6804d9556c015103a5e15f1fdded/examples/arduino-mega2560/src/bin/mega2560-adc.rs), demonstrating the new "dynamic" channel type.