### PR TITLE
Add RAVEDUDE_PORT definition to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Go into `./examples/arduino-uno` (or the directory for whatever board you want),
 ```bash
 cd examples/arduino-uno
 
+# Set the serial port connected to the Arduino
+export RAVEDUDE_PORT=/dev/ttyUSB1
+
 # Build and run it on a connected board
 cargo run --bin uno-blink
 ```


### PR DESCRIPTION
The uno-blink example does not run unless RAVEDUDE_PORT is defined.