### PR TITLE
minor amendment to SPI code

### DIFF
--- a/avr-hal-generic/src/spi.rs
+++ b/avr-hal-generic/src/spi.rs
@@ -231,6 +231,10 @@ where
         Ok(())
     }
 
+    fn receive(&mut self) -> u8 {
+        self.p.raw_read()
+    }
+
     fn write(&mut self, byte: u8) {
         self.write_in_progress = true;
         self.p.raw_write(byte);
@@ -261,7 +265,7 @@ where
     /// Reads and returns the response in the data register
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.flush()?;
-        Ok(self.p.raw_read())
+        Ok(self.receive())
     }
 }
 


### PR DESCRIPTION
## Summary

If you want to write code that doesn't want to depend on embedded-hal for some reason, there's no way to do that without this fix since there's no "native" receive function.  This change adds that, and it makes the embedded-hal trait implementation depend on the "native" functions.

## Testing done
Works on my nano.