### PR TITLE
Added one pair of vid_pid for Arduino Nano

### DIFF
--- a/ravedude/README.md
+++ b/ravedude/README.md
@@ -7,6 +7,9 @@ target's serial console, similar to the Arduino IDE.
 `ravedude` is meant to be used as a cargo "runner".  This allows you to just use
 `cargo run` for building, deploying, and running your AVR code!
 
+if you get an `Error: no matching serial port found, use -P or set RAVEDUDE_PORT in your environment` , 
+run `cargo run` with set environment variable or adjust `runner = "ravedude {X} -cb {X} -P /dev/ttyUSB{X}"` inside `.cargo/config.toml` (replace {X} with your respective values)
+
 ## Installation
 On Linux systems, you'll need pkg-config and libudev development files
 installed:
@@ -46,7 +49,7 @@ Reading | ################################################## | 100% 0.00s
 
 avrdude: Device signature = 0x1e950f (probably m328p)
 avrdude: erasing chip
-avrdude: reading input file &quot;avr-hal/target/avr-atmega328p/debug/uno-i2cdetect.elf&quot;
+avrdude: reading input file &quot;avr-hal/target/avr-atmega328p/debug/uno-i2cdetect.elf&quot; 
 avrdude: writing flash (1654 bytes):
 
 Writing | ################################################## | 100% 0.27s

--- a/ravedude/README.md
+++ b/ravedude/README.md
@@ -49,7 +49,7 @@ Reading | ################################################## | 100% 0.00s
 
 avrdude: Device signature = 0x1e950f (probably m328p)
 avrdude: erasing chip
-avrdude: reading input file &quot;avr-hal/target/avr-atmega328p/debug/uno-i2cdetect.elf&quot; 
+avrdude: reading input file &quot;avr-hal/target/avr-atmega328p/debug/uno-i2cdetect.elf&quot;
 avrdude: writing flash (1654 bytes):
 
 Writing | ################################################## | 100% 0.27s

--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -127,7 +127,9 @@ impl Board for ArduinoNano {
     }
 
     fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
-        Some(Err(anyhow::anyhow!("Not able to guess port")))
+        Some(find_port_from_vid_pid_list(&[
+            (0x1A86, 0x7523),
+        ]))
     }
 }
 

--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -127,9 +127,7 @@ impl Board for ArduinoNano {
     }
 
     fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
-        Some(find_port_from_vid_pid_list(&[
-            (0x1A86, 0x7523),
-        ]))
+        Some(Err(anyhow::anyhow!("Not able to guess port")))
     }
 }
 


### PR DESCRIPTION
Hey, thank you for your great Arduino libraries.
I wanted to try out rust for embedded on one of my Arduino Nano's and noticed, that the `guess_port` method failed for my device due to missing vid,pid pairs for the arduino nano via:
``` 
Error: no matching serial port found, use -P or set RAVEDUDE_PORT in your environment

Caused by: Not able to guess port
```
I added at least my pair and added a sentence about this failure inside `Readme`.

```
[34817.652918] usb 1-4: New USB device found, idVendor=1a86, idProduct=7523, bcdDevice= 2.64
[34817.652927] usb 1-4: New USB device strings: Mfr=0, Product=2, SerialNumber=0
[34817.652932] usb 1-4: Product: USB Serial
[34817.654680] ch341 1-4:1.0: ch341-uart converter detected
[34817.655335] usb 1-4: ch341-uart converter now attached to ttyUSB0

Bus 001 Device 009: ID 1a86:7523 QinHeng Electronics HL-340 USB-Serial adapter
```