### PR TITLE
Arduino Uno - example HC-SR04 - Handling panic due to overflow

### DIFF
--- a/boards/arduino-uno/examples/uno-hc-sr04.rs
+++ b/boards/arduino-uno/examples/uno-hc-sr04.rs
@@ -59,12 +59,27 @@ fn main() -> ! {
         // Wait for the echo to get low again
         while echo.is_high().void_unwrap() {}
 
-        // 1 count == 4 us, so the value is multiplied by 4.
-        // 1/58 ≈ (34000 ms/2)* 1µs
-        let value = (timer1.tcnt1.read().bits() * 4) / 58;
+        // 1 count == 4 µs, so the value is multiplied by 4.
+        // 1/58 ≈ (34000 cm/s) * 1µs / 2
+        // when no object is detected, instead of keeping the echo pin completely low,  
+        // some HC-SR04 labeled sensor holds the echo pin in high state for very long time,
+        // thus overflowing the u16 value when multiplying the timer1 value with 4. 
+        // overflow during runtime causes panic! so it must be handled
+        let temp_timer = timer1.tcnt1.read().bits().saturating_mul(4);
+        let value  = match temp_timer {
+            u16::MAX => {
+                ufmt::uwriteln!(
+                &mut serial,
+                "Nothing was detected and jump to outer loop.\r"
+                )
+                .void_unwrap();
+                continue
+            },
+            _ => temp_timer / 58
+        };
 
         // Await 100 ms before sending the next trig
-        // 0.1s/4µs = 50000
+        // 0.1s/4µs = 25000
         while timer1.tcnt1.read().bits() < 25000 {}
 
         ufmt::uwriteln!(


### PR DESCRIPTION
Some HC-SR04 sensor builds keep their echo pin in high state for long time, instead of keeping it in low state when no object is detected. This is mentioned here for example: https://forum.arduino.cc/index.php?topic=55119.0

When this happens the multiplication of the TIMER1 value with 4 goes into overflow, resulting panic, crashing the program execution.

The proposed change solves this issue by handling the saturating u16 value the same way as if the echo pin never had gone high. 

