### PR TITLE
Add explicit support for arduino-nano

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ members = [
 
     # Examples
     "examples/arduino-leonardo",
-    "examples/arduino-uno",
     "examples/arduino-mega2560",
+    "examples/arduino-nano",
+    "examples/arduino-uno",
 ]
 exclude = [
     # The RAVEDUDE! Yeah!

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -10,9 +10,10 @@ rt = ["atmega-hal/rt"]
 
 board-selected = []
 mcu-atmega=[]
-arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 arduino-leonardo = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 arduino-mega2560 = ["mcu-atmega", "atmega-hal/atmega2560", "board-selected"]
+arduino-nano = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-adc", "board-selected"]
+arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 
 [dependencies]
 cfg-if = "1"

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -1,10 +1,11 @@
 pub use avr_hal_generic::clock::*;
 
 pub(crate) mod default {
-    #[cfg(feature = "arduino-uno")]
-    pub type DefaultClock = avr_hal_generic::clock::MHz16;
-    #[cfg(feature = "arduino-leonardo")]
-    pub type DefaultClock = avr_hal_generic::clock::MHz16;
-    #[cfg(feature = "arduino-mega2560")]
+    #[cfg(any(
+        feature = "arduino-leonardo",
+        feature = "arduino-mega2560",
+        feature = "arduino-nano",
+        feature = "arduino-uno",
+    ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz16;
 }

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -6,9 +6,10 @@ compile_error!(
 
     Please select one of the following
 
-    * arduino-uno
     * arduino-leonardo
     * arduino-mega2560
+    * arduino-nano
+    * arduino-uno
     "
 );
 
@@ -74,7 +75,7 @@ pub use usart::Usart;
 #[cfg(feature = "board-selected")]
 pub mod prelude {
     cfg_if::cfg_if! {
-        if #[cfg(feature = "arduino-uno")] {
+        if #[cfg(any(feature = "arduino-mega2560", feature = "arduino-uno"))] {
             pub use crate::hal::usart::BaudrateArduinoExt as _;
         } else {
             pub use crate::hal::usart::BaudrateExt as _;
@@ -94,18 +95,6 @@ macro_rules! pins {
     };
 }
 
-#[cfg(any(feature = "arduino-uno"))]
-#[macro_export]
-macro_rules! default_serial {
-    ($p:expr, $pins:expr, $baud:expr) => {
-        $crate::Usart::new(
-            $p.USART0,
-            $pins.d0,
-            $pins.d1.into_output(),
-            $crate::hal::usart::BaudrateArduinoExt::into_baudrate($baud),
-        )
-    };
-}
 #[cfg(any(feature = "arduino-leonardo"))]
 #[macro_export]
 macro_rules! default_serial {
@@ -118,7 +107,21 @@ macro_rules! default_serial {
         )
     };
 }
-#[cfg(any(feature = "arduino-mega2560"))]
+// See comment in avr-hal-generic/src/usart.rs for why these boards use
+// the BaudrateArduinoExt trait instead of BaudrateExt
+#[cfg(any(feature = "arduino-mega2560", feature = "arduino-uno"))]
+#[macro_export]
+macro_rules! default_serial {
+    ($p:expr, $pins:expr, $baud:expr) => {
+        $crate::Usart::new(
+            $p.USART0,
+            $pins.d0,
+            $pins.d1.into_output(),
+            $crate::hal::usart::BaudrateArduinoExt::into_baudrate($baud),
+        )
+    };
+}
+#[cfg(feature = "arduino-nano")]
 #[macro_export]
 macro_rules! default_serial {
     ($p:expr, $pins:expr, $baud:expr) => {

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -2,11 +2,11 @@
 mod leonardo;
 #[cfg(feature = "arduino-leonardo")]
 pub use leonardo::*;
-#[cfg(feature = "arduino-uno")]
-mod uno;
-#[cfg(feature = "arduino-uno")]
-pub use uno::*;
 #[cfg(feature = "arduino-mega2560")]
 mod mega2560;
 #[cfg(feature = "arduino-mega2560")]
 pub use mega2560::*;
+#[cfg(any(feature = "arduino-nano", feature = "arduino-uno"))]
+mod uno;
+#[cfg(any(feature = "arduino-nano", feature = "arduino-uno"))]
+pub use uno::*;

--- a/examples/arduino-nano/.cargo/config.toml
+++ b/examples/arduino-nano/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-atmega328p.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "ravedude nano -cb 57600"
+
+[unstable]
+build-std = ["core"]

--- a/examples/arduino-nano/Cargo.toml
+++ b/examples/arduino-nano/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "arduino-nano-examples"
+version = "0.0.0"
+authors = ["David R. Morrison <drmorr@evokewonder.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+ufmt = "0.1.0"
+nb = "0.1.2"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["arduino-nano"]

--- a/examples/arduino-nano/src/bin/nano-adc.rs
+++ b/examples/arduino-nano/src/bin/nano-adc.rs
@@ -44,6 +44,14 @@ fn main() -> ! {
             ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
         }
 
+        // Arduino Nano has two more ADC pins A6 and A7.  Accessing them works a bit different from
+        // the other pins as they are not normal IO pins.  The code below shows how it works.
+        let (a6, a7) = (
+            adc.read_blocking(&adc::channel::ADC6),
+            adc.read_blocking(&adc::channel::ADC7),
+        );
+        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).void_unwrap();
+
         ufmt::uwriteln!(&mut serial, "").void_unwrap();
         arduino_hal::delay_ms(1000);
     }

--- a/examples/arduino-nano/src/bin/nano-blink.rs
+++ b/examples/arduino-nano/src/bin/nano-blink.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    // Digital pin 13 is also connected to an onboard LED marked "L"
+    let mut led = pins.d13.into_output();
+    led.set_high();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(800);
+    }
+}

