### PR TITLE
ravedude: Add support for Arduino Micro

### DIFF
--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -79,7 +79,7 @@ impl Board for ArduinoMicro {
     }
 
     fn needs_reset(&self) -> Option<&str> {
-        None
+        Some("Reset the board by pressing the reset button once.")
     }
 
     fn avrdude_options(&self) -> avrdude::AvrdudeOptions {
@@ -92,7 +92,14 @@ impl Board for ArduinoMicro {
     }
 
     fn guess_port(&self) -> Option<std::path::PathBuf> {
-        None
+        find_port_from_vid_pid_list(&[
+            (0x2341, 0x0037),
+            (0x2341, 0x8037),
+            (0x2A03, 0x0037),
+            (0x2A03, 0x8037),
+            (0x2341, 0x0237),
+            (0x2341, 0x8237),
+        ])
     }
 }
 

--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -12,6 +12,7 @@ pub fn get_board(board: &str) -> Option<Box<dyn Board>> {
         "uno" => Box::new(ArduinoUno),
         "nano" => Box::new(ArduinoNano),
         "leonardo" => Box::new(ArduinoLeonardo),
+        "micro" => Box::new(ArduinoMicro),
         "mega2560" => Box::new(ArduinoMega2560),
         "diecimila" => Box::new(ArduinoDiecimila),
         "promicro" => Box::new(SparkFunProMicro),
@@ -67,6 +68,31 @@ impl Board for ArduinoUno {
             (0x2A03, 0x0043),
             (0x2341, 0x0243),
         ])
+    }
+}
+
+struct ArduinoMicro;
+
+impl Board for ArduinoMicro {
+    fn display_name(&self) -> &str {
+        "Arduino Micro"
+    }
+
+    fn needs_reset(&self) -> Option<&str> {
+        None
+    }
+
+    fn avrdude_options(&self) -> avrdude::AvrdudeOptions {
+        avrdude::AvrdudeOptions {
+            programmer: "avr109",
+            partno: "atmega32u4",
+            baudrate: Some(115200),
+            do_chip_erase: true,
+        }
+    }
+
+    fn guess_port(&self) -> Option<std::path::PathBuf> {
+        None
     }
 }
 

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -41,6 +41,7 @@ struct Args {
     /// Must be one of the known board identifiers:
     ///
     /// * uno
+    /// * micro
     /// * nano
     /// * leonardo
     /// * mega2560


### PR DESCRIPTION
This PR copies the MC definition from `leonardo` and adds it explicitly as `micro`.