### PR TITLE
digital::StatefulOutputPin.is_set_high() was using incorrect reg

### DIFF
--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -591,7 +591,7 @@ macro_rules! impl_port {
                 impl digital::StatefulOutputPin for $PXi<mode::Output> {
                     fn is_set_high(&self) -> Result<bool, Self::Error> {
                         Ok(unsafe {
-                            (*<$PORTX>::ptr()).$reg_port.read().bits()
+                            (*<$PORTX>::ptr()).$reg_pin.read().bits()
                         } & (1 << $i) != 0)
                     }
 


### PR DESCRIPTION
Discovered that the OutputPin trait is using the wrong register to read the value of the Pin.

Fixed function to use PINd instead of PORTd register