### PR TITLE
Run `cargo install cargo-generate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cargo run --bin uno-blink
 The best way to start your own project is via the [`avr-hal-template`](https://github.com/Rahix/avr-hal-template) which you can easily use with [`cargo-generate`](https://github.com/cargo-generate/cargo-generate):
 
 ```bash
+cargo install cargo-generate
 cargo generate --git https://github.com/Rahix/avr-hal-template.git
 ```
 


### PR DESCRIPTION
Added
  cargo install cargo-generate
to the advice on project start.

In case `cargo-generate` is already present, will the user get
      Updating crates.io index
       Ignored package `cargo-generate v0.12.0` is already installed
and an
  use --force to override
hint.