### PR TITLE
Fix to support avrdude version numbers with multiple decimal points

### DIFF
--- a/ravedude/src/avrdude/mod.rs
+++ b/ravedude/src/avrdude/mod.rs
@@ -26,9 +26,9 @@ impl Avrdude {
             .chars()
             .take_while(|c| c.is_ascii_digit() || *c == '.')
             .collect();
-        let (major, minor) = version.split_once('.').ok_or_else(err)?;
-        let major = major.parse::<u8>()?;
-        let minor = minor.parse::<u8>()?;
+        let mut version_splits = version.split('.');
+        let major = version_splits.next().ok_or_else(err)?.parse::<u8>()?;
+        let minor = version_splits.next().ok_or_else(err)?.parse::<u8>()?;
         Ok((major, minor))
     }
 


### PR DESCRIPTION
I was getting a hello world app up and running with avr-hal on Windows and took this version of avrdude: https://github.com/mariusgreuel/avrdude/releases/tag/v6.3.1.1-windows

The problem is that the version number reported in this version was **6.3.1.1** which causes an error in the code as it assumes only one decimal point (thus parsing "3.1.1" as the minor version number)

I worked around it by grabbing the latest version of avrdude which is 6.99 and that now works fine