### PR TITLE
include examples of generics-based portable routines for AVR serial, ADC, and SPI usage.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ members = [
 exclude = [
     # The RAVEDUDE! Yeah!
     "ravedude",
+    # requires the user of this crate to specify the features for embedded-hal
+    "examples/avr-portable",
 ]
 
 [patch.crates-io]

--- a/examples/arduino-leonardo/src/bin/leonardo-i2cdetect.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-i2cdetect.rs
@@ -18,9 +18,11 @@ fn main() -> ! {
     );
 
     ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write)
+        .void_unwrap();
     ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read)
+        .void_unwrap();
 
     loop {}
 }

--- a/examples/arduino-mega2560/Cargo.toml
+++ b/examples/arduino-mega2560/Cargo.toml
@@ -14,3 +14,6 @@ embedded-hal = "0.2.3"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["arduino-mega2560"]
+
+[dependencies.avr-portable]
+path = "../avr-portable"

--- a/examples/arduino-mega2560/src/bin/mega2560-adc.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-adc.rs
@@ -21,9 +21,9 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
     ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
 
+    let a0 = pins.a0.into_analog_input(&mut adc);
     // To store multiple channels in an array, we use the `into_channel()` method.
-    let channels: [adc::Channel; 16] = [
-        pins.a0.into_analog_input(&mut adc).into_channel(),
+    let channels: [adc::Channel; 15] = [
         pins.a1.into_analog_input(&mut adc).into_channel(),
         pins.a2.into_analog_input(&mut adc).into_channel(),
         pins.a3.into_analog_input(&mut adc).into_channel(),
@@ -42,12 +42,8 @@ fn main() -> ! {
     ];
 
     loop {
-        for (i, ch) in channels.iter().enumerate() {
-            let v = adc.read_blocking(ch);
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
-        }
-
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        avr_portable::report_adc_single(&mut serial, &mut adc, 0, &a0);
+        avr_portable::report_adc_multi(&mut serial, &mut adc, &channels);
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-adc.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-adc.rs
@@ -21,9 +21,9 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
     ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
 
-    let a0 = pins.a0.into_analog_input(&mut adc);
     // To store multiple channels in an array, we use the `into_channel()` method.
-    let channels: [adc::Channel; 15] = [
+    let channels: [adc::Channel; 16] = [
+        pins.a0.into_analog_input(&mut adc).into_channel(),
         pins.a1.into_analog_input(&mut adc).into_channel(),
         pins.a2.into_analog_input(&mut adc).into_channel(),
         pins.a3.into_analog_input(&mut adc).into_channel(),
@@ -42,8 +42,17 @@ fn main() -> ! {
     ];
 
     loop {
-        avr_portable::report_adc_single(&mut serial, &mut adc, 0, &a0);
-        avr_portable::report_adc_multi(&mut serial, &mut adc, &channels);
+        if true {
+            for (i, ch) in channels.iter().enumerate() {
+                let v = adc.read_blocking(ch);
+                ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            }
+
+            ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        } else {
+            avr_portable::report_adc_single(&mut serial, &mut adc, 0, &channels[0]);
+            avr_portable::report_adc_multi(&mut serial, &mut adc, &channels[1..]);
+        }
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-i2cdetect.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-i2cdetect.rs
@@ -18,9 +18,11 @@ fn main() -> ! {
     );
 
     ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write)
+        .void_unwrap();
     ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read)
+        .void_unwrap();
 
     loop {}
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
@@ -17,7 +17,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-use embedded_hal::spi::FullDuplex;
+// use embedded_hal::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -39,10 +39,7 @@ fn main() -> ! {
     );
 
     loop {
-        // Send a byte
-        nb::block!(spi.send(0b00001111)).void_unwrap();
-        // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).void_unwrap();
+        let data = avr_portable::spi_loopback(&mut spi, 0b00001111);
 
         ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
         arduino_hal::delay_ms(1000);

--- a/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
@@ -17,7 +17,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-// use embedded_hal::spi::FullDuplex;
+use embedded_hal::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -39,7 +39,14 @@ fn main() -> ! {
     );
 
     loop {
-        let data = avr_portable::spi_loopback(&mut spi, 0b00001111);
+        let data = if true {
+            // Send a byte
+            nb::block!(spi.send(0b00001111)).void_unwrap();
+            // Because MISO is connected to MOSI, the read data should be the same
+            nb::block!(spi.read()).void_unwrap()
+        } else {
+            avr_portable::spi_loopback(&mut spi, 0b00001111)
+        };
 
         ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
         arduino_hal::delay_ms(1000);

--- a/examples/arduino-mega2560/src/bin/mega2560-usart.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+//use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -15,10 +15,6 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
-
-        // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        avr_portable::report(&mut serial);
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-usart.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-//use embedded_hal::serial::Read;
+use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -15,6 +15,14 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        avr_portable::report(&mut serial);
+        if true {
+            // Read a byte from the serial connection
+            let b = nb::block!(serial.read()).void_unwrap();
+
+            // Answer
+            ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        } else {
+            avr_portable::report(&mut serial);
+        }
     }
 }

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -22,3 +22,6 @@ version = "0.3"
 [dependencies.either]
 version = "1.6.1"
 default-features = false
+
+[dependencies.avr-portable]
+path = "../avr-portable"

--- a/examples/arduino-uno/src/bin/uno-16chan-servo-driver.rs
+++ b/examples/arduino-uno/src/bin/uno-16chan-servo-driver.rs
@@ -57,7 +57,8 @@ fn main() -> ! {
         arduino_hal::delay_ms(500);
 
         pwm.set_channel_off(Channel::C0, current).unwrap();
-        pwm.set_channel_off(Channel::C1, servo_min + (servo_max - current)).unwrap();
+        pwm.set_channel_off(Channel::C1, servo_min + (servo_max - current))
+            .unwrap();
 
         if current == servo_max {
             factor -= 1;

--- a/examples/arduino-uno/src/bin/uno-adc.rs
+++ b/examples/arduino-uno/src/bin/uno-adc.rs
@@ -34,9 +34,9 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
     ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).void_unwrap();
 
-    let a0 = pins.a0.into_analog_input(&mut adc);
     // To store multiple channels in an array, we use the `into_channel()` method.
-    let channels: [adc::Channel; 5] = [
+    let channels: [adc::Channel; 6] = [
+        pins.a0.into_analog_input(&mut adc).into_channel(),
         pins.a1.into_analog_input(&mut adc).into_channel(),
         pins.a2.into_analog_input(&mut adc).into_channel(),
         pins.a3.into_analog_input(&mut adc).into_channel(),
@@ -45,8 +45,17 @@ fn main() -> ! {
     ];
 
     loop {
-        avr_portable::report_adc_single(&mut serial, &mut adc, 0, &a0);
-        avr_portable::report_adc_multi(&mut serial, &mut adc, &channels);
+        if true {
+            let values = channels.iter().map(|ch| adc.read_blocking(ch));
+            for (i, v) in values.enumerate() {
+                ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            }
+
+            ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        } else {
+            avr_portable::report_adc_single(&mut serial, &mut adc, 0, &channels[0]);
+            avr_portable::report_adc_multi(&mut serial, &mut adc, &channels[1..]);
+        }
 
         arduino_hal::delay_ms(1000);
     }

--- a/examples/arduino-uno/src/bin/uno-adc.rs
+++ b/examples/arduino-uno/src/bin/uno-adc.rs
@@ -35,27 +35,19 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).void_unwrap();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
-    let a1 = pins.a1.into_analog_input(&mut adc);
-    let a2 = pins.a2.into_analog_input(&mut adc);
-    let a3 = pins.a3.into_analog_input(&mut adc);
-    let a4 = pins.a4.into_analog_input(&mut adc);
-    let a5 = pins.a5.into_analog_input(&mut adc);
+    // To store multiple channels in an array, we use the `into_channel()` method.
+    let channels: [adc::Channel; 5] = [
+        pins.a1.into_analog_input(&mut adc).into_channel(),
+        pins.a2.into_analog_input(&mut adc).into_channel(),
+        pins.a3.into_analog_input(&mut adc).into_channel(),
+        pins.a4.into_analog_input(&mut adc).into_channel(),
+        pins.a5.into_analog_input(&mut adc).into_channel(),
+    ];
 
     loop {
-        let values = [
-            a0.analog_read(&mut adc),
-            a1.analog_read(&mut adc),
-            a2.analog_read(&mut adc),
-            a3.analog_read(&mut adc),
-            a4.analog_read(&mut adc),
-            a5.analog_read(&mut adc),
-        ];
+        avr_portable::report_adc_single(&mut serial, &mut adc, 0, &a0);
+        avr_portable::report_adc_multi(&mut serial, &mut adc, &channels);
 
-        for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
-        }
-
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-uno/src/bin/uno-ext-interrupt.rs
+++ b/examples/arduino-uno/src/bin/uno-ext-interrupt.rs
@@ -1,19 +1,19 @@
 /*!
  * Blinks a 4 leds in sequence on pins D3 - D6. When an external interrupt on D2/INT0 comes in
  * the sequence is reversed.
- * 
- * Note: The use of the either crate requires the deactivation of std to use it in core. See the Cargo.toml 
+ *
+ * Note: The use of the either crate requires the deactivation of std to use it in core. See the Cargo.toml
  * in this directory for details.
  */
 #![no_std]
 #![no_main]
 #![feature(abi_avr_interrupt)]
 
-use panic_halt as _;
+use arduino_hal::port::{mode, Pin};
 use core::ops::Range;
 use core::sync::atomic::{AtomicBool, Ordering};
-use arduino_hal::port::{mode, Pin};
 use either::*;
+use panic_halt as _;
 
 static REVERSED: AtomicBool = AtomicBool::new(false);
 
@@ -27,7 +27,7 @@ fn INT0() {
     REVERSED.store(!current, Ordering::SeqCst);
 }
 
-fn blink_for_range(range : Range<u16>, leds : &mut[Pin<mode::Output>]) {
+fn blink_for_range(range: Range<u16>, leds: &mut [Pin<mode::Output>]) {
     range.map(|i| i * 100).for_each(|ms| {
         let iter = if is_reversed() {
             Left(leds.iter_mut().rev())

--- a/examples/arduino-uno/src/bin/uno-pin-change-interrupt.rs
+++ b/examples/arduino-uno/src/bin/uno-pin-change-interrupt.rs
@@ -12,7 +12,7 @@
 use arduino_hal;
 use panic_halt as _;
 
-use core:: sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, Ordering};
 
 static PIN_CHANGED: AtomicBool = AtomicBool::new(false);
 
@@ -42,11 +42,11 @@ fn main() -> ! {
     //Pins used to drive the stepper motor
     let mut dir_pin = pins.d4.into_output();
     let mut step_pin = pins.d5.into_output();
-    
+
     //Rotary encoder attached on these pins
     let rotary_pins = [
         pins.d2.into_floating_input().downgrade(), //CLK
-        pins.d3.into_floating_input().downgrade() //DT
+        pins.d3.into_floating_input().downgrade(), //DT
     ];
 
     // Enable the PCINT2 pin change interrupt

--- a/examples/arduino-uno/src/bin/uno-spi-feedback.rs
+++ b/examples/arduino-uno/src/bin/uno-spi-feedback.rs
@@ -16,7 +16,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-// use embedded_hal::spi::FullDuplex;
+use embedded_hal::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -38,7 +38,14 @@ fn main() -> ! {
     );
 
     loop {
-        let data = avr_portable::spi_loopback(&mut spi, 0b00001111);
+        let data = if true {
+            // Send a byte
+            nb::block!(spi.send(0b00001111)).void_unwrap();
+            // Because MISO is connected to MOSI, the read data should be the same
+            nb::block!(spi.read()).void_unwrap()
+        } else {
+            avr_portable::spi_loopback(&mut spi, 0b00001111)
+        };
 
         ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
         arduino_hal::delay_ms(1000);

--- a/examples/arduino-uno/src/bin/uno-spi-feedback.rs
+++ b/examples/arduino-uno/src/bin/uno-spi-feedback.rs
@@ -16,7 +16,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-use embedded_hal::spi::FullDuplex;
+// use embedded_hal::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -38,10 +38,7 @@ fn main() -> ! {
     );
 
     loop {
-        // Send a byte
-        nb::block!(spi.send(0b00001111)).void_unwrap();
-        // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).void_unwrap();
+        let data = avr_portable::spi_loopback(&mut spi, 0b00001111);
 
         ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
         arduino_hal::delay_ms(1000);

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -7,7 +7,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-// use embedded_hal::serial::Read;
+use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -18,6 +18,14 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        avr_portable::report(&mut serial);
+        if true {
+            // Read a byte from the serial connection
+            let b = nb::block!(serial.read()).void_unwrap();
+
+            // Answer
+            ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        } else {
+            avr_portable::report(&mut serial);
+        }
     }
 }

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -7,7 +7,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+// use embedded_hal::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {
@@ -18,10 +18,6 @@ fn main() -> ! {
     ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
 
     loop {
-        // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
-
-        // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        avr_portable::report(&mut serial);
     }
 }

--- a/examples/arduino-uno/src/bin/uno-watchdog.rs
+++ b/examples/arduino-uno/src/bin/uno-watchdog.rs
@@ -9,7 +9,7 @@
 #![no_main]
 
 use arduino_hal::hal::wdt;
-use arduino_hal::prelude::*;
+// use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -20,7 +20,7 @@ fn main() -> ! {
     let mut led = pins.d13.into_output();
     led.set_high();
 
-    for i in 0..20 {
+    for _i in 0..20 {
         led.toggle();
         arduino_hal::delay_ms(100);
     }

--- a/examples/avr-portable/Cargo.toml
+++ b/examples/avr-portable/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "avr-portable"
+version = "0.1.0"
+authors = ["Robert Forsman <git@thoth.purplefrog.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nb = "*"
+ufmt = "*"
+void = { version="*", default-features = false }
+avr-hal-generic = { path="../../avr-hal-generic" }
+embedded-hal = "*"

--- a/examples/avr-portable/src/lib.rs
+++ b/examples/avr-portable/src/lib.rs
@@ -1,0 +1,83 @@
+#![no_std]
+
+//! If you want library routines to be portable between different AVR implementations,
+//! it is best to use types from [avr_hal_generic] instead of [arduino_hal]
+
+use avr_hal_generic::adc::AdcChannel;
+use avr_hal_generic::port::PinOps;
+use avr_hal_generic::spi::{Spi, SpiOps};
+use avr_hal_generic::usart::{Usart, UsartOps};
+use embedded_hal::serial::Read;
+use embedded_hal::spi::FullDuplex;
+use ufmt::uWrite;
+pub use void::ResultVoidErrExt as _;
+pub use void::ResultVoidExt as _;
+
+pub fn report<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK>(
+    serial: &mut Usart<H, USART, RX, TX, CLOCK>,
+) {
+    // Read a byte from the serial connection
+    let b = nb::block!(serial.read()).void_unwrap();
+
+    // Answer
+    ufmt::uwriteln!(serial, "Got {}!\r", b).void_unwrap();
+}
+
+pub fn report_adc_single<
+    W: uWrite<Error = void::Void>,
+    H,
+    ADCOPS: avr_hal_generic::adc::AdcOps<H>,
+    CLOCK: avr_hal_generic::clock::Clock,
+    PIN: AdcChannel<H, ADCOPS>,
+>(
+    serial: &mut W,
+    adc: &mut avr_hal_generic::adc::Adc<H, ADCOPS, CLOCK>,
+    i: usize,
+    analog_pin: &PIN,
+) {
+    let v = adc.read_blocking(analog_pin);
+    ufmt::uwrite!(serial, "A{}: {} ", i, v).void_unwrap();
+}
+
+pub fn report_adc_multi<
+    W: uWrite<Error = void::Void>,
+    H,
+    ADCOPS: avr_hal_generic::adc::AdcOps<H>,
+    CLOCK: avr_hal_generic::clock::Clock,
+>(
+    serial: &mut W,
+    adc: &mut avr_hal_generic::adc::Adc<H, ADCOPS, CLOCK>,
+    channels: &[avr_hal_generic::adc::Channel<H, ADCOPS>],
+) {
+    for (i, ch) in channels.iter().enumerate() {
+        let v = adc.read_blocking(ch);
+        ufmt::uwrite!(serial, "A{}: {} ", i, v).void_unwrap();
+    }
+
+    ufmt::uwriteln!(serial, "").void_unwrap();
+}
+
+pub fn spi_loopback<H, SPI, SCLKPIN, MOSIPIN, MISOPIN, CSPIN>(
+    spi: &mut Spi<H, SPI, SCLKPIN, MOSIPIN, MISOPIN, CSPIN>,
+    val: u8,
+) -> u8
+where
+    SPI: SpiOps<H, SCLKPIN, MOSIPIN, MISOPIN, CSPIN>,
+    SCLKPIN: PinOps,
+    MOSIPIN: PinOps,
+    MISOPIN: PinOps,
+    CSPIN: PinOps,
+{
+    // Send a byte
+    nb::block!(spi.send(val)).void_unwrap();
+    // Because MISO is connected to MOSI, the read data should be the same
+    nb::block!(spi.read()).void_unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/examples/nano168/src/bin/nano168-i2cdetect.rs
+++ b/examples/nano168/src/bin/nano168-i2cdetect.rs
@@ -18,9 +18,11 @@ fn main() -> ! {
     );
 
     ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write)
+        .void_unwrap();
     ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read)
+        .void_unwrap();
 
     loop {}
 }

--- a/examples/nano168/src/bin/nano168-millis.rs
+++ b/examples/nano168/src/bin/nano168-millis.rs
@@ -89,4 +89,3 @@ fn main() -> ! {
         ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).void_unwrap();
     }
 }
-

--- a/examples/sparkfun-promicro/src/bin/promicro-i2cdetect.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-i2cdetect.rs
@@ -18,9 +18,11 @@ fn main() -> ! {
     );
 
     ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write)
+        .void_unwrap();
     ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read)
+        .void_unwrap();
 
     loop {}
 }


### PR DESCRIPTION
This is a modified version of https://github.com/Rahix/avr-hal/pull/259 .  Based on feedback from Rahix, it includes the `avr-portable/` crate, but only the `arduino-uno` and `arduino-mega2560` examples are modified to show calling the generic routines, and only in the `else` clause of an `if true` which calls the old code.