### PR TITLE
Use the mode constant from the embedded hal.

### DIFF
--- a/avr-hal-generic/src/spi.rs
+++ b/avr-hal-generic/src/spi.rs
@@ -58,10 +58,7 @@ impl Default for Settings {
         Settings {
             data_order: DataOrder::MostSignificantFirst,
             clock: SerialClockRate::OscfOver4,
-            mode: spi::Mode {
-                polarity: spi::Polarity::IdleLow,
-                phase: spi::Phase::CaptureOnSecondTransition,
-            },
+            mode: spi::MODE_1,
         }
     }
 }


### PR DESCRIPTION
The setting in the avr-generic-hal match the MODE_1
constant in the embedded hal spi implementation. Use
that instead of duplicating it.