### PR TITLE
ravedude: Cleanly terminate on CTRL+C

### DIFF
--- a/ravedude/Cargo.lock
+++ b/ravedude/Cargo.lock
@@ -59,10 +59,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.2.1"
+name = "autocfg"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
@@ -103,6 +109,16 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
+ "winapi",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
+dependencies = [
+ "nix 0.23.0",
  "winapi",
 ]
 
@@ -165,9 +181,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.90"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "libudev"
@@ -214,6 +230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "nix"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +249,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -332,6 +370,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "colored",
+ "ctrlc",
  "git-version",
  "serialport",
  "structopt",
@@ -385,7 +424,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libudev",
  "mach 0.2.3",
- "nix",
+ "nix 0.16.1",
  "regex",
  "winapi",
 ]

--- a/ravedude/Cargo.toml
+++ b/ravedude/Cargo.toml
@@ -16,6 +16,7 @@ tempfile = "3.2.0"
 serialport = "4.0.0"
 anyhow = "1.0.38"
 git-version = "0.3.4"
+ctrlc = "3.2.1"
 
 [dependencies.structopt]
 version = "0.3.21"

--- a/ravedude/src/console.rs
+++ b/ravedude/src/console.rs
@@ -12,6 +12,13 @@ pub fn open(port: &std::path::Path, baudrate: u32) -> anyhow::Result<()> {
     let mut stdin = std::io::stdin();
     let mut stdout = std::io::stdout();
 
+    // Set a CTRL+C handler to terminate cleanly instead of with an error.
+    ctrlc::set_handler(move || {
+        eprintln!("");
+        eprintln!("Exiting.");
+        std::process::exit(0);
+    }).context("failed setting a CTRL+C handler")?;
+
     // Spawn a thread for the receiving end because stdio is not portably non-blocking...
     std::thread::spawn(move || loop {
         let mut buf = [0u8; 4098];

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -134,6 +134,11 @@ fn ravedude() -> anyhow::Result<()> {
         let port = port.context("console can only be opened for devices with USB-to-Serial")?;
 
         task_message!("Console", "{} at {} baud", port.display(), baudrate);
+        task_message!(
+            "",
+            "{}",
+            "CTRL+C to exit.".dimmed()
+        );
         // Empty line for visual consistency
         eprintln!();
         console::open(&port, baudrate)?;


### PR DESCRIPTION
Install a CTRL+C handler to terminate with exit code 0 instead of the default handler which exits with a failure.

@lord-ne, can you give this a test-run on your windows system to see if the error message is gone now?

Fixes: #216