### PR TITLE
Upgrade to a recent rust compiler nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-01-07
+          toolchain: nightly-2022-05-10
           override: true
           components: rust-src
       - name: Install avr-gcc, binutils, and libc

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hardware Abstraction Layer for AVR microcontrollers and common boards (for examp
 **This is a new version of `avr-hal`!  Older versions can be found in the `old` branch but will no longer get support.**
 
 ## Quickstart
-You need a nightly Rust compiler for compiling Rust code for AVR.  **Note**: Due to a regression, versions after `nightly-2021-01-07` are currently broken (see [#124](https://github.com/Rahix/avr-hal/issues/124)).  Please use that version of the compiler for now. The correct version will be installed automatically.
+You need a nightly Rust compiler for compiling Rust code for AVR.  The correct version will be installed automatically due to the `rust-toolchain.toml` file.
 
 On Ubuntu, you'll need to install dependencies:
 

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -9,7 +9,7 @@ cfg-if = "0.1.7"
 nb = "0.1.2"
 ufmt = "0.1.0"
 paste = "1.0.0"
-avr-device = "0.3"
+avr-device = "0.3.3"
 
 [dependencies.embedded-hal]
 version = "0.2.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-01-07"
+channel = "nightly-2022-05-10"
 components = [ "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
Through the work of @Patryk27, nightly can compile for AVR again as of today :)  Upgrade the nightly version referenced in the toolchain file to opt people into the new compiler if they are using rustup.

Finally closes #124.  Thanks again @Patryk27!