### PR TITLE
generic: delay: update to asm!

### DIFF
--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -34,13 +34,12 @@ impl<SPEED> Delay<SPEED> {
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "avr")] {
         #[allow(unused_assignments)]
-        fn busy_loop(mut c: u16) {
+        fn busy_loop(c: u16) {
             unsafe {
-                llvm_asm!("1: sbiw $0,1\n\tbrne 1b"
-                     : "=w"(c)
-                     : "0"(c)
-                     :
-                     : "volatile"
+                 asm!(
+                    "1: sbiw {}, 1",
+                    "brne 1b",
+                    in(reg_iw) c,
                  );
             }
         }
@@ -82,7 +81,12 @@ impl delay::DelayUs<u16> for Delay<crate::clock::MHz20> {
         // for a one-microsecond delay, simply return.  the overhead
         // of the function call takes 18 (20) cycles, which is 1us
         unsafe {
-            llvm_asm!("nop\nnop\nnop\nnop" :::: "volatile");
+            asm!(
+                "nop",
+                "nop",
+                "nop",
+                "nop",
+            );
         } //just waiting 4 cycles
 
         if us <= 1 {

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
-#![feature(llvm_asm)]
+#![feature(asm)]
+#![feature(asm_experimental_arch)]
 
 pub extern crate embedded_hal as hal;
 


### PR DESCRIPTION
Not mergeable until:
- [ ] LLVM [D114611](https://reviews.llvm.org/D114611) lands
- [ ] and is cherry-picked into Rust, and
- [x]  rust-lang/rust#91224 lands,
- [ ] and a nightly is released with both.

Will need to:

- [ ] update `rust-toolchain` file to use `nightly`
- [ ] remove `#![feature(asm)]` if https://github.com/rust-lang/rust/issues/72016 merges first (likely)

Tested on a local build of rustc bringing in both of those changes.