### PR TITLE
ravedude: nano: Support nano boards flashed with optiboot and 115200 baudrate

### DIFF
--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -11,6 +11,7 @@ pub fn get_board(board: &str) -> Option<Box<dyn Board>> {
     Some(match board {
         "uno" => Box::new(ArduinoUno),
         "nano" => Box::new(ArduinoNano),
+        "nano-new" => Box::new(ArduinoNanoNew),
         "leonardo" => Box::new(ArduinoLeonardo),
         "micro" => Box::new(ArduinoMicro),
         "mega2560" => Box::new(ArduinoMega2560),
@@ -122,6 +123,31 @@ impl Board for ArduinoNano {
             programmer: "arduino",
             partno: "atmega328p",
             baudrate: Some(57600),
+            do_chip_erase: true,
+        }
+    }
+
+    fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
+        Some(Err(anyhow::anyhow!("Not able to guess port")))
+    }
+}
+
+struct ArduinoNanoNew;
+
+impl Board for ArduinoNanoNew {
+    fn display_name(&self) -> &str {
+        "Arduino Nano (New Bootloader)"
+    }
+
+    fn needs_reset(&self) -> Option<&str> {
+        None
+    }
+
+    fn avrdude_options(&self) -> avrdude::AvrdudeOptions {
+        avrdude::AvrdudeOptions {
+            programmer: "arduino",
+            partno: "atmega328p",
+            baudrate: Some(115200),
             do_chip_erase: true,
         }
     }

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -45,6 +45,7 @@ struct Args {
     ///
     /// * uno
     /// * nano
+    /// * nano-new
     /// * leonardo
     /// * micro
     /// * mega2560


### PR DESCRIPTION
Adds support for Arduino nano boards which are flashed with optiboot and have a default upload speed of 115200. Ref: https://github.com/arduino/ArduinoCore-avr/commit/1b14cc07331268e95eddcce2cc67e29ed667e62f