### PR TITLE
ravedude: Add autoreset logic for Arduino Leonardo

### DIFF
--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -138,7 +138,19 @@ impl Board for ArduinoLeonardo {
     }
 
     fn needs_reset(&self) -> Option<&str> {
-        Some("Reset the board by pressing the reset button once.")
+        let a = self.guess_port();
+        match a {
+            Some(Ok(name)) => {
+                match serialport::new(name.to_str().unwrap(), 1200).open() {
+                    Ok(_) => {
+                        std::thread::sleep(core::time::Duration::from_secs(1));
+                        None
+                    },
+                    Err(_) => Some("Reset the board by pressing the reset button once.")
+                }
+            },
+            _ => Some("Reset the board by pressing the reset button once.")
+        }
     }
 
     fn avrdude_options(&self) -> avrdude::AvrdudeOptions {


### PR DESCRIPTION
The arduino leonardo uses a funny method for autoreset. Whenever
you connect to the usb driven serial port at 1200 baud, it resets.
I have implemented this logic. If it can't find a device to
connect to, then it will fall back to asking you to manually
reset the device.

This protocol is not yet implemented in avr-hal, so this will
only work with loading firmware on a device that was flashed with
the arduino tools. Until avr-hal implements this protocol for
the leonardo, you will have to continue to manually reset if
during programming. However, I think that it is useful to
implement this side of the protocol as a motivation for getting
the USB CDC serial device working on leonardo.

I tested it numerous times, and it seems to be reliable when I
flash a device previously flashed with the arduino tools.