### PR TITLE
trinket-pro support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
             name: arduino-mega2560
           - type: board
             name: sparkfun-promicro
+          - type: board
+            name: trinket-pro
           - type: mcu
             name: atmega1280
             spec: atmega1280

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "examples/arduino-nano",
     "examples/arduino-uno",
     "examples/sparkfun-promicro",
+    "examples/trinket-pro",
 ]
 exclude = [
     # The RAVEDUDE! Yeah!

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -15,6 +15,7 @@ arduino-leonardo = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 arduino-mega2560 = ["mcu-atmega", "atmega-hal/atmega2560", "board-selected"]
 arduino-nano = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-adc", "board-selected"]
 arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
+trinket-pro = ["arduino-uno"]
 sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 
 [dependencies]

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -15,7 +15,7 @@ arduino-leonardo = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 arduino-mega2560 = ["mcu-atmega", "atmega-hal/atmega2560", "board-selected"]
 arduino-nano = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-adc", "board-selected"]
 arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
-trinket-pro = ["arduino-uno"]
+trinket-pro = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 
 [dependencies]

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -21,6 +21,7 @@ pub(crate) mod default {
         feature = "arduino-nano",
         feature = "arduino-uno",
         feature = "sparkfun-promicro",
+        feature = "trinket-pro",
     ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz16;
 }

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(feature = "arduino-nano", doc = "**Arduino Nano**.")]
 #![cfg_attr(feature = "arduino-uno", doc = "**Arduino Uno**.")]
 #![cfg_attr(feature = "sparkfun-promicro", doc = "**SparkFun ProMicro**.")]
+#![cfg_attr(feature = "trinket-pro", doc = "**Trinket Pro**.")]
 //! This means that only items which are available for this board are visible.  If you are using a
 //! different board, try building the documentation locally with
 //!
@@ -54,6 +55,7 @@ compile_error!(
     * arduino-nano
     * arduino-uno
     * sparkfun-promicro
+    * trinket-pro
     "
 );
 

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -35,3 +35,7 @@ pub use uno::*;
 mod promicro;
 #[cfg(feature = "sparkfun-promicro")]
 pub use promicro::*;
+#[cfg(feature = "trinket-pro")]
+mod trinket_pro;
+#[cfg(feature = "trinket-pro")]
+pub use trinket_pro::*;