--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 rt = ["avr-device/rt"]
 device-selected = []
+enable-extra-adc = []
 atmega48p = ["avr-device/atmega48p", "device-selected"]
 atmega168 = ["avr-device/atmega168", "device-selected"]
 atmega328p = ["avr-device/atmega328p", "device-selected"]

--- a/mcu/atmega-hal/src/adc.rs
+++ b/mcu/atmega-hal/src/adc.rs
@@ -22,18 +22,24 @@ pub type Channel = avr_hal_generic::adc::Channel<crate::Atmega, crate::pac::ADC>
 /// let value = adc.read_blocking(&channel::Vbg);
 /// ```
 pub mod channel {
-    #[cfg(any(
-        feature = "atmega168",
-        feature = "atmega328p",
-        feature = "atmega328pb",
-        feature = "atmega48p"
+    #[cfg(all(
+        any(
+            feature = "atmega168",
+            feature = "atmega328p",
+            feature = "atmega328pb",
+            feature = "atmega48p",
+        ),
+        feature = "enable-extra-adc",
     ))]
     pub struct ADC6;
-    #[cfg(any(
-        feature = "atmega168",
-        feature = "atmega328p",
-        feature = "atmega328pb",
-        feature = "atmega48p"
+    #[cfg(all(
+        any(
+            feature = "atmega168",
+            feature = "atmega328p",
+            feature = "atmega328pb",
+            feature = "atmega48p"
+        ),
+        feature = "enable-extra-adc",
     ))]
     pub struct ADC7;
     #[cfg(any(
@@ -87,7 +93,9 @@ avr_hal_generic::impl_adc! {
         port::PC5: (crate::pac::adc::admux::MUX_A::ADC5, didr0::adc5d),
     },
     channels: {
+        #[cfg(feature = "enable-extra-adc")]
         channel::ADC6: crate::pac::adc::admux::MUX_A::ADC6,
+        #[cfg(feature = "enable-extra-adc")]
         channel::ADC7: crate::pac::adc::admux::MUX_A::ADC7,
         channel::Vbg: crate::pac::adc::admux::MUX_A::ADC_VBG,
         channel::Gnd: crate::pac::adc::admux::MUX_A::ADC_GND,


### PR DESCRIPTION
Ugh I somehow screwed up my other PR (#169) again; I'm not sure how I did that this time.  Anyways, I think I addressed your comments.

1. Add the arduino-nano feature flag to arduino-hal.
2. Make the ADC6 and ADC7 pins only available for nano, not for uno.
3. Add an example crate for arduino-nano with just a blink and ADC example.