### PR TITLE
The  nano168 also supports serial

### DIFF
--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -233,7 +233,7 @@ macro_rules! default_serial {
         )
     };
 }
-#[cfg(feature = "arduino-nano")]
+#[cfg(any(feature = "arduino-nano", feature = "nano168"))]
 #[macro_export]
 macro_rules! default_serial {
     ($p:expr, $pins:expr, $baud:expr) => {


### PR DESCRIPTION
I think it does make sense to enable serial for the atmega168.