### PR TITLE
trinket: erase chip on upload

### DIFF
--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -301,7 +301,7 @@ impl Board for Trinket {
             programmer: "usbtiny",
             partno: "attiny85",
             baudrate: None,
-            do_chip_erase: false,
+            do_chip_erase: true,
         }
     }
 


### PR DESCRIPTION
After few tests I spotted that chip should be erased for Trinket. Still I'm getting 
```
avrdude: verifying ...
avrdude: verification error, first mismatch at byte 0x0000
         0x00 != 0x0e
avrdude: verification error; content mismatch

avrdude: safemode: Fuses OK (E:00, H:00, L:00)

avrdude done.  Thank you.
```
Blink example is uploaded with success - tested for few version. @Rahix can you please review? Maybe after first load bootloader was corrupted.