### PR TITLE
Add support for Nano clones with ATmega168

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,6 @@ jobs:
             spec: atmega1280
             crate: atmega-hal
           - type: mcu
-            name: atmega168
-            spec: atmega168
-            crate: atmega-hal
-          - type: mcu
             name: atmega328pb
             spec: atmega328p
             crate: atmega-hal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,28 @@ jobs:
         m:
           - type: board
             name: arduino-uno
+            examples: true
           - type: board
             name: arduino-diecimila
+            examples: true
           - type: board
             name: arduino-leonardo
+            examples: true
           - type: board
             name: arduino-mega2560
+            examples: true
           - type: board
             name: sparkfun-promicro
+            examples: true
           - type: board
             name: trinket-pro
+            examples: true
+          - type: board
+            name: arduino-nano
+            examples: false
+          - type: board
+            name: nano168
+            examples: false
           - type: mcu
             name: atmega1280
             spec: atmega1280
@@ -65,8 +77,11 @@ jobs:
       - name: Install avr-gcc, binutils, and libc
         run: sudo apt-get install -y avr-libc binutils-avr gcc-avr
       - name: Compile board crate and examples
-        if: "${{ matrix.m.type == 'board' }}"
+        if: "${{ matrix.m.type == 'board' && matrix.m.examples }}"
         run: cd "examples/${{ matrix.m.name }}" && cargo build --bins
+      - name: Compile board crate (without examples)
+        if: "${{ matrix.m.type == 'board' && !matrix.m.examples }}"
+        run: cd "arduino-hal/" && cargo build --features "${{ matrix.m.name }}"
       - name: Test-compile HAL crate for an MCU
         if: "${{ matrix.m.type == 'mcu' }}"
         run: cd "mcu/${{ matrix.m.crate }}" && cargo build --features "${{ matrix.m.name }}" -Z build-std=core --target "../../avr-specs/avr-${{ matrix.m.spec }}.json"

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -17,6 +17,7 @@ arduino-nano = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-
 arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 trinket-pro = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
+nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", "board-selected"]
 
 [dependencies]
 cfg-if = "1"

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -22,6 +22,7 @@ pub(crate) mod default {
         feature = "arduino-uno",
         feature = "sparkfun-promicro",
         feature = "trinket-pro",
+        feature = "nano168",
     ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz16;
 }

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(feature = "arduino-uno", doc = "**Arduino Uno**.")]
 #![cfg_attr(feature = "sparkfun-promicro", doc = "**SparkFun ProMicro**.")]
 #![cfg_attr(feature = "trinket-pro", doc = "**Trinket Pro**.")]
+#![cfg_attr(feature = "nano168", doc = "**Nano clone (ATmega168)**.")]
 //! This means that only items which are available for this board are visible.  If you are using a
 //! different board, try building the documentation locally with
 //!
@@ -56,6 +57,7 @@ compile_error!(
     * arduino-uno
     * sparkfun-promicro
     * trinket-pro
+    * nano168
     "
 );
 

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -27,9 +27,9 @@ pub use leonardo::*;
 mod mega2560;
 #[cfg(feature = "arduino-mega2560")]
 pub use mega2560::*;
-#[cfg(any(feature = "arduino-nano", feature = "arduino-uno"))]
+#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168"))]
 mod uno;
-#[cfg(any(feature = "arduino-nano", feature = "arduino-uno"))]
+#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168"))]
 pub use uno::*;
 #[cfg(feature = "sparkfun-promicro")]
 mod promicro;

--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -17,6 +17,7 @@ pub fn get_board(board: &str) -> Option<Box<dyn Board>> {
         "diecimila" => Box::new(ArduinoDiecimila),
         "promicro" => Box::new(SparkFunProMicro),
         "trinket-pro" => Box::new(TrinketPro),
+        "nano168" => Box::new(Nano168),
         _ => return None,
     })
 }
@@ -268,5 +269,30 @@ impl Board for TrinketPro {
 
     fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
         None // The TrinketPro does not have USB-to-Serial.
+    }
+}
+
+struct Nano168;
+
+impl Board for Nano168 {
+    fn display_name(&self) -> &str {
+        "Nano Clone (ATmega168)"
+    }
+
+    fn needs_reset(&self) -> Option<&str> {
+        None
+    }
+
+    fn avrdude_options(&self) -> avrdude::AvrdudeOptions {
+        avrdude::AvrdudeOptions {
+            programmer: "arduino",
+            partno: "atmega168",
+            baudrate: Some(19200),
+            do_chip_erase: false,
+        }
+    }
+
+    fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
+        Some(Err(anyhow::anyhow!("Not able to guess port")))
     }
 }


### PR DESCRIPTION
Apparently there is a big market of Arduino Nano clones which use the ATmega168 instead of ATmega328P.  Support those devices as well under the name `nano168`.

- [x] `ravedude` support
  - [x] confirm it is working
- [x] `arduino-hal` support
- [x] `avr-hal-template` support