### PR TITLE
Add support for `asm!()`

### DIFF
--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -18,3 +18,6 @@ features = ["unproven"]
 [dependencies.void]
 version = "1.0.2"
 default-features = false
+
+[build-dependencies]
+rustversion = "1.0"

--- a/avr-hal-generic/build.rs
+++ b/avr-hal-generic/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    maybe_enable_asm();
+}
+
+#[rustversion::before(1.59.0)]
+fn maybe_enable_asm() {
+    //
+}
+
+#[rustversion::since(1.59.0)]
+fn maybe_enable_asm() {
+    // https://github.com/rust-lang/rust/pull/92816
+    println!("cargo:rustc-cfg=avr_hal_asm_macro");
+}

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
-#![feature(llvm_asm)]
+#![cfg_attr(avr_hal_asm_macro, feature(asm_experimental_arch))]
+#![cfg_attr(not(avr_hal_asm_macro), feature(llvm_asm))]
 
 pub extern crate embedded_hal as hal;
 


### PR DESCRIPTION
Closes https://github.com/Rahix/avr-hal/issues/254.
Closes https://github.com/Rahix/avr-hal/pull/229.

Abstract & rest the same as for https://github.com/Rahix/avr-device/pull/97 🙂 

As for the LLVM IR, there's a small change in `delay()`:
```
older rustc:
  %7 = tail call addrspace(0) i16 asm sideeffect "1: sbiw $0,1\0A\09brne 1b", "=w,0"(i16 %6) #10, !srcloc !6

newer rustc:
  tail call addrspace(0) void asm sideeffect alignstack "1:\0Asbiw ${0}, 1\0Abrne 1b", "w,~{sreg},~{memory}"(i16 %5) #14, !srcloc !7
```
... but I think it looks alright (& the code works fine on an Atmega328p).