### PR TITLE
Bugfix Error Type of SPI Chipselect

### DIFF
--- a/avr-hal-generic/src/spi.rs
+++ b/avr-hal-generic/src/spi.rs
@@ -86,7 +86,7 @@ pub trait SpiOps<H, SCLK, MOSI, MISO, CS> {
 pub struct ChipSelectPin<CSPIN>(port::Pin<port::mode::Output, CSPIN>);
 
 impl<CSPIN: port::PinOps> hal::digital::v2::OutputPin for ChipSelectPin<CSPIN> {
-    type Error = crate::void::Void;
+    type Error = core::convert::Infallible;
     fn set_low(&mut self) -> Result<(), Self::Error> {
         self.0.set_low();
         Ok(())
@@ -107,7 +107,7 @@ impl<CSPIN: port::PinOps> hal::digital::v2::StatefulOutputPin for ChipSelectPin<
 }
 
 impl<CSPIN: port::PinOps> hal::digital::v2::ToggleableOutputPin for ChipSelectPin<CSPIN> {
-    type Error = crate::void::Void;
+    type Error = core::convert::Infallible;
     fn toggle(&mut self) -> Result<(), Self::Error> {
         self.0.toggle();
         Ok(())


### PR DESCRIPTION
As discussed in #241, the current Error Type of Chipselect does not comply with the current ErrorType of OutputPins and thus makes it impossible to be directly used as such.
This change does update to Error type from legacy Void to the new Infallible.