### PR TITLE
README: Add a note about necessary dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Hardware Abstraction Layer for AVR microcontrollers and common boards (for examp
 ## Quickstart
 You need a nightly Rust compiler for compiling Rust code for AVR.  **Note**: Due to a regression, versions after `nightly-2021-01-07` are currently broken (see [#124](https://github.com/Rahix/avr-hal/issues/124)).  Please use that version of the compiler for now. The correct version will be installed automatically.
 
+On Ubuntu, you'll need to install dependencies:
+
+```bash
+sudo apt install avr-libc gcc-avr pkg-config avrdude
+```
+
 Next, install ["ravedude"](./ravedude), a tool which seamlessly integrates flashing your board into the usual cargo workflow:
 
 ```bash


### PR DESCRIPTION
I ran into trouble running the examples as I didn't realize from the README that it was necessary to install a few things from `apt` before running the Rust code. In case it's useful I've documented them here. 