### PR TITLE
Implement Time-Keeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,5 @@ exclude = [
 ]
 
 [patch.crates-io]
-# XXX: Temporary fix for avr-rust/rust#148
-ufmt = { git = "https://github.com/Rahix/ufmt.git", rev = "12225dc1678e42fecb0e8635bf80f501e24817d9" }
+# XXX: fix i32 / u32 uDebug impl for 16-bit pointer width by mrk-its
+ufmt = { git = "https://github.com/mrk-its/ufmt.git", rev = "e6e574625e89bce9a5cb907eae43bfd45672f768" }

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -24,7 +24,12 @@ nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", 
 [dependencies]
 cfg-if = "1"
 embedded-hal = "0.2.3"
+embedded-time = "0.10.0" # The 0.12, does not compile with Rust 1.51
 ufmt = "0.1.0"
+
+[dependencies.derivative]
+version = "2.2"
+features = ["use_core"]
 
 [dependencies.void]
 version = "1.0.2"

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -166,6 +166,9 @@ pub mod usart {
 #[cfg(feature = "mcu-atmega")]
 pub use usart::Usart;
 
+#[cfg(feature = "board-selected")]
+pub mod time;
+
 #[cfg(feature = "mcu-atmega")]
 pub mod prelude {
     cfg_if::cfg_if! {

--- a/arduino-hal/src/time/chrono.rs
+++ b/arduino-hal/src/time/chrono.rs
@@ -1,0 +1,208 @@
+use crate::clock::Clock as CpuClock;
+use crate::time::Timepiece;
+use avr_hal_generic::time::TimingCircuitOps;
+use embedded_time::clock::Error as ClockError;
+use embedded_time::rate::Fraction;
+use embedded_time::Instant;
+
+/// A statically accessible clock
+///
+/// Notice, if the clock is stopped or not yet initialized, it will just
+/// return the last value, and the clock will appear frozen.
+#[derive(derivative::Derivative)]
+#[derivative(Debug(bound = ""), Copy(bound = ""), Clone(bound = ""))]
+pub struct StaticChronometer<H, Tp> {
+    _pre_timer: core::marker::PhantomData<*const Tp>,
+    _h: core::marker::PhantomData<*const H>,
+}
+unsafe impl<H, Tp> Send for StaticChronometer<H, Tp> {
+    // SAFETY: We neither store a `Tp` nor `H`
+}
+unsafe impl<H, Tp> Sync for StaticChronometer<H, Tp> {
+    // SAFETY: We neither store a `Tp` nor `H`
+}
+impl<H, Tp> StaticChronometer<H, Tp> {
+    pub const fn new() -> Self {
+        Self {
+            _pre_timer: core::marker::PhantomData,
+            _h: core::marker::PhantomData,
+        }
+    }
+}
+impl<H, Tp: Timepiece<H>> StaticChronometer<H, Tp> {
+    /// Returns the number of milliseconds since this clock was started
+    ///
+    /// Notice, if the clock is stopped or not yet initialized, it will just
+    /// return the last value, and the clock will appear frozen.
+    pub fn millis() -> Tp::Millis {
+        // Get the current number of milliseconds
+        avr_device::interrupt::free(|cs| Tp::access_millis(cs).get())
+    }
+}
+impl<H, Tp: Timepiece<H>> embedded_time::clock::Clock for StaticChronometer<H, Tp>
+where
+    <Tp as Timepiece<H>>::Millis: ufmt::uDebug + core::hash::Hash, // + embedded_time::TimeInt // Not accessible in 0.10
+    Tp: Timepiece<H, Millis = u32>, // Just workaround until above gets accessible
+{
+    type T = Tp::Millis;
+
+    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000);
+
+    #[inline(always)]
+    fn try_now(&self) -> Result<Instant<Self>, ClockError> {
+        Ok(self.now())
+    }
+}
+impl<H, Tp: Timepiece<H>> StaticChronometer<H, Tp>
+where
+    <Tp as Timepiece<H>>::Millis: ufmt::uDebug + core::hash::Hash, // + embedded_time::TimeInt // Not accessible in 0.10
+    Tp: Timepiece<H, Millis = u32>, // Just workaround until above gets accessible
+{
+    pub fn now(&self) -> Instant<Self> {
+        avr_device::interrupt::free(|cs| self.now_with_cs(cs))
+    }
+
+    pub fn now_with_cs(&self, cs: &avr_device::interrupt::CriticalSection) -> Instant<Self> {
+        // TODO make use of `cs`
+        Instant::new(Self::millis())
+    }
+}
+
+/// A Timer-based Clock, tells an approximated wall time.
+///
+/// This type is a defacto singleton that can only once instantiated,
+/// see [`new`](Self::new).
+///
+/// You must create an instance of this clock to make the clock work.
+/// However, if you leak or drop the clock without call [`stop`],
+/// it will keep running.
+#[derive(Debug)]
+//#[derive(ufmt::derive::uDebug)]
+pub struct Chronometer<H, Tp> {
+    inner: Tp,
+    _h: core::marker::PhantomData<H>,
+}
+
+impl<H, Tp: Timepiece<H>> Chronometer<H, Tp> {
+    /// Initialize the clock.
+    ///
+    /// The clock start running immediately after this call.
+    /// However, in order to work properly interrupts must be enabled too, e.g.:
+    ///
+    /// ```rust
+    /// // Enable interrupts globally
+    /// unsafe { avr_device::interrupt::enable() };
+    /// ```
+    pub fn new(timepiece: Tp) -> Self {
+        let (prescaler, timer_cnt) = Tp::TIMER_PARAMS;
+
+        // TODO: obviously most of these fields are numbered by the Timer nr
+        // that is used.
+
+        // Configure the timer for the above interval (in CTC mode)
+        // and enable its interrupt.
+        let tc = timepiece.access_peripheral();
+        tc.disable();
+
+        // Reset the global millisecond counter
+        avr_device::interrupt::free(|cs| {
+            Tp::access_millis(cs).set(0.into());
+        });
+
+        unsafe {
+            // SAFETY: we have a `Tp: Timepiece`, which guarantees us that a
+            // corresponding interrupt handler has been installed.
+            tc.enable_interrupt();
+        }
+
+        // Init timer stuff
+        tc.initialize(prescaler, timer_cnt);
+
+        // We are done here
+        Self {
+            inner: timepiece,
+            _h: core::marker::PhantomData,
+        }
+    }
+
+    /// Stops the clock and returns back the used timer
+    pub fn stop(self) -> Tp {
+        self.inner.access_peripheral().disable();
+
+        self.inner
+    }
+
+    /// Reset the millis counter to zero, and return the old value
+    pub fn reset_time(&self) {
+        avr_device::interrupt::free(|cs| Tp::access_millis(cs).replace(0.into()));
+    }
+
+    /// Returns the number of milliseconds since this clock was started
+    pub fn millis(&self) -> Tp::Millis {
+        // Get the current number of milliseconds
+        avr_device::interrupt::free(|cs| Tp::access_millis(cs).get())
+    }
+
+    /// Returns the number of microseconds since this clock was started
+    pub fn micros(&self) -> Tp::Micros {
+        let (mut m, t, tifr) = avr_device::interrupt::free(|cs| {
+            let m = Tp::access_millis(cs).get();
+
+            let tc = &self.inner.access_peripheral();
+            let (t, tifr) = tc.read_counter();
+
+            (m, t, tifr)
+        });
+
+        // Caluclate the duration of timer tick in microseconds
+        let interrupt_duration_us = Tp::Micros::from(1_000_000u32)
+            * Tp::Micros::from(u32::from(Tp::TIMER_PARAMS.0.to_val()))
+            / Tp::Micros::from(<Tp::CpuClock as CpuClock>::FREQ);
+
+        // TODO: use wrapping arithmetics
+        let counter_micros = Tp::Micros::from(t) * interrupt_duration_us;
+
+        // Check whether a interrupt was pending when we read the counter value,
+        // which typically means it wrapped around, without the millis getting
+        // incremented, so we do it here manually:
+        let max_counter_value = Tp::TIMER_PARAMS.1;
+        if tifr && t < max_counter_value {
+            // TODO: use wrapping arithmetics
+            m = m + Tp::Millis::from(1);
+        }
+
+        let millis = Tp::Micros::from(m);
+
+        // TODO: use wrapping arithmetics
+        millis * Tp::Micros::from(1000) + counter_micros
+    }
+}
+
+impl<H, Tp: Timepiece<H>> embedded_time::clock::Clock for Chronometer<H, Tp>
+where
+    <Tp as Timepiece<H>>::Micros: ufmt::uDebug + core::hash::Hash, // + embedded_time::TimeInt // Not accessible in 0.10
+    Tp: Timepiece<H, Micros = u32>, // Just workaround until above gets accessible
+{
+    type T = Tp::Micros;
+
+    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000_000);
+
+    #[inline(always)]
+    fn try_now(&self) -> Result<Instant<Self>, ClockError> {
+        Ok(self.now())
+    }
+}
+impl<H, Tp: Timepiece<H>> Chronometer<H, Tp>
+where
+    <Tp as Timepiece<H>>::Micros: ufmt::uDebug + core::hash::Hash, // + embedded_time::TimeInt // Not accessible in 0.10
+    Tp: Timepiece<H, Micros = u32>, // Just workaround until above gets accessible
+{
+    pub fn now(&self) -> Instant<Self> {
+        avr_device::interrupt::free(|cs| self.now_with_cs(cs))
+    }
+
+    pub fn now_with_cs(&self, cs: &avr_device::interrupt::CriticalSection) -> Instant<Self> {
+        // TODO make use of `cs`
+        Instant::new(self.micros())
+    }
+}

--- a/arduino-hal/src/time/chrono.rs
+++ b/arduino-hal/src/time/chrono.rs
@@ -34,7 +34,7 @@ impl<H, Tp: Timepiece<H>> StaticChronometer<H, Tp> {
     ///
     /// Notice, if the clock is stopped or not yet initialized, it will just
     /// return the last value, and the clock will appear frozen.
-    pub fn millis() -> Tp::Millis {
+    pub fn millis(&self) -> Tp::Millis {
         // Get the current number of milliseconds
         avr_device::interrupt::free(|cs| Tp::access_millis(cs).get())
     }
@@ -64,7 +64,7 @@ where
 
     pub fn now_with_cs(&self, cs: &avr_device::interrupt::CriticalSection) -> Instant<Self> {
         // TODO make use of `cs`
-        Instant::new(Self::millis())
+        Instant::new(Self::new().millis())
     }
 }
 

--- a/arduino-hal/src/time/macros.rs
+++ b/arduino-hal/src/time/macros.rs
@@ -1,0 +1,110 @@
+// Stuff to be used in the macros
+
+pub use crate::clock::Clock as CpuClock;
+pub use avr_device::interrupt::free as interrupt_free;
+pub use avr_device::interrupt::CriticalSection;
+pub use avr_device::interrupt::Mutex;
+pub use core::cell::Cell;
+pub use core::cell::RefCell;
+
+/// Creates a timepiece for the [timer peripheral](crate::time::timers) and
+/// the given configuration
+///
+/// # Example
+///
+/// ```
+/// use arduino_hal::impl_timepiece;
+/// impl_timepiece! {
+///     pub timepiece MyFooTimer {
+///         hal: arduino_hal::hal::Atmega,
+///         peripheral: Timer0,
+///         cpu_clock: arduino_hal::DefaultClock,
+///         millis: u32,
+///         micros: u32,
+///         resolution: crate::time::Resolution::_1_MS,
+///     }
+/// }
+/// ```
+///
+#[macro_export]
+macro_rules! impl_timepiece {
+    (
+        $(#[$meta:meta])*
+        $vis:vis timepiece $Name: ident {
+            peripheral: $TC:ident,
+            cpu_clock: $CLOCK:ty,
+            millis: $MILLIS:ty,
+            micros: $MICROS:ty,
+            resolution: $resolution:expr,
+        }
+    ) => {
+        // The timer interrupt service routine
+        $crate::hal::attach_timing_circuit_interrupt!{$TC; {
+            // Increment the "millis" counter
+            $crate::time::macros::interrupt_free(|cs| {
+                $crate::time::update_timer::<$crate::hal::HAL, $Name>(cs)
+            })
+        }}
+
+        $(#[$meta])*
+        $vis struct $Name {
+            pub peripheral: $crate::hal::time::$TC,
+        }
+
+        unsafe impl $crate::time::Timepiece<$crate::hal::HAL> for $Name {
+            // SAFETY: We registered the interrupt for $TC above
+            type Circuit = $crate::hal::time::$TC;
+            type CpuClock = $CLOCK;
+            type Millis = $MILLIS;
+            type Micros = $MICROS;
+
+            const RESOLUTION: Self::Millis = {
+                // Ensure that `$resolution` is a Resolution
+                let res: $crate::time::Resolution = $resolution;
+                let millis = $resolution.as_ms();
+
+                // TODO: use `Into`, but it is not const yet
+                millis as Self::Millis
+            };
+
+            const TIMER_PARAMS: ($crate::time::Prescaler, <Self::Circuit as $crate::time::TimingCircuitOps<$crate::hal::HAL>>::Counter) = {
+                // Ensure that `$resolution` is a Resolution
+                let res: $crate::time::Resolution = $resolution;
+                let (prescaler, cnt_top) = res.params_for_frq(
+                    <Self::CpuClock as $crate::time::macros::CpuClock>::FREQ,
+                    <Self::Circuit as $crate::time::TimingCircuitOps<$crate::hal::HAL>>::Counter::MAX as u32 /* TODO: use `Into` */
+                ).unwrap();
+
+                (prescaler, cnt_top as _)
+            };
+
+            fn access_millis(cs: &$crate::time::macros::CriticalSection) -> & $crate::time::macros::Cell<Self::Millis> {
+                // Counts proper milliseconds
+                static MILLIS_COUNTER: $crate::time::macros::Mutex<$crate::time::macros::Cell<$MILLIS>> = $crate::time::macros::Mutex::new($crate::time::macros::Cell::new(0));
+
+                MILLIS_COUNTER.borrow(cs)
+            }
+
+            fn access_peripheral(&self) -> &Self::Circuit {
+                &self.peripheral
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+pub mod test {
+    // TODO: needs
+    // #![feature(abi_avr_interrupt)]
+    // #![feature(const_option)]
+
+    impl_timepiece! {
+        pub timepiece MyFooTimer {
+            peripheral: Timer0,
+            cpu_clock: crate::DefaultClock,
+            millis: u32,
+            micros: u32,
+            resolution: crate::time::Resolution::MS_1,
+        }
+    }
+}

--- a/arduino-hal/src/time/mod.rs
+++ b/arduino-hal/src/time/mod.rs
@@ -1,0 +1,24 @@
+//! Time-keeping facilities
+//!
+//! TODO: how do you use that?
+//!
+
+mod chrono;
+#[doc(hidden)]
+pub mod macros;
+mod piece;
+
+pub use chrono::Chronometer;
+pub use chrono::StaticChronometer;
+#[doc(hidden)] // Used in macros
+pub use piece::update_timer;
+pub use piece::Timepiece;
+
+pub use avr_hal_generic::time::Prescaler;
+pub use avr_hal_generic::time::Resolution;
+pub use avr_hal_generic::time::TimingCircuitOps;
+
+/// Supported timer devices
+pub mod timers {
+    pub use crate::hal::time::*;
+}

--- a/arduino-hal/src/time/mod.rs
+++ b/arduino-hal/src/time/mod.rs
@@ -18,6 +18,8 @@ pub use avr_hal_generic::time::Prescaler;
 pub use avr_hal_generic::time::Resolution;
 pub use avr_hal_generic::time::TimingCircuitOps;
 
+pub use embedded_time;
+
 /// Supported timer devices
 pub mod timers {
     pub use crate::hal::time::*;

--- a/arduino-hal/src/time/piece.rs
+++ b/arduino-hal/src/time/piece.rs
@@ -1,0 +1,59 @@
+use crate::clock::Clock as CpuClock;
+use avr_device::interrupt::CriticalSection;
+use avr_hal_generic::time::Prescaler;
+use avr_hal_generic::time::TimingCircuitOps;
+use core::cell::Cell;
+use core::ops;
+
+/// Represents a timer that has a proper timer interrupt handler assigned.
+///
+/// Please use `TimerClock` wrapper instead of this trait.
+/// Also, do not implement this trait yourself, instead use the `todo` macro.
+///
+/// # Safety
+///
+/// If value of this type exists, an interrupt handler must be installed,
+/// that handles the OCR interrupts of indicated `Timer` peripheral.
+///
+/// Also, at most a single value of the underling type must exist at any given
+/// point in time.
+pub unsafe trait Timepiece<H> {
+    /// The use timer peripheral
+    type Circuit: TimingCircuitOps<H>;
+    /// The CPU clock speed to which this timer is tuned for
+    type CpuClock: CpuClock;
+    /// The type of the software milliseconds counter
+    type Millis: Copy + ops::Add<Output = Self::Millis> + From<u8>;
+    /// The typo of microsecond output
+    type Micros: Copy
+        + From<u32>
+        + From<Self::Millis>
+        + From<<Self::Circuit as TimingCircuitOps<H>>::Counter>
+        + ops::Add<Output = Self::Micros>
+        + ops::Mul<Output = Self::Micros>
+        + ops::Div<Output = Self::Micros>;
+    /// The resolution of the software milliseconds counter
+    const RESOLUTION: Self::Millis;
+    /// The timer parameters to achieve the state resolution
+    const TIMER_PARAMS: (Prescaler, <Self::Circuit as TimingCircuitOps<H>>::Counter);
+
+    /// Reads the current value of the software milliseconds counter
+    fn access_millis(cs: &CriticalSection) -> &Cell<Self::Millis>;
+
+    /// Gives access to the underling timer peripheral
+    fn access_peripheral(&self) -> &Self::Circuit;
+}
+
+/// Increment the timer value of `Pt`
+///
+/// This function should only be used by a timer interrupt.
+#[doc(hidden)]
+pub fn update_timer<H, Tp: Timepiece<H>>(cs: &CriticalSection) {
+    let counter_cell = Tp::access_millis(cs);
+    let counter = counter_cell.get();
+
+    let interrupt_duration = Tp::RESOLUTION;
+
+    // TODO: use wrapping arithmetics
+    counter_cell.set(counter + interrupt_duration);
+}

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -1,5 +1,11 @@
 #![no_std]
 #![feature(llvm_asm)]
+//
+// Stable since 1.53.0
+#![feature(int_bits_const)]
+//
+// Stable since 1.57.0
+#![feature(const_panic)]
 
 pub extern crate embedded_hal as hal;
 

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -23,6 +23,7 @@ pub mod spi;
 pub mod adc;
 pub mod pwm;
 pub mod wdt;
+pub mod time;
 
 /// Prelude containing all HAL traits
 pub mod prelude {

--- a/avr-hal-generic/src/time.rs
+++ b/avr-hal-generic/src/time.rs
@@ -1,0 +1,96 @@
+//! Timing Circuits
+//!
+//! This module contains low-level hardware abstractions to be used for
+//! time-keeping.
+
+
+/// A hardware component that can generate regular interrupts.
+///
+/// A timing circuit is basically a counter that starts at `0` and counts up
+/// in fixed (appox.) wall time intervals.
+/// Once the counter reaches a defined value it resets to zero and triggers
+/// some interrupt.
+/// The counting interval can be configured via a [`Prescaler`] from the
+/// MCUs CPU clock frequency.
+//
+// TODO: shall we really add the `Ops` suffix?
+pub trait TimingCircuitOps<H> {
+	/// The internal type of the counter register (typically `u8` or `u16`)
+	type Counter: Copy + core::cmp::Ord;
+
+	/// Returns the current value of the counter register and whether an
+	/// interrupt is scheduled to be triggered.
+	///
+	/// The reason behind the interrupt flag is, that the once the counter
+	/// reaches the predetermined value, it will reset to zero, however,
+	/// if the interrupt handler might be currently blocked from running,
+	/// and thus executing its update function.
+	/// Thus this interrupt flag can be seen as an additional counter bit,
+	/// indicating that the counter value (might) have been reset to zero,
+	/// without the interrupt been executed yet.
+	fn read_counter(&self) -> (Self::Counter, bool);
+
+	/// Configure the timer with the given prescaler and top value.
+	///
+	/// This also starts the timer.
+	fn initialize(&self, p: Prescaler, top: Self::Counter);
+
+	/// Enable the timer interrupt
+	///
+	/// # Safety
+	/// A timer interrupt handler for this timer must have been set up.
+	//
+	// TODO: Would it make sens if this were safe? What if no handler is set?
+	//
+	// TODO: maybe we call it just `enable` and also kick-off
+	//       the timer here (instead of doing it in `initialize`)
+	unsafe fn enable_interrupt(&self);
+
+	/// Disable this timer and disable any interrupts from it
+	fn disable(&self);
+}
+
+
+/// Represents one of the few valid prescaler values for [TimingCircuitOps]s.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Prescaler {
+	P1,
+	P8,
+	P64,
+	P256,
+	P1024,
+}
+impl Prescaler {
+	/// Returns the next best prescaler for the given prescaler exponent.
+	///
+	/// The next best prescaler means here, the next bigger value, unless,
+	/// the value goes beyond 10, which is the highest supported prescaler
+	/// exponent.
+	pub const fn from_exp(exp: u32) -> Option<Self> {
+		let prescaler = match exp {
+			0 => Self::P1,
+			1..=3 => Self::P8,
+			4..=6 => Self::P64,
+			7..=8 => Self::P256,
+			9..=10 => Self::P1024,
+			_ => return None,
+		};
+		Some(prescaler)
+	}
+
+	/// Gives the exponent of this prescaler.
+	pub const fn to_exp(self) -> u8 {
+		match self {
+			Self::P1 => 0,
+			Self::P8 => 3,
+			Self::P64 => 6,
+			Self::P256 => 8,
+			Self::P1024 => 10,
+		}
+	}
+
+	/// Returns the numeric value of this prescaler.
+	pub const fn to_val(self) -> u16 {
+		1 << self.to_exp()
+	}
+}

--- a/avr-hal-generic/src/time.rs
+++ b/avr-hal-generic/src/time.rs
@@ -3,7 +3,6 @@
 //! This module contains low-level hardware abstractions to be used for
 //! time-keeping.
 
-
 /// A hardware component that can generate regular interrupts.
 ///
 /// A timing circuit is basically a counter that starts at `0` and counts up
@@ -15,87 +14,84 @@
 //
 // TODO: shall we really add the `Ops` suffix?
 pub trait TimingCircuitOps<H> {
-	/// The internal type of the counter register (typically `u8` or `u16`)
-	type Counter: Copy + core::cmp::Ord;
+    /// The internal type of the counter register (typically `u8` or `u16`)
+    type Counter: Copy + core::cmp::Ord;
 
-	/// Returns the current value of the counter register and whether an
-	/// interrupt is scheduled to be triggered.
-	///
-	/// The reason behind the interrupt flag is, that the once the counter
-	/// reaches the predetermined value, it will reset to zero, however,
-	/// if the interrupt handler might be currently blocked from running,
-	/// and thus executing its update function.
-	/// Thus this interrupt flag can be seen as an additional counter bit,
-	/// indicating that the counter value (might) have been reset to zero,
-	/// without the interrupt been executed yet.
-	fn read_counter(&self) -> (Self::Counter, bool);
+    /// Returns the current value of the counter register and whether an
+    /// interrupt is scheduled to be triggered.
+    ///
+    /// The reason behind the interrupt flag is, that the once the counter
+    /// reaches the predetermined value, it will reset to zero, however,
+    /// if the interrupt handler might be currently blocked from running,
+    /// and thus executing its update function.
+    /// Thus this interrupt flag can be seen as an additional counter bit,
+    /// indicating that the counter value (might) have been reset to zero,
+    /// without the interrupt been executed yet.
+    fn read_counter(&self) -> (Self::Counter, bool);
 
-	/// Configure the timer with the given prescaler and top value.
-	///
-	/// This also starts the timer.
-	fn initialize(&self, p: Prescaler, top: Self::Counter);
+    /// Configure the timer with the given prescaler and top value.
+    ///
+    /// This also starts the timer.
+    fn initialize(&self, p: Prescaler, top: Self::Counter);
 
-	/// Enable the timer interrupt
-	///
-	/// # Safety
-	/// A timer interrupt handler for this timer must have been set up.
-	//
-	// TODO: Would it make sens if this were safe? What if no handler is set?
-	//
-	// TODO: maybe we call it just `enable` and also kick-off
-	//       the timer here (instead of doing it in `initialize`)
-	unsafe fn enable_interrupt(&self);
+    /// Enable the timer interrupt
+    ///
+    /// # Safety
+    /// A timer interrupt handler for this timer must have been set up.
+    //
+    // TODO: Would it make sens if this were safe? What if no handler is set?
+    //
+    // TODO: maybe we call it just `enable` and also kick-off
+    //       the timer here (instead of doing it in `initialize`)
+    unsafe fn enable_interrupt(&self);
 
-	/// Disable this timer and disable any interrupts from it
-	fn disable(&self);
+    /// Disable this timer and disable any interrupts from it
+    fn disable(&self);
 }
-
 
 /// Represents one of the few valid prescaler values for [TimingCircuitOps].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Prescaler {
-	P1,
-	P8,
-	P64,
-	P256,
-	P1024,
+    P1,
+    P8,
+    P64,
+    P256,
+    P1024,
 }
 impl Prescaler {
-	/// Returns the next best prescaler for the given prescaler exponent.
-	///
-	/// The next best prescaler means here, the next bigger value, unless,
-	/// the value goes beyond 10, which is the highest supported prescaler
-	/// exponent.
-	pub const fn from_exp(exp: u32) -> Option<Self> {
-		let prescaler = match exp {
-			0 => Self::P1,
-			1..=3 => Self::P8,
-			4..=6 => Self::P64,
-			7..=8 => Self::P256,
-			9..=10 => Self::P1024,
-			_ => return None,
-		};
-		Some(prescaler)
-	}
+    /// Returns the next best prescaler for the given prescaler exponent.
+    ///
+    /// The next best prescaler means here, the next bigger value, unless,
+    /// the value goes beyond 10, which is the highest supported prescaler
+    /// exponent.
+    pub const fn from_exp(exp: u32) -> Option<Self> {
+        let prescaler = match exp {
+            0 => Self::P1,
+            1..=3 => Self::P8,
+            4..=6 => Self::P64,
+            7..=8 => Self::P256,
+            9..=10 => Self::P1024,
+            _ => return None,
+        };
+        Some(prescaler)
+    }
 
-	/// Gives the exponent of this prescaler.
-	pub const fn to_exp(self) -> u8 {
-		match self {
-			Self::P1 => 0,
-			Self::P8 => 3,
-			Self::P64 => 6,
-			Self::P256 => 8,
-			Self::P1024 => 10,
-		}
-	}
+    /// Gives the exponent of this prescaler.
+    pub const fn to_exp(self) -> u8 {
+        match self {
+            Self::P1 => 0,
+            Self::P8 => 3,
+            Self::P64 => 6,
+            Self::P256 => 8,
+            Self::P1024 => 10,
+        }
+    }
 
-	/// Returns the numeric value of this prescaler.
-	pub const fn to_val(self) -> u16 {
-		1 << self.to_exp()
-	}
+    /// Returns the numeric value of this prescaler.
+    pub const fn to_val(self) -> u16 {
+        1 << self.to_exp()
+    }
 }
-
-
 
 /// Represents the interrupt firing interval of a [TimingCircuitOps] in
 /// milliseconds.
@@ -104,85 +100,81 @@ impl Prescaler {
 /// chronometer.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Resolution {
-	millis: u32,
+    millis: u32,
 }
 
 impl Resolution {
-	pub const MS_1: Self = Self::from_ms(1);
-	pub const MS_2: Self = Self::from_ms(2);
-	pub const MS_4: Self = Self::from_ms(4);
-	pub const MS_8: Self = Self::from_ms(8);
-	pub const MS_16: Self = Self::from_ms(16);
+    pub const MS_1: Self = Self::from_ms(1);
+    pub const MS_2: Self = Self::from_ms(2);
+    pub const MS_4: Self = Self::from_ms(4);
+    pub const MS_8: Self = Self::from_ms(8);
+    pub const MS_16: Self = Self::from_ms(16);
 
-	/// A resolution of `ms` milliseconds
-	pub const fn from_ms(ms: u32) -> Self {
-		Self {
-			millis: ms,
-		}
-	}
+    /// A resolution of `ms` milliseconds
+    pub const fn from_ms(ms: u32) -> Self {
+        Self { millis: ms }
+    }
 
-	/// A resolution of `2^exp` milliseconds
-	pub const fn from_exp(exp: u8) -> Self {
-		Self {
-			millis: 1 << exp
-		}
-	}
+    /// A resolution of `2^exp` milliseconds
+    pub const fn from_exp(exp: u8) -> Self {
+        Self { millis: 1 << exp }
+    }
 
-	/// The interval in milliseconds
-	pub const fn as_ms(self) -> u32 {
-		self.millis
-	}
+    /// The interval in milliseconds
+    pub const fn as_ms(self) -> u32 {
+        self.millis
+    }
 
-	/// Calculates the optimal prescaler and counter value for the given clock
-	/// frequency in Hz, and maximum supported counter value.
-	///
-	/// Returns `None`, if there there is no valid configuration for this
-	/// resolution at the given frequency.
-	pub const fn params_for_frq(self, freq_hz: u32, cnt_max: u32) -> Option<(Prescaler, u32)> {
-		// The maximum valid counter value
-		// TODO: use a generic parameter instead of `cnt_max`, however,
-		//       this would need several unstable features.
-		//const MAX: u32 = u8::MAX as u32; // 255
+    /// Calculates the optimal prescaler and counter value for the given clock
+    /// frequency in Hz, and maximum supported counter value.
+    ///
+    /// Returns `None`, if there there is no valid configuration for this
+    /// resolution at the given frequency.
+    pub const fn params_for_frq(self, freq_hz: u32, cnt_max: u32) -> Option<(Prescaler, u32)> {
+        // The maximum valid counter value
+        // TODO: use a generic parameter instead of `cnt_max`, however,
+        //       this would need several unstable features.
+        //const MAX: u32 = u8::MAX as u32; // 255
 
-		let cycles_per_second = freq_hz;
-		// Combine for better precision:
-		//     let cycles_per_ms = (cycles_per_second + 499) / 1_000;
-		//     let cycles_per_interrupt = cycles_per_ms * self.as_ms();
-		let cycles_per_interrupt = (cycles_per_second * self.as_ms() + 499) / 1_000; // rounded
+        let cycles_per_second = freq_hz;
+        // Combine for better precision:
+        //     let cycles_per_ms = (cycles_per_second + 499) / 1_000;
+        //     let cycles_per_interrupt = cycles_per_ms * self.as_ms();
+        let cycles_per_interrupt = (cycles_per_second * self.as_ms() + 499) / 1_000; // rounded
 
-		// Calculate a perfect prescaler.
-		// It is also the minimum prescaler, because it yield the highest
-		// yet valid counter value.
-		// So, if need to tweak the prescaler, we need to make it bigger.
-		// Thus, we already calculate this rounded up
-		let perfect_prescaler: u32 = (cycles_per_interrupt + cnt_max - 1) / cnt_max;
+        // Calculate a perfect prescaler.
+        // It is also the minimum prescaler, because it yield the highest
+        // yet valid counter value.
+        // So, if need to tweak the prescaler, we need to make it bigger.
+        // Thus, we already calculate this rounded up
+        let perfect_prescaler: u32 = (cycles_per_interrupt + cnt_max - 1) / cnt_max;
 
-		// Calculate the log2 of `perfect_prescaler`, rounded up
-		// To get the correct result for powers of two, we will subtract 1
-		// if we have a power of two. Power of two have exactly one `1` in
-		// binary.
-		let sub_for_pot = if perfect_prescaler.count_ones() == 1 {
-			1
-		} else {
-			0
-		};
-		let perfect_prescaler_exp = u32::BITS - perfect_prescaler.leading_zeros() - sub_for_pot;
+        // Calculate the log2 of `perfect_prescaler`, rounded up
+        // To get the correct result for powers of two, we will subtract 1
+        // if we have a power of two. Power of two have exactly one `1` in
+        // binary.
+        let sub_for_pot = if perfect_prescaler.count_ones() == 1 {
+            1
+        } else {
+            0
+        };
+        let perfect_prescaler_exp = u32::BITS - perfect_prescaler.leading_zeros() - sub_for_pot;
 
-		// Get the next best (i.e. exact or bigger) available prescaler, if any
-		let prescaler = match Prescaler::from_exp(perfect_prescaler_exp) {
-			Some(p) => p,
-			None => return None,
-		};
+        // Get the next best (i.e. exact or bigger) available prescaler, if any
+        let prescaler = match Prescaler::from_exp(perfect_prescaler_exp) {
+            Some(p) => p,
+            None => return None,
+        };
 
-		// The scalar value of the available perscaler
-		let prescaler_val: u16 = prescaler.to_val();
+        // The scalar value of the available perscaler
+        let prescaler_val: u16 = prescaler.to_val();
 
-		// Calculate the number of prescaled cycles per interrupt
-		let cnt = (cycles_per_interrupt + (prescaler_val / 2) as u32) / (prescaler_val as u32); // rounded
+        // Calculate the number of prescaled cycles per interrupt
+        let cnt = (cycles_per_interrupt + (prescaler_val / 2) as u32) / (prescaler_val as u32); // rounded
 
-		// If we calculated correctly, it holds: `cnt <= MAX`
-		assert!(cnt < cnt_max);
+        // If we calculated correctly, it holds: `cnt <= MAX`
+        assert!(cnt < cnt_max);
 
-		Some((prescaler, cnt))
-	}
+        Some((prescaler, cnt))
+    }
 }

--- a/avr-hal-generic/src/time.rs
+++ b/avr-hal-generic/src/time.rs
@@ -51,7 +51,7 @@ pub trait TimingCircuitOps<H> {
 }
 
 
-/// Represents one of the few valid prescaler values for [TimingCircuitOps]s.
+/// Represents one of the few valid prescaler values for [TimingCircuitOps].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Prescaler {
 	P1,
@@ -92,5 +92,97 @@ impl Prescaler {
 	/// Returns the numeric value of this prescaler.
 	pub const fn to_val(self) -> u16 {
 		1 << self.to_exp()
+	}
+}
+
+
+
+/// Represents the interrupt firing interval of a [TimingCircuitOps] in
+/// milliseconds.
+///
+/// When used as in a chronometer, this defines the precision of the
+/// chronometer.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Resolution {
+	millis: u32,
+}
+
+impl Resolution {
+	pub const MS_1: Self = Self::from_ms(1);
+	pub const MS_2: Self = Self::from_ms(2);
+	pub const MS_4: Self = Self::from_ms(4);
+	pub const MS_8: Self = Self::from_ms(8);
+	pub const MS_16: Self = Self::from_ms(16);
+
+	/// A resolution of `ms` milliseconds
+	pub const fn from_ms(ms: u32) -> Self {
+		Self {
+			millis: ms,
+		}
+	}
+
+	/// A resolution of `2^exp` milliseconds
+	pub const fn from_exp(exp: u8) -> Self {
+		Self {
+			millis: 1 << exp
+		}
+	}
+
+	/// The interval in milliseconds
+	pub const fn as_ms(self) -> u32 {
+		self.millis
+	}
+
+	/// Calculates the optimal prescaler and counter value for the given clock
+	/// frequency in Hz, and maximum supported counter value.
+	///
+	/// Returns `None`, if there there is no valid configuration for this
+	/// resolution at the given frequency.
+	pub const fn params_for_frq(self, freq_hz: u32, cnt_max: u32) -> Option<(Prescaler, u32)> {
+		// The maximum valid counter value
+		// TODO: use a generic parameter instead of `cnt_max`, however,
+		//       this would need several unstable features.
+		//const MAX: u32 = u8::MAX as u32; // 255
+
+		let cycles_per_second = freq_hz;
+		// Combine for better precision:
+		//     let cycles_per_ms = (cycles_per_second + 499) / 1_000;
+		//     let cycles_per_interrupt = cycles_per_ms * self.as_ms();
+		let cycles_per_interrupt = (cycles_per_second * self.as_ms() + 499) / 1_000; // rounded
+
+		// Calculate a perfect prescaler.
+		// It is also the minimum prescaler, because it yield the highest
+		// yet valid counter value.
+		// So, if need to tweak the prescaler, we need to make it bigger.
+		// Thus, we already calculate this rounded up
+		let perfect_prescaler: u32 = (cycles_per_interrupt + cnt_max - 1) / cnt_max;
+
+		// Calculate the log2 of `perfect_prescaler`, rounded up
+		// To get the correct result for powers of two, we will subtract 1
+		// if we have a power of two. Power of two have exactly one `1` in
+		// binary.
+		let sub_for_pot = if perfect_prescaler.count_ones() == 1 {
+			1
+		} else {
+			0
+		};
+		let perfect_prescaler_exp = u32::BITS - perfect_prescaler.leading_zeros() - sub_for_pot;
+
+		// Get the next best (i.e. exact or bigger) available prescaler, if any
+		let prescaler = match Prescaler::from_exp(perfect_prescaler_exp) {
+			Some(p) => p,
+			None => return None,
+		};
+
+		// The scalar value of the available perscaler
+		let prescaler_val: u16 = prescaler.to_val();
+
+		// Calculate the number of prescaled cycles per interrupt
+		let cnt = (cycles_per_interrupt + (prescaler_val / 2) as u32) / (prescaler_val as u32); // rounded
+
+		// If we calculated correctly, it holds: `cnt <= MAX`
+		assert!(cnt < cnt_max);
+
+		Some((prescaler, cnt))
 	}
 }

--- a/examples/arduino-uno/src/bin/uno-time.rs
+++ b/examples/arduino-uno/src/bin/uno-time.rs
@@ -1,0 +1,89 @@
+/*!
+ * Demonstration of using the time-keeping facilities. (Based on `uno-serial`)
+ */
+#![no_std]
+#![no_main]
+//
+// Needed for the timer interrupt that is attached via `impl_timepiece`
+#![feature(abi_avr_interrupt)]
+//
+// Needed if compiling with Rust prior to 1.57.0
+#![feature(const_panic)]
+
+use arduino_hal::impl_timepiece;
+use arduino_hal::prelude::*;
+use arduino_hal::time::embedded_time::duration::Microseconds;
+use arduino_hal::time::embedded_time::duration::Seconds;
+use arduino_hal::time::embedded_time::fixed_point::FixedPoint;
+use arduino_hal::time::Chronometer;
+use core::convert::TryFrom;
+use panic_halt as _;
+
+use embedded_hal::serial::Read;
+
+// Prepare `Timer0` to be used for time-keeping.
+// This will define the configuration and attach its timer interrupt.
+impl_timepiece! {
+    pub timepiece Foo {
+        peripheral: Timer0,
+        cpu_clock: arduino_hal::DefaultClock,
+        millis: u32,
+        micros: u32,
+        resolution: arduino_hal::time::Resolution::MS_4,
+    }
+}
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    // Take the timer peripheral (TC0 for Timer0) and wrap it in our `Foo` warpper
+    let timepiece = Foo::new(dp.TC0);
+    // Initialize the time-keeping facility
+    let clock = Chronometer::new(timepiece);
+
+    // Since the Chronometer relies on interrupts, we have to enable them
+    // globally:
+    unsafe {
+        // SAFETY: This is not within `interrupt::free`
+        avr_device::interrupt::enable();
+    }
+
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+
+    loop {
+        // Read a byte from the serial connection
+        let b = nb::block!(serial.read()).void_unwrap();
+
+        // Answer
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+
+        // Using the local `Chronometer` instance, it has up to microseconds
+        // precision
+        let time = clock.now().duration_since_epoch();
+        let us = Microseconds::<u32>::try_from(time).unwrap();
+        let us = us.integer(); // extract the integer, since `Microseconds` is not `uDisplay`
+
+        // Alternatively, you can use the static clock (it is statically
+        // accessible), which has just milliseconds precision with whatever
+        // resolution you configured your timepiece (i.e. `Foo`)
+        let time = Foo::CLOCK.now().duration_since_epoch();
+        /* Currently using `Seconds::from` has some
+         * "undefined reference to `__lshrsi3'" errors,
+         * however, it works with drmorr0's compiler
+        let seconds = Seconds::<u32>::try_from(time).unwrap();
+        let seconds = seconds.integer(); // extract the integer, since `Seconds` is not `uDisplay`
+         */
+        let seconds = Foo::CLOCK.millis() / 1_000; // default tool-chain alternative
+
+        ufmt::uwriteln!(
+            &mut serial,
+            "It is now {} s since boot up! ({} us)\r",
+            seconds,
+            us
+        )
+        .void_unwrap();
+    }
+}

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -103,7 +103,13 @@ pub use wdt::Wdt;
 #[cfg(feature = "device-selected")]
 pub mod time;
 
+/// HAL token
 pub struct Atmega;
+
+#[doc(hidden)] // to be used in macros
+pub use crate::Atmega as HAL;
+#[doc(hidden)] // to be used in macros
+pub use avr_device;
 
 #[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
 #[macro_export]

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -100,6 +100,9 @@ pub mod wdt;
 #[cfg(feature = "device-selected")]
 pub use wdt::Wdt;
 
+#[cfg(feature = "device-selected")]
+pub mod time;
+
 pub struct Atmega;
 
 #[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]

--- a/mcu/atmega-hal/src/time.rs
+++ b/mcu/atmega-hal/src/time.rs
@@ -1,0 +1,77 @@
+//! Timing Circuits
+//!
+//! This module contains low-level hardware implementations to be used for
+//! time-keeping.
+//!
+//! Also see [avr_hal_generic::time]
+
+pub use avr_hal_generic::time::Prescaler;
+pub use avr_hal_generic::time::Resolution;
+pub use avr_hal_generic::time::TimingCircuitOps;
+
+use crate::pac;
+use crate::Atmega as HAL;
+
+/// Define the interrupt handler for the interrupt vector for the given
+/// Timer peripheral
+#[cfg(feature = "atmega328p")]
+#[macro_export]
+macro_rules! attach_timing_circuit_interrupt {
+    (Timer0; $body:block) => {
+        // The timer interrupt service routine
+        #[$crate::avr_device::interrupt(atmega328p)]
+        fn TIMER0_COMPA() $body
+    };
+}
+
+#[cfg(any(feature = "atmega328p"))]
+pub use pac::TC0 as Timer0;
+
+// TODO: implement via macro
+#[cfg(any(feature = "atmega328p"))]
+impl TimingCircuitOps<HAL> for Timer0 {
+    type Counter = <pac::tc0::tcnt0::TCNT0_SPEC as avr_device::generic::RegisterSpec>::Ux;
+
+    fn read_counter(&self) -> (Self::Counter, bool) {
+        (self.tcnt0.read().bits(), self.tifr0.read().ocf0a().bit())
+    }
+
+    fn initialize(&self, p: Prescaler, top: Self::Counter) {
+        // Set top value
+        self.ocr0a.write(|w| unsafe {
+            // TODO: Why is this unsafe???
+            // TODO: Safety, is this sound?
+            w.bits(top)
+        });
+        // Set prescaler
+        self.tccr0b.write(|w| match p {
+            Prescaler::P1 => w.cs0().direct(),
+            Prescaler::P8 => w.cs0().prescale_8(),
+            Prescaler::P64 => w.cs0().prescale_64(),
+            Prescaler::P256 => w.cs0().prescale_256(),
+            Prescaler::P1024 => w.cs0().prescale_1024(),
+        });
+        // Set CTC mode, enable timer
+        // TODO: might be better to be put into `enable_timer`
+        self.tccr0a.write(|w| w.wgm0().ctc());
+    }
+
+    unsafe fn enable_interrupt(&self) {
+        self.timsk0.write(|w| w.ocie0a().set_bit());
+    }
+
+    /// Disable this clock and disable any interrupts from it
+    fn disable(&self) {
+        // Stop clock
+        self.tccr0b.write(|w| w.cs0().no_clock());
+        // Disable all interrupts
+        self.timsk0.write(|w| {
+            w.ocie0a()
+                .clear_bit() //
+                .ocie0b()
+                .clear_bit() //
+                .toie0()
+                .clear_bit() //
+        });
+    }
+}

--- a/mcu/atmega-hal/src/time.rs
+++ b/mcu/atmega-hal/src/time.rs
@@ -5,12 +5,11 @@
 //!
 //! Also see [avr_hal_generic::time]
 
-pub use avr_hal_generic::time::Prescaler;
-pub use avr_hal_generic::time::Resolution;
-pub use avr_hal_generic::time::TimingCircuitOps;
+use avr_hal_generic::time::Prescaler;
+use avr_hal_generic::time::TimingCircuitOps;
 
+use crate::HAL;
 use crate::pac;
-use crate::Atmega as HAL;
 
 /// Define the interrupt handler for the interrupt vector for the given
 /// Timer peripheral
@@ -22,6 +21,13 @@ macro_rules! attach_timing_circuit_interrupt {
         #[$crate::avr_device::interrupt(atmega328p)]
         fn TIMER0_COMPA() $body
     };
+    ($name:ident; $body:block) => {
+        compile_error!(concat!(
+            "Your selected platform does not have a compatible timer named: ",
+            stringify!($name),
+            "\nSee arduino_hal::time::timers for a list of supported timers"
+        ));
+    }
 }
 
 #[cfg(any(feature = "atmega328p"))]

--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -51,7 +51,16 @@ pub mod port;
 #[cfg(feature = "device-selected")]
 pub use port::Pins;
 
+#[cfg(feature = "device-selected")]
+pub mod time;
+
+/// HAL token
 pub struct Attiny;
+
+#[doc(hidden)] // to be used in macros
+pub use crate::Attiny as HAL;
+#[doc(hidden)] // to be used in macros
+pub use avr_device;
 
 #[cfg(feature = "attiny85")]
 #[macro_export]

--- a/mcu/attiny-hal/src/time.rs
+++ b/mcu/attiny-hal/src/time.rs
@@ -1,0 +1,5 @@
+
+//
+// TODO: implement. This file currently only exists to allow building attinys
+//       with the arduino-hal
+//


### PR DESCRIPTION
This PR adds:

* `TimingCircuit` trait to abstract over various hardware timers that are eligible for time-keeping.
* `attach_timing_circuit_interrupt` macro, which allows attaching timer interrupts in a somewhat generic manor.
* `Timepiece` trait and `impl_timepiece` macro, that users will use to "prepare" a hardware timer (i.e. a `TimingCircuit`) for the time-keeping facilities (i.e. the `Choronometer`). "Preparing" means here that the user defines the configuration (e.g. hardware, resolution) and the macro will attach a corresponding timer interrupt handler.
* `Choronometer`, a struct that wraps a `Timepiece` (which in turn wraps a `TimingCircuit`), initializes the corresponding hardware timer, and implements the `embedded_time::Clock` trait with microseconds precision.
* `StaticChronometer` a statically accessible `embedded_time::Clock` implementation that yields milliseconds precision.

For a quick peek, see the [uno-time example](https://github.com/Cryptjar/avr-hal/blob/impl-timing-lib/examples/arduino-uno/src/bin/uno-time.rs)

**TODOs:**

- [ ] implement `TimingCircuit` on all eligible hardware Timers
- [ ] add an Arduino Mega example
- [ ] decide on what names to use
- [ ] polish docs

Fixes #256