--- a/arduino-hal/src/port/trinket_pro.rs
+++ b/arduino-hal/src/port/trinket_pro.rs
@@ -1,0 +1,119 @@
+pub use atmega_hal::port::mode;
+pub use atmega_hal::port::Pin;
+
+avr_hal_generic::renamed_pins! {
+    type Pin = Pin;
+
+    /// Pins of the **Trinket Pro**.
+    ///
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][pins] macro.
+    pub struct Pins from atmega_hal::Pins {
+        /// `A0`
+        ///
+        /// * ADC0 (ADC input channel 0)
+        /// * PCINT8 (pin change interrupt 8)
+        pub a0: atmega_hal::port::PC0 = pc0,
+        /// `A1`
+        ///
+        /// * ADC1 (ADC input channel 1)
+        /// * PCINT9 (pin change interrupt 9)
+        pub a1: atmega_hal::port::PC1 = pc1,
+        /// `A2`
+        ///
+        /// * ADC2 (ADC input channel 2)
+        /// * PCINT10 (pin change interrupt 10)
+        pub a2: atmega_hal::port::PC2 = pc2,
+        /// `A3`
+        ///
+        /// * ADC3 (ADC input channel 3)
+        /// * PCINT11 (pin change interrupt 11)
+        pub a3: atmega_hal::port::PC3 = pc3,
+        /// `A4`
+        ///
+        /// * ADC4 (ADC input channel 4)
+        /// * SDA (2-wire serial bus data input/output line)
+        /// * PCINT12 (pin change interrupt 12)
+        pub a4: atmega_hal::port::PC4 = pc4,
+        /// `A5`
+        ///
+        /// ADC5 (ADC input channel 5)
+        /// SCL (2-wire serial bus clock line)
+        /// PCINT13 (pin change interrupt 13)
+        pub a5: atmega_hal::port::PC5 = pc5,
+
+        /// `D0` / `RX`
+        ///
+        /// * RXD (USART input pin)
+        /// * PCINT16 (pin change interrupt 16)
+        pub d0: atmega_hal::port::PD0 = pd0,
+        /// `D1` / `TX`
+        ///
+        /// * TXD (USART output pin)
+        /// * PCINT17 (pin change interrupt 17)
+        pub d1: atmega_hal::port::PD1 = pd1,
+        /// `D3`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * INT1 (external interrupt 1 input)
+        /// * OC2B (Timer/Counter2 output compare match B output)
+        /// * PCINT19 (pin change interrupt 19)
+        pub d3: atmega_hal::port::PD3 = pd3,
+        /// `D4`
+        ///
+        /// * XCK (USART external clock input/output)
+        /// * T0 (Timer/Counter 0 external counter input)
+        /// * PCINT20 (pin change interrupt 20)
+        pub d4: atmega_hal::port::PD4 = pd4,
+        /// `D5`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * T1 (Timer/Counter 1 external counter input)
+        /// * OC0B (Timer/Counter0 output compare match B output)
+        /// * PCINT21 (pin change interrupt 21)
+        pub d5: atmega_hal::port::PD5 = pd5,
+        /// `D6`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * AIN0 (analog comparator positive input)
+        /// * OC0A (Timer/Counter0 output compare match A output)
+        /// * PCINT22 (pin change interrupt 22)
+        pub d6: atmega_hal::port::PD6 = pd6,
+        /// `D8`
+        ///
+        /// * ICP1 (Timer/Counter1 input capture input)
+        /// * CLKO (divided system clock output)
+        /// * PCINT0 (pin change interrupt 0)
+        pub d8: atmega_hal::port::PB0 = pb0,
+        /// `D9`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * OC1A (Timer/Counter1 output compare match A output)
+        /// * PCINT1 (pin change interrupt 1)
+        pub d9: atmega_hal::port::PB1 = pb1,
+        /// `D10`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * SS (SPI bus master slave select)
+        /// * OC1B (Timer/Counter1 output compare match B output)
+        /// * PCINT2 (pin change interrupt 2)
+        pub d10: atmega_hal::port::PB2 = pb2,
+        /// `D11`
+        ///
+        /// * **PWM**: [atmega328p_hal::timer::Timer3Pwm]
+        /// * MOSI (SPI bus master/slave input)
+        /// * OC2A (Timer/Counter2 output compare match A output)
+        /// * PCINT3 (pin change interrupt 3)
+        pub d11: atmega_hal::port::PB3 = pb3,
+        /// `D12`
+        ///
+        /// * MISO (SPI bus master input/slave output)
+        /// * PCINT4 (pin change interrupt 4)
+        pub d12: atmega_hal::port::PB4 = pb4,
+        /// `D13`
+        ///
+        /// * SCK (SPI bus master clock input)
+        /// * PCINT5 (pin change interrupt 5)
+        /// * L LED on Trinket Pro
+        pub d13: atmega_hal::port::PB5 = pb5,
+    }
+}

--- a/examples/trinket-pro/.cargo/config.toml
+++ b/examples/trinket-pro/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-atmega328p.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "ravedude trinket-pro"
+
+[unstable]
+build-std = ["core"]

--- a/examples/trinket-pro/Cargo.toml
+++ b/examples/trinket-pro/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "trinket-pro-examples"
+version = "0.0.0"
+authors = ["Gaute Hope <eg@gaute.vetsj.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["trinket-pro"]

--- a/examples/trinket-pro/src/bin/trinket-pro-blink.rs
+++ b/examples/trinket-pro/src/bin/trinket-pro-blink.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    // Digital pin 13 is also connected to an onboard LED marked "L"
+    let mut led = pins.d13.into_output();
+    led.set_high();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(800);
+    }
+}

--- a/ravedude/src/avrdude/mod.rs
+++ b/ravedude/src/avrdude/mod.rs
@@ -19,7 +19,7 @@ pub struct Avrdude {
 impl Avrdude {
     pub fn run(
         options: &AvrdudeOptions,
-        port: &path::Path,
+        port: Option<impl AsRef<path::Path>>,
         bin: &path::Path,
     ) -> anyhow::Result<Self> {
         let config = tempfile::Builder::new()
@@ -44,9 +44,13 @@ impl Avrdude {
             .arg("-c")
             .arg(options.programmer)
             .arg("-p")
-            .arg(options.partno)
-            .arg("-P")
-            .arg(port);
+            .arg(options.partno);
+
+        if let Some(port) = port {
+            command = command
+                .arg("-P")
+                .arg(port.as_ref());
+        }
 
         if let Some(baudrate) = options.baudrate {
             command = command.arg("-b").arg(baudrate.to_string());


### PR DESCRIPTION
* adds support to ravedude for boards without serial console
* pins anyhow for ravedude on version that works on rust 2021-01-07
* adds blink example for trinket-pro

tested on 5V board, but think should work on 3V as well. Have not verified all pin names yet.