### PR TITLE
make serial port example portable across targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ members = [
 exclude = [
     # The RAVEDUDE! Yeah!
     "ravedude",
+    # requires the user of this crate to specify the features for embedded-hal
+    "examples/arduino-portable",
 ]
 
 [patch.crates-io]

--- a/examples/arduino-diecimila/Cargo.toml
+++ b/examples/arduino-diecimila/Cargo.toml
@@ -14,3 +14,6 @@ embedded-hal = "0.2.3"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["arduino-diecimila"]
+
+[dependencies.arduino-portable]
+path = "../arduino-portable"

--- a/examples/arduino-diecimila/src/bin/diecimila-usart.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+// use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -15,10 +15,6 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        // Read a byte from the serial connection default
-        let b = nb::block!(serial.read()).void_unwrap();
-
-        // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        arduino_portable::report(&mut serial);
     }
 }

--- a/examples/arduino-leonardo/Cargo.toml
+++ b/examples/arduino-leonardo/Cargo.toml
@@ -14,3 +14,6 @@ embedded-hal = "0.2.3"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["arduino-leonardo"]
+
+[dependencies.arduino-portable]
+path = "../arduino-portable"

--- a/examples/arduino-leonardo/src/bin/leonardo-usart.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+// use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -15,10 +15,6 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
-
-        // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        arduino_portable::report(&mut serial);
     }
 }

--- a/examples/arduino-mega2560/Cargo.toml
+++ b/examples/arduino-mega2560/Cargo.toml
@@ -14,3 +14,6 @@ embedded-hal = "0.2.3"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["arduino-mega2560"]
+
+[dependencies.arduino-portable]
+path = "../arduino-portable"

--- a/examples/arduino-mega2560/src/bin/mega2560-usart.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+//use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -15,10 +15,6 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
-
-        // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        arduino_portable::report(&mut serial);
     }
 }

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -22,3 +22,6 @@ version = "0.3"
 [dependencies.either]
 version = "1.6.1"
 default-features = false
+
+[dependencies.arduino-portable]
+path = "../arduino-portable"

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -7,7 +7,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+// use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -18,10 +18,6 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
-
-        // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        arduino_portable::report(&mut serial);
     }
 }

--- a/examples/arduino-uno/src/bin/uno-watchdog.rs
+++ b/examples/arduino-uno/src/bin/uno-watchdog.rs
@@ -9,7 +9,7 @@
 #![no_main]
 
 use arduino_hal::hal::wdt;
-use arduino_hal::prelude::*;
+// use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -20,7 +20,7 @@ fn main() -> ! {
     let mut led = pins.d13.into_output();
     led.set_high();
 
-    for i in 0..20 {
+    for _i in 0..20 {
         led.toggle();
         arduino_hal::delay_ms(100);
     }

--- a/examples/nano168/Cargo.toml
+++ b/examples/nano168/Cargo.toml
@@ -18,3 +18,6 @@ features = ["nano168"]
 
 [dependencies.avr-device]
 version = "0.3"
+
+[dependencies.arduino-portable]
+path = "../arduino-portable"

--- a/examples/nano168/src/bin/nano168-ldr.rs
+++ b/examples/nano168/src/bin/nano168-ldr.rs
@@ -28,7 +28,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use arduino_hal::adc;
+//use arduino_hal::adc;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -54,7 +54,7 @@ fn main() -> ! {
             x if x > 250 => "dimmly lit",
             x if x > 50 => "rather dark",
             x if x <= 50 => "very dark",
-            x => "invalid", // to satisfy the compiler ()
+            _ => "invalid", // to satisfy the compiler ()
         };
 
         // output to the serial

--- a/examples/nano168/src/bin/nano168-usart.rs
+++ b/examples/nano168/src/bin/nano168-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+// use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -15,10 +15,6 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
-
-        // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        arduino_portable::report(&mut serial);
     }
 }

--- a/examples/nano168/src/bin/nano168-watchdog.rs
+++ b/examples/nano168/src/bin/nano168-watchdog.rs
@@ -16,7 +16,7 @@ fn main() -> ! {
 
     ufmt::uwriteln!(&mut serial, "Setup started...").void_unwrap();
 
-    for i in 0..20 {
+    for _i in 0..20 {
         ufmt::uwrite!(&mut serial, ".").void_unwrap();
         led.toggle();
         arduino_hal::delay_ms(100);

--- a/examples/sparkfun-promicro/Cargo.toml
+++ b/examples/sparkfun-promicro/Cargo.toml
@@ -14,3 +14,6 @@ embedded-hal = "0.2.3"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["sparkfun-promicro"]
+
+[dependencies.arduino-portable]
+path = "../arduino-portable"

--- a/examples/sparkfun-promicro/src/bin/promicro-usart.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+// use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -15,10 +15,6 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
-
-        // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        arduino_portable::report(&mut serial);
     }
 }


### PR DESCRIPTION
extract the serial port example into a portable function that demonstrates how to declare the serial port using generics such that it will compile on multiple targets.

I think folks can benefit from seeing concrete examples of how to write cross-platform fuctions like

```
pub fn report<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK>(
    serial: &mut Usart<H, USART, RX, TX, CLOCK>,
) {
```