### PR TITLE
Fix delay inline assembly for new rust versions

### DIFF
--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -36,13 +36,14 @@ impl<SPEED> Delay<SPEED> {
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "avr", avr_hal_asm_macro))] {
-        fn busy_loop(c: u16) {
+        #[allow(unused_assignments)]
+        fn busy_loop(mut c: u16) {
             unsafe {
                 asm!(
                     "1:",
                     "sbiw {c}, 1",
                     "brne 1b",
-                    c = in(reg_iw) c,
+                    c = inout(reg_iw) c,
                 );
             }
         }


### PR DESCRIPTION
The register needs to be marked `inout` to have the same behavior as the old code.

@Patryk27, just fyi.  Without this change, the code still "works" but delays are much longer.  I didn't dig deep enough to truly understand why this is happening but I figured changing the behavior back to what `llvm_asm!()` was doing is good enough for now.