### PR TITLE
Reimplement simple pwm

### DIFF
--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -113,7 +113,7 @@ pub use delay::{delay_ms, delay_us, Delay};
 #[cfg(feature = "board-selected")]
 pub mod port;
 
-#[cfg(feature = "mcu-atmega")]
+#[cfg(feature = "board-selected")]
 pub mod simple_pwm;
 
 #[doc(no_inline)]

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -113,7 +113,7 @@ pub use delay::{delay_ms, delay_us, Delay};
 #[cfg(feature = "board-selected")]
 pub mod port;
 
-#[cfg(feature = "board-selected")]
+#[cfg(feature = "mcu-atmega")]
 pub mod simple_pwm;
 
 #[doc(no_inline)]

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -112,6 +112,10 @@ pub use delay::{delay_ms, delay_us, Delay};
 
 #[cfg(feature = "board-selected")]
 pub mod port;
+
+#[cfg(feature = "board-selected")]
+pub mod simple_pwm;
+
 #[doc(no_inline)]
 #[cfg(feature = "board-selected")]
 pub use port::Pins;

--- a/arduino-hal/src/simple_pwm.rs
+++ b/arduino-hal/src/simple_pwm.rs
@@ -1,0 +1,10 @@
+//! Simple PWM output for supported Pins.
+//!
+//! This module implements simple (FastPWM) PWM output for supported Pins.
+//!
+//! Check the documentation for each of the TimerXPwm-structs for usage
+//! examples.
+
+pub use avr_hal_generic::simple_pwm::IntoPwmPin;
+pub use avr_hal_generic::simple_pwm::Prescaler;
+pub use atmega_hal::simple_pwm::*;

--- a/arduino-hal/src/simple_pwm.rs
+++ b/arduino-hal/src/simple_pwm.rs
@@ -7,4 +7,9 @@
 
 pub use avr_hal_generic::simple_pwm::IntoPwmPin;
 pub use avr_hal_generic::simple_pwm::Prescaler;
+
+#[cfg(feature = "mcu-atmega")]
 pub use atmega_hal::simple_pwm::*;
+
+#[cfg(feature = "mcu-attiny")]
+pub use attiny_hal::simple_pwm::*;

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -22,7 +22,7 @@ pub mod usart;
 pub mod i2c;
 pub mod spi;
 pub mod adc;
-pub mod pwm;
+pub mod simple_pwm;
 pub mod wdt;
 
 /// Prelude containing all HAL traits

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -24,6 +24,12 @@ pub mod mode {
     impl Io for OpenDrain {}
     impl crate::Sealed for OpenDrain {}
 
+    pub struct PwmOutput<TC> {
+        pub(crate) _timer: PhantomData<TC>
+    }
+    impl<TC> super::PinMode for PwmOutput<TC> {}
+    impl<TC> crate::Sealed for PwmOutput<TC> {}
+
     pub trait InputMode: crate::Sealed {}
 
     /// Pin is configured as digital input (floating or pulled-up).

--- a/avr-hal-generic/src/simple_pwm.rs
+++ b/avr-hal-generic/src/simple_pwm.rs
@@ -1,5 +1,10 @@
 //! PWM Implementation
 
+use core::marker::PhantomData;
+
+use crate::port::Pin;
+use crate::port::mode;
+
 /// Clock prescaler for PWM
 ///
 /// The prescaler dictates the PWM frequency, together with the IO clock.  The formula is as
@@ -31,15 +36,61 @@ pub enum Prescaler {
 }
 
 /// Implement traits and types for PWM timers
+pub trait PwmPinOps<TC> {
+    type Duty;
+
+    fn enable(&mut self);
+    fn disable(&mut self);
+    fn get_duty(&self) -> Self::Duty;
+    fn get_max_duty(&self) -> Self::Duty;
+
+    fn set_duty(&mut self, value: u8);
+}
+
+pub trait IntoPwmPin<TC, PIN> {
+    fn into_pwm(self, timer: &TC) -> Pin<mode::PwmOutput<TC>, PIN>;
+}
+
+impl<TC, PIN: PwmPinOps<TC>> IntoPwmPin<TC, PIN> for Pin<mode::Output, PIN> {
+    fn into_pwm(self, _timer: &TC) -> Pin<mode::PwmOutput<TC>, PIN> {
+        Pin {
+            pin: self.pin,
+            _mode: PhantomData
+        }
+    }
+}
+
+impl<TC, PIN: PwmPinOps<TC>> Pin<mode::PwmOutput<TC>, PIN> {
+    pub fn enable(&mut self) {
+        self.pin.enable();
+    }
+
+    pub fn disable(&mut self) {
+        self.pin.disable();
+    }
+
+    pub fn get_duty(&self) -> <PIN as PwmPinOps<TC>>::Duty {
+        self.pin.get_duty()
+    }
+
+    pub fn get_max_duty(&self) -> <PIN as PwmPinOps<TC>>::Duty {
+        self.pin.get_max_duty()
+    }
+
+    pub fn set_duty(&mut self, duty: u8) {
+        self.pin.set_duty(duty);
+    }
+}
+
 #[macro_export]
-macro_rules! impl_pwm {
+macro_rules! impl_simple_pwm {
     (
         $(#[$timer_pwm_attr:meta])*
         pub struct $TimerPwm:ident {
             timer: $TIMER:ty,
             init: |$init_timer:ident, $prescaler:ident| $init_block:block,
             pins: {$(
-                $port:ident::$PXi:ident: {
+                $PXi:ident: {
                     ocr: $ocr:ident,
                     $into_pwm:ident: |$pin_timer:ident| if enable
                         $pin_enable_block:block else $pin_disable_block:block,
@@ -53,7 +104,7 @@ macro_rules! impl_pwm {
         }
 
         impl $TimerPwm {
-            pub fn new(timer: $TIMER, prescaler: $crate::pwm::Prescaler) -> $TimerPwm {
+            pub fn new(timer: $TIMER, prescaler: $crate::simple_pwm::Prescaler) -> $TimerPwm {
                 let mut t = $TimerPwm { timer };
 
                 {
@@ -67,15 +118,7 @@ macro_rules! impl_pwm {
         }
 
         $(
-            impl $port::$PXi<$crate::port::mode::Output> {
-                pub fn $into_pwm(self, pwm_timer: &mut $TimerPwm)
-                    -> $port::$PXi<$crate::port::mode::Pwm<$TimerPwm>>
-                {
-                    $port::$PXi { _mode: core::marker::PhantomData }
-                }
-            }
-
-            impl $crate::hal::PwmPin for $port::$PXi<$crate::port::mode::Pwm<$TimerPwm>> {
+            impl avr_hal_generic::simple_pwm::PwmPinOps<$TimerPwm> for $PXi {
                 type Duty = u8;
 
                 fn enable(&mut self) {
@@ -85,7 +128,7 @@ macro_rules! impl_pwm {
                     $crate::avr_device::interrupt::free(|_| {
                         let $pin_timer = unsafe { &*<$TIMER>::ptr() };
                         $pin_enable_block
-                    })
+                    });
                 }
 
                 fn disable(&mut self) {
@@ -95,7 +138,7 @@ macro_rules! impl_pwm {
                     $crate::avr_device::interrupt::free(|_| {
                         let $pin_timer = unsafe { &*<$TIMER>::ptr() };
                         $pin_disable_block
-                    })
+                    });
                 }
 
                 fn get_duty(&self) -> Self::Duty {
@@ -109,7 +152,7 @@ macro_rules! impl_pwm {
                 fn set_duty(&mut self, duty: Self::Duty) {
                     // SAFETY: This register is exclusively used here so there are no concurrency
                     // issues.
-                    unsafe { (&*<$TIMER>::ptr()).$ocr.write(|w| w.bits(duty.into())) };
+                    unsafe { (&*<$TIMER>::ptr()).$ocr.write(|w| w.bits(duty.into())); };
                 }
             }
         )+

--- a/examples/arduino-uno/src/bin/uno-simple-pwm.rs
+++ b/examples/arduino-uno/src/bin/uno-simple-pwm.rs
@@ -1,0 +1,27 @@
+/*!
+ * Example of using simple_pwm to fade a LED in and out on pin d5.
+ */
+#![no_std]
+#![no_main]
+
+use arduino_hal::simple_pwm::*;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    let timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+
+    // Digital pin 5 is connected to a LED and a resistor in series
+    let mut pwm_led = pins.d5.into_output().into_pwm(&timer0);
+    pwm_led.enable();
+
+    loop {
+        for x in (0..=255).chain((0..=254).rev()) {
+            pwm_led.set_duty(x);
+            arduino_hal::delay_ms(10);
+        }
+    }
+}

--- a/examples/trinket/src/bin/trinket-simple-pwm.rs
+++ b/examples/trinket/src/bin/trinket-simple-pwm.rs
@@ -1,0 +1,28 @@
+/*!
+ * Example of using simple_pwm to fade the built-in LED in and out.
+ */
+
+#![no_std]
+#![no_main]
+
+use arduino_hal::simple_pwm::*;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    let timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+
+    // Digital pin 1 is also connected to an onboard LED marked "L"
+    let mut pwm_led = pins.d1.into_output().into_pwm(&timer0);
+    pwm_led.enable();
+
+    loop {
+        for x in (0..=255).chain((0..=254).rev()) {
+            pwm_led.set_duty(x);
+            arduino_hal::delay_ms(10);
+        }
+    }
+}

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -91,6 +91,9 @@ pub mod port;
 pub use port::Pins;
 
 #[cfg(feature = "device-selected")]
+pub mod simple_pwm;
+
+#[cfg(feature = "device-selected")]
 pub mod usart;
 #[cfg(feature = "device-selected")]
 pub use usart::Usart;

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -233,7 +233,7 @@ avr_hal_generic::impl_simple_pwm! {
 }
 
 
-#[cfg(feature = "atmega2560")]
+#[cfg(any(feature = "atmega1280", feature="atmega2560"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC0` for PWM (pins `PB7`, `PG5`)
     ///
@@ -281,7 +281,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(feature = "atmega2560")]
+#[cfg(any(feature = "atmega1280", feature="atmega2560"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC1` for PWM (pins `PB5`, `PB6`, `PB7`)
     ///
@@ -339,7 +339,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(feature = "atmega2560")]
+#[cfg(any(feature = "atmega1280", feature="atmega2560"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC2` for PWM (pins `PB4`, `PH6`)
     ///
@@ -392,7 +392,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(feature = "atmega2560")]
+#[cfg(any(feature = "atmega1280", feature="atmega2560"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC3` for PWM (pins `PE3`, `PE4`, `PE5`)
     ///
@@ -455,7 +455,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(feature = "atmega2560")]
+#[cfg(any(feature = "atmega1280", feature="atmega2560"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC4` for PWM (pins `PH3`, `PH4`, `PH5`)
     ///
@@ -518,7 +518,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(feature = "atmega2560")]
+#[cfg(any(feature = "atmega1280", feature="atmega2560"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC5` for PWM (pins `PL3`, `PL4`, `PL5`)
     ///

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -580,3 +580,212 @@ avr_hal_generic::impl_simple_pwm! {
         },
     }
 }
+
+#[cfg(any(feature = "atmega32u4"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC0` for PWM (pins `PB7`, `PD0`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+    ///
+    /// let mut d11 = pins.d11.into_output().into_pwm(&mut timer0);
+    /// let mut d3 = pins.d3.into_output().into_pwm(&mut timer0);
+    ///
+    /// d11.set_duty(128);
+    /// d11.enable();
+    /// ```
+    pub struct Timer0Pwm {
+        timer: crate::pac::TC0,
+        init: |tim, prescaler| {
+            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs0().direct(),
+                Prescaler::Prescale8 => w.cs0().prescale_8(),
+                Prescaler::Prescale64 => w.cs0().prescale_64(),
+                Prescaler::Prescale256 => w.cs0().prescale_256(),
+                Prescaler::Prescale1024 => w.cs0().prescale_1024(),
+            });
+        },
+        pins: {
+            PB7: {
+                ocr: ocr0a,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                },
+            },
+
+            PD0: {
+                ocr: ocr0b,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(any(feature = "atmega32u4"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC1` for PWM (pins `PB5`, `PB6`, `PB7`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
+    ///
+    /// let mut d9 = pins.d9.into_output().into_pwm(&mut timer1);
+    /// let mut d10 = pins.d10.into_output().into_pwm(&mut timer1);
+    /// let mut d11 = pins.d11.into_output().into_pwm(&mut timer1);
+    ///
+    /// d9.set_duty(128);
+    /// d9.enable();
+    /// ```
+    pub struct Timer1Pwm {
+        timer: crate::pac::TC1,
+        init: |tim, prescaler| {
+            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
+            tim.tccr1b.modify(|_r, w| w.wgm1().bits(0b01));
+
+            tim.tccr1b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs1().direct(),
+                Prescaler::Prescale8 => w.cs1().prescale_8(),
+                Prescaler::Prescale64 => w.cs1().prescale_64(),
+                Prescaler::Prescale256 => w.cs1().prescale_256(),
+                Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+            });
+        },
+        pins: {
+            PB5: {
+                ocr: ocr1a,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                },
+            },
+
+            PB6: {
+                ocr: ocr1b,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                },
+            },
+
+            PB7: {
+                ocr: ocr1c,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1c().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1c().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(any(feature = "atmega32u4"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC3` for PWM (pins `PC6`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer3 = Timer3Pwm::new(dp.TC3, Prescaler::Prescale64);
+    ///
+    /// let mut d5 = pins.d5.into_output().into_pwm(&mut timer3);
+    ///
+    /// d5.set_duty(128);
+    /// d5.enable();
+    /// ```
+    pub struct Timer3Pwm {
+        timer: crate::pac::TC3,
+        init: |tim, prescaler| {
+            tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
+            tim.tccr3b.modify(|_r, w| w.wgm3().bits(0b01));
+
+            tim.tccr3b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs3().direct(),
+                Prescaler::Prescale8 => w.cs3().prescale_8(),
+                Prescaler::Prescale64 => w.cs3().prescale_64(),
+                Prescaler::Prescale256 => w.cs3().prescale_256(),
+                Prescaler::Prescale1024 => w.cs3().prescale_1024(),
+            });
+        },
+        pins: {
+            PC6: {
+                ocr: ocr3a,
+                into_pwm: |tim| if enable {
+                    tim.tccr3a.modify(|_r, w| w.com3a().match_clear());
+                } else {
+                    tim.tccr3a.modify(|_r, w| w.com3a().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(any(feature = "atmega32u4"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC4` for PWM (pins `PB6`, `PC7`, `PD7`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer4 = Timer4Pwm::new(dp.TC4, Prescaler::Prescale64);
+    ///
+    /// let mut d6 = pins.d6.into_output().into_pwm(&mut timer4);
+    /// let mut d10 = pins.d10.into_output().into_pwm(&mut timer4);
+    /// let mut d13 = pins.d13.into_output().into_pwm(&mut timer4);
+    ///
+    /// d6.set_duty(128);
+    /// d6.enable();
+    /// ```
+    pub struct Timer4Pwm {
+        timer: crate::pac::TC4,
+        init: |tim, prescaler| {
+            tim.tccr4a.modify(|_r, w| w.pwm4a().set_bit());
+            tim.tccr4a.modify(|_r, w| w.pwm4b().set_bit());
+            tim.tccr4c.modify(|_r, w| w.pwm4d().set_bit());
+
+            tim.tccr4b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs4().direct(),
+                Prescaler::Prescale8 => w.cs4().prescale_8(),
+                Prescaler::Prescale64 => w.cs4().prescale_64(),
+                Prescaler::Prescale256 => w.cs4().prescale_256(),
+                Prescaler::Prescale1024 => w.cs4().prescale_1024(),
+            });
+        },
+        pins: {
+            PB6: {
+                ocr: ocr4b,
+                into_pwm: |tim| if enable {
+                    tim.tccr4a.modify(|_r, w| w.com4b().match_clear());
+                } else {
+                    tim.tccr4a.modify(|_r, w| w.com4b().disconnected());
+                },
+            },
+
+            PC7: {
+                ocr: ocr4a,
+                into_pwm: |tim| if enable {
+                    tim.tccr4a.modify(|_r, w| w.com4a().match_clear());
+                } else {
+                    tim.tccr4a.modify(|_r, w| w.com4a().disconnected());
+                },
+            },
+
+            PD7: {
+                ocr: ocr4d,
+                into_pwm: |tim| if enable {
+                    tim.tccr4c.modify(|_r, w| w.com4d().match_clear());
+                } else {
+                    tim.tccr4c.modify(|_r, w| w.com4d().disconnected());
+                },
+            },
+        },
+    }
+}

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -10,8 +10,8 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
     ///
-    /// let mut d5 = portd.d5.into_output().into_pwm(&mut timer0);
-    /// let mut d6 = portd.d6.into_output().into_pwm(&mut timer0);
+    /// let mut d5 = pins.d5.into_output().into_pwm(&mut timer0);
+    /// let mut d6 = pins.d6.into_output().into_pwm(&mut timer0);
     ///
     /// d5.set_duty(128);
     /// d5.enable();
@@ -58,8 +58,8 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
     ///
-    /// let mut d9 = portb.d9.into_output().into_pwm(&mut timer1);
-    /// let mut d10 = portb.d10.into_output().into_pwm(&mut timer1);
+    /// let mut d9 = pins.d9.into_output().into_pwm(&mut timer1);
+    /// let mut d10 = pins.d10.into_output().into_pwm(&mut timer1);
     ///
     /// d9.set_duty(128);
     /// d9.enable();
@@ -110,8 +110,8 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer2 = Timer2Pwm::new(dp.TC2, Prescaler::Prescale64);
     ///
-    /// let mut d11 = portb.d11.into_output().into_pwm(&mut timer2);
-    /// let mut d3 = portd.d3.into_output().into_pwm(&mut timer2);
+    /// let mut d11 = pins.d11.into_output().into_pwm(&mut timer2);
+    /// let mut d3 = pins.d3.into_output().into_pwm(&mut timer2);
     ///
     /// d11.set_duty(128);
     /// d11.enable();
@@ -241,8 +241,8 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
     ///
-    /// let mut d13 = portb.d13.into_output().into_pwm(&mut timer0);
-    /// let mut d4 = portg.d4.into_output().into_pwm(&mut timer0);
+    /// let mut d13 = pins.d13.into_output().into_pwm(&mut timer0);
+    /// let mut d4 = pins.d4.into_output().into_pwm(&mut timer0);
     ///
     /// d13.set_duty(128);
     /// d13.enable();
@@ -289,9 +289,9 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
     ///
-    /// let mut d11 = portb.d11.into_output().into_pwm(&mut timer1);
-    /// let mut d12 = portb.d12.into_output().into_pwm(&mut timer1);
-    /// let mut d13 = portb.d13.into_output().into_pwm(&mut timer1);
+    /// let mut d11 = pins.d11.into_output().into_pwm(&mut timer1);
+    /// let mut d12 = pins.d12.into_output().into_pwm(&mut timer1);
+    /// let mut d13 = pins.d13.into_output().into_pwm(&mut timer1);
     ///
     /// d11.set_duty(128);
     /// d11.enable();
@@ -347,8 +347,8 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer2 = Timer2Pwm::new(dp.TC2, Prescaler::Prescale64);
     ///
-    /// let mut d10 = portb.into_output().into_pwm(&mut timer2);
-    /// let mut d9 = porth.into_output().into_pwm(&mut timer2);
+    /// let mut d10 = pins.d10.into_output().into_pwm(&mut timer2);
+    /// let mut d9 = pins.d9.into_output().into_pwm(&mut timer2);
     ///
     /// d10.set_duty(128);
     /// d10.enable();
@@ -400,9 +400,9 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer3 = Timer3Pwm::new(dp.TC3, Prescaler::Prescale64);
     ///
-    /// let mut d5 = porte.d5.into_output().into_pwm(&mut timer3);
-    /// let mut d2 = porte.d2.into_output().into_pwm(&mut timer3);
-    /// let mut d3 = porte.d3.into_output().into_pwm(&mut timer3);
+    /// let mut d5 = pins.d5.into_output().into_pwm(&mut timer3);
+    /// let mut d2 = pins.d2.into_output().into_pwm(&mut timer3);
+    /// let mut d3 = pins.d3.into_output().into_pwm(&mut timer3);
     ///
     /// d5.set_duty(128);
     /// d5.enable();
@@ -463,9 +463,9 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer4 = Timer4Pwm::new(dp.TC4, Prescaler::Prescale64);
     ///
-    /// let mut d6 = porth.d6.into_output().into_pwm(&mut timer4);
-    /// let mut d7 = porth.d7.into_output().into_pwm(&mut timer4);
-    /// let mut d8 = porth.d8.into_output().into_pwm(&mut timer4);
+    /// let mut d6 = pins.d6.into_output().into_pwm(&mut timer4);
+    /// let mut d7 = pins.d7.into_output().into_pwm(&mut timer4);
+    /// let mut d8 = pins.d8.into_output().into_pwm(&mut timer4);
     ///
     /// d6.set_duty(128);
     /// d6.enable();
@@ -526,9 +526,9 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer5 = Timer5Pwm::new(dp.TC5, Prescaler::Prescale64);
     ///
-    /// let mut d46 = portl.d46.into_output().into_pwm(&mut timer5);
-    /// let mut d45 = portl.d45.into_output().into_pwm(&mut timer5);
-    /// let mut d44 = portl.d44.into_output().into_pwm(&mut timer5);
+    /// let mut d46 = pins.d46.into_output().into_pwm(&mut timer5);
+    /// let mut d45 = pins.d45.into_output().into_pwm(&mut timer5);
+    /// let mut d44 = pins.d44.into_output().into_pwm(&mut timer5);
     ///
     /// d46.set_duty(128);
     /// d46.enable();

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -1,0 +1,582 @@
+use avr_hal_generic::simple_pwm::Prescaler;
+
+use crate::port::*;
+
+#[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p", feature = "atmega328pb"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC0` for PWM (pins `PD5`, `PD6`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+    ///
+    /// let mut d5 = portd.d5.into_output().into_pwm(&mut timer0);
+    /// let mut d6 = portd.d6.into_output().into_pwm(&mut timer0);
+    ///
+    /// d5.set_duty(128);
+    /// d5.enable();
+    /// ```
+    pub struct Timer0Pwm {
+        timer: crate::pac::TC0,
+        init: |tim, prescaler| {
+            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs0().direct(),
+                Prescaler::Prescale8 => w.cs0().prescale_8(),
+                Prescaler::Prescale64 => w.cs0().prescale_64(),
+                Prescaler::Prescale256 => w.cs0().prescale_256(),
+                Prescaler::Prescale1024 => w.cs0().prescale_1024(),
+            });
+        },
+        pins: {
+            PD6: {
+                ocr: ocr0a,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                },
+            },
+
+            PD5: {
+                ocr: ocr0b,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p", feature = "atmega328pb"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC1` for PWM (pins `PB1`, `PB2`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
+    ///
+    /// let mut d9 = portb.d9.into_output().into_pwm(&mut timer1);
+    /// let mut d10 = portb.d10.into_output().into_pwm(&mut timer1);
+    ///
+    /// d9.set_duty(128);
+    /// d9.enable();
+    /// ```
+    pub struct Timer1Pwm {
+        timer: crate::pac::TC1,
+        init: |tim, prescaler| {
+            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
+            tim.tccr1b.modify(|_r, w| {
+                w.wgm1().bits(0b01);
+
+                match prescaler {
+                    Prescaler::Direct => w.cs1().direct(),
+                    Prescaler::Prescale8 => w.cs1().prescale_8(),
+                    Prescaler::Prescale64 => w.cs1().prescale_64(),
+                    Prescaler::Prescale256 => w.cs1().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PB1: {
+                ocr: ocr1a,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                },
+            },
+
+            PB2: {
+                ocr: ocr1b,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p", feature = "atmega328pb"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC2` for PWM (pins `PB3`, `PD3`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer2 = Timer2Pwm::new(dp.TC2, Prescaler::Prescale64);
+    ///
+    /// let mut d11 = portb.d11.into_output().into_pwm(&mut timer2);
+    /// let mut d3 = portd.d3.into_output().into_pwm(&mut timer2);
+    ///
+    /// d11.set_duty(128);
+    /// d11.enable();
+    /// ```
+    pub struct Timer2Pwm {
+        timer: crate::pac::TC2,
+        init: |tim, prescaler| {
+            tim.tccr2a.modify(|_r, w| w.wgm2().pwm_fast());
+            tim.tccr2b.modify(|_r, w| match prescaler {
+                    Prescaler::Direct => w.cs2().direct(),
+                    Prescaler::Prescale8 => w.cs2().prescale_8(),
+                    Prescaler::Prescale64 => w.cs2().prescale_64(),
+                    Prescaler::Prescale256 => w.cs2().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs2().prescale_1024(),
+            });
+        },
+        pins: {
+            PB3: {
+                ocr: ocr2a,
+                into_pwm: |tim| if enable {
+                    tim.tccr2a.modify(|_r, w| w.com2a().match_clear());
+                } else {
+                    tim.tccr2a.modify(|_r, w| w.com2a().disconnected());
+                },
+            },
+
+            PD3: {
+                ocr: ocr2b,
+                into_pwm: |tim| if enable {
+                    tim.tccr2a.modify(|_r, w| w.com2b().match_clear());
+                } else {
+                    tim.tccr2a.modify(|_r, w| w.com2b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(feature = "atmega328pb")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC3` for PWM (pins `PD0`, `PD2`)
+    pub struct Timer3Pwm {
+        timer: crate::pac::TC3,
+        init: |tim, prescaler| {
+            tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
+            tim.tccr3b.modify(|_r, w| {
+                unsafe { w.wgm3().bits(0b01) };
+
+                match prescaler {
+                    Prescaler::Direct => w.cs3().direct(),
+                    Prescaler::Prescale8 => w.cs3().prescale_8(),
+                    Prescaler::Prescale64 => w.cs3().prescale_64(),
+                    Prescaler::Prescale256 => w.cs3().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs3().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PD0: {
+                ocr: ocr3a,
+                into_pwm: |tim| if enable {
+                    tim.tccr3a.modify(|_r, w| w.com3a().match_clear());
+                } else {
+                    tim.tccr3a.modify(|_r, w| w.com3a().disconnected());
+                },
+            },
+
+            PD2: {
+                ocr: ocr3b,
+                into_pwm: |tim| if enable {
+                    tim.tccr3a.modify(|_r, w| w.com3b().match_clear());
+                } else {
+                    tim.tccr3a.modify(|_r, w| w.com3b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(feature = "atmega328pb")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC4` for PWM (pins `PD1`, `PD2`)
+    pub struct Timer4Pwm {
+        timer: crate::pac::TC4,
+        init: |tim, prescaler| {
+            tim.tccr4a.modify(|_r, w| w.wgm4().bits(0b01));
+            tim.tccr4b.modify(|_r, w| {
+                unsafe { w.wgm4().bits(0b01) };
+
+                match prescaler {
+                    Prescaler::Direct => w.cs4().direct(),
+                    Prescaler::Prescale8 => w.cs4().prescale_8(),
+                    Prescaler::Prescale64 => w.cs4().prescale_64(),
+                    Prescaler::Prescale256 => w.cs4().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs4().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PD1: {
+                ocr: ocr4a,
+                into_pwm: |tim| if enable {
+                    tim.tccr4a.modify(|_r, w| w.com4a().match_clear());
+                } else {
+                    tim.tccr4a.modify(|_r, w| w.com4a().disconnected());
+                },
+            },
+
+            PD2: {
+                ocr: ocr4b,
+                into_pwm: |tim| if enable {
+                    tim.tccr4a.modify(|_r, w| w.com4b().match_clear());
+                } else {
+                    tim.tccr4a.modify(|_r, w| w.com4b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+
+#[cfg(feature = "atmega2560")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC0` for PWM (pins `PB7`, `PG5`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+    ///
+    /// let mut d13 = portb.d13.into_output().into_pwm(&mut timer0);
+    /// let mut d4 = portg.d4.into_output().into_pwm(&mut timer0);
+    ///
+    /// d13.set_duty(128);
+    /// d13.enable();
+    /// ```
+    pub struct Timer0Pwm {
+        timer: crate::pac::TC0,
+        init: |tim, prescaler| {
+            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs0().direct(),
+                Prescaler::Prescale8 => w.cs0().prescale_8(),
+                Prescaler::Prescale64 => w.cs0().prescale_64(),
+                Prescaler::Prescale256 => w.cs0().prescale_256(),
+                Prescaler::Prescale1024 => w.cs0().prescale_1024(),
+            });
+        },
+        pins: {
+            PB7: {
+                ocr: ocr0a,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                },
+            },
+
+            PG5: {
+                ocr: ocr0b,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(feature = "atmega2560")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC1` for PWM (pins `PB5`, `PB6`, `PB7`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
+    ///
+    /// let mut d11 = portb.d11.into_output().into_pwm(&mut timer1);
+    /// let mut d12 = portb.d12.into_output().into_pwm(&mut timer1);
+    /// let mut d13 = portb.d13.into_output().into_pwm(&mut timer1);
+    ///
+    /// d11.set_duty(128);
+    /// d11.enable();
+    /// ```
+    pub struct Timer1Pwm {
+        timer: crate::pac::TC1,
+        init: |tim, prescaler| {
+            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
+            tim.tccr1b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs1().direct(),
+                Prescaler::Prescale8 => w.cs1().prescale_8(),
+                Prescaler::Prescale64 => w.cs1().prescale_64(),
+                Prescaler::Prescale256 => w.cs1().prescale_256(),
+                Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+            });
+        },
+        pins: {
+            PB5: {
+                ocr: ocr1a,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                },
+            },
+
+            PB6: {
+                ocr: ocr1b,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                },
+            },
+
+            PB7: {
+                ocr: ocr1c,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1c().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1c().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(feature = "atmega2560")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC2` for PWM (pins `PB4`, `PH6`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer2 = Timer2Pwm::new(dp.TC2, Prescaler::Prescale64);
+    ///
+    /// let mut d10 = portb.into_output().into_pwm(&mut timer2);
+    /// let mut d9 = porth.into_output().into_pwm(&mut timer2);
+    ///
+    /// d10.set_duty(128);
+    /// d10.enable();
+    /// ```
+
+    pub struct Timer2Pwm {
+        timer: crate::pac::TC2,
+        init: |tim, prescaler| {
+            tim.tccr2a.modify(|_r, w| w.wgm2().bits(0b01));
+            tim.tccr2b.modify(|_r, w| {
+                w.wgm22().clear_bit();
+
+                match prescaler {
+                    Prescaler::Direct => w.cs2().direct(),
+                    Prescaler::Prescale8 => w.cs2().prescale_8(),
+                    Prescaler::Prescale64 => w.cs2().prescale_64(),
+                    Prescaler::Prescale256 => w.cs2().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs2().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PB4: {
+                ocr: ocr2a,
+                into_pwm: |tim| if enable {
+                    tim.tccr2a.modify(|_r, w| w.com2a().match_clear());
+                } else {
+                    tim.tccr2a.modify(|_r, w| w.com2a().disconnected());
+                },
+            },
+
+            PH6: {
+                ocr: ocr2b,
+                into_pwm: |tim| if enable {
+                    tim.tccr2a.modify(|_r, w| w.com2b().match_clear());
+                } else {
+                    tim.tccr2a.modify(|_r, w| w.com2b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(feature = "atmega2560")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC3` for PWM (pins `PE3`, `PE4`, `PE5`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer3 = Timer3Pwm::new(dp.TC3, Prescaler::Prescale64);
+    ///
+    /// let mut d5 = porte.d5.into_output().into_pwm(&mut timer3);
+    /// let mut d2 = porte.d2.into_output().into_pwm(&mut timer3);
+    /// let mut d3 = porte.d3.into_output().into_pwm(&mut timer3);
+    ///
+    /// d5.set_duty(128);
+    /// d5.enable();
+    /// ```
+    pub struct Timer3Pwm {
+        timer: crate::pac::TC3,
+        init: |tim, prescaler| {
+            tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
+            tim.tccr3b.modify(|_r, w| {
+                w.wgm3().bits(0b01);
+
+                match prescaler {
+                    Prescaler::Direct => w.cs3().direct(),
+                    Prescaler::Prescale8 => w.cs3().prescale_8(),
+                    Prescaler::Prescale64 => w.cs3().prescale_64(),
+                    Prescaler::Prescale256 => w.cs3().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs3().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PE3: {
+                ocr: ocr3a,
+                into_pwm: |tim| if enable {
+                    tim.tccr3a.modify(|_r, w| w.com3a().match_clear());
+                } else {
+                    tim.tccr3a.modify(|_r, w| w.com3a().disconnected());
+                },
+            },
+
+            PE4: {
+                ocr: ocr3b,
+                into_pwm: |tim| if enable {
+                    tim.tccr3a.modify(|_r, w| w.com3b().match_clear());
+                } else {
+                    tim.tccr3a.modify(|_r, w| w.com3b().disconnected());
+                },
+            },
+
+            PE5: {
+                ocr: ocr3c,
+                into_pwm: |tim| if enable {
+                    tim.tccr3a.modify(|_r, w| w.com3c().match_clear());
+                } else {
+                    tim.tccr3a.modify(|_r, w| w.com3c().disconnected());
+                },
+            },
+
+        },
+    }
+}
+
+#[cfg(feature = "atmega2560")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC4` for PWM (pins `PH3`, `PH4`, `PH5`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer4 = Timer4Pwm::new(dp.TC4, Prescaler::Prescale64);
+    ///
+    /// let mut d6 = porth.d6.into_output().into_pwm(&mut timer4);
+    /// let mut d7 = porth.d7.into_output().into_pwm(&mut timer4);
+    /// let mut d8 = porth.d8.into_output().into_pwm(&mut timer4);
+    ///
+    /// d6.set_duty(128);
+    /// d6.enable();
+    /// ```
+    pub struct Timer4Pwm {
+        timer: crate::pac::TC4,
+        init: |tim, prescaler| {
+            tim.tccr4a.modify(|_r, w| w.wgm4().bits(0b01));
+            tim.tccr4b.modify(|_r, w| {
+                w.wgm4().bits(0b01);
+
+                match prescaler {
+                    Prescaler::Direct => w.cs4().direct(),
+                    Prescaler::Prescale8 => w.cs4().prescale_8(),
+                    Prescaler::Prescale64 => w.cs4().prescale_64(),
+                    Prescaler::Prescale256 => w.cs4().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs4().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PH3: {
+                ocr: ocr4a,
+                into_pwm: |tim| if enable {
+                    tim.tccr4a.modify(|_r, w| w.com4a().match_clear());
+                } else {
+                    tim.tccr4a.modify(|_r, w| w.com4a().disconnected());
+                },
+            },
+
+            PH4: {
+                ocr: ocr4b,
+                into_pwm: |tim| if enable {
+                    tim.tccr4a.modify(|_r, w| w.com4b().match_clear());
+                } else {
+                    tim.tccr4a.modify(|_r, w| w.com4b().disconnected());
+                },
+            },
+
+            PH5: {
+                ocr: ocr4c,
+                into_pwm: |tim| if enable {
+                    tim.tccr4a.modify(|_r, w| w.com4c().match_clear());
+                } else {
+                    tim.tccr4a.modify(|_r, w| w.com4c().disconnected());
+                },
+            },
+
+        },
+    }
+}
+
+#[cfg(feature = "atmega2560")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC5` for PWM (pins `PL3`, `PL4`, `PL5`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer5 = Timer5Pwm::new(dp.TC5, Prescaler::Prescale64);
+    ///
+    /// let mut d46 = portl.d46.into_output().into_pwm(&mut timer5);
+    /// let mut d45 = portl.d45.into_output().into_pwm(&mut timer5);
+    /// let mut d44 = portl.d44.into_output().into_pwm(&mut timer5);
+    ///
+    /// d46.set_duty(128);
+    /// d46.enable();
+    /// ```
+    pub struct Timer5Pwm {
+        timer: crate::pac::TC5,
+        init: |tim, prescaler| {
+            tim.tccr5a.modify(|_r, w| w.wgm5().bits(0b01));
+            tim.tccr5b.modify(|_r, w| {
+                w.wgm5().bits(0b01);
+
+                match prescaler {
+                    Prescaler::Direct => w.cs5().direct(),
+                    Prescaler::Prescale8 => w.cs5().prescale_8(),
+                    Prescaler::Prescale64 => w.cs5().prescale_64(),
+                    Prescaler::Prescale256 => w.cs5().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs5().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PL3: {
+                ocr: ocr5a,
+                into_pwm: |tim| if enable {
+                    tim.tccr5a.modify(|_r, w| w.com5a().match_clear());
+                } else {
+                    tim.tccr5a.modify(|_r, w| w.com5a().disconnected());
+                },
+            },
+
+            PL4: {
+                ocr: ocr5b,
+                into_pwm: |tim| if enable {
+                    tim.tccr5a.modify(|_r, w| w.com5b().match_clear());
+                } else {
+                    tim.tccr5a.modify(|_r, w| w.com5b().disconnected());
+                },
+            },
+
+            PL5: {
+                ocr: ocr5c,
+                into_pwm: |tim| if enable {
+                    tim.tccr5a.modify(|_r, w| w.com5c().match_clear());
+                } else {
+                    tim.tccr5a.modify(|_r, w| w.com5c().disconnected());
+                },
+            },
+
+        },
+    }
+}

--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -54,6 +54,9 @@ pub mod port;
 #[cfg(feature = "device-selected")]
 pub use port::Pins;
 
+#[cfg(feature = "device-selected")]
+pub mod simple_pwm;
+
 pub struct Attiny;
 
 #[cfg(feature = "attiny84")]

--- a/mcu/attiny-hal/src/simple_pwm.rs
+++ b/mcu/attiny-hal/src/simple_pwm.rs
@@ -2,6 +2,82 @@ use avr_hal_generic::simple_pwm::Prescaler;
 
 use crate::port::*;
 
+#[cfg(feature = "attiny84")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC0` for PWM (pins `PB2`, `PA7`)
+    pub struct Timer0Pwm {
+        timer: crate::pac::TC0,
+        init: |tim, prescaler| {
+            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs0().direct(),
+                Prescaler::Prescale8 => w.cs0().prescale_8(),
+                Prescaler::Prescale64 => w.cs0().prescale_64(),
+                Prescaler::Prescale256 => w.cs0().prescale_256(),
+                Prescaler::Prescale1024 => w.cs0().prescale_1024(),
+            });
+        },
+        pins: {
+            PB2: {
+                ocr: ocr0a,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                },
+            },
+
+            PA7: {
+                ocr: ocr0b,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(feature = "attiny84")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC1` for PWM (pins `PA6`, 'PA5')
+    pub struct Timer1Pwm {
+        timer: crate::pac::TC1,
+        init: |tim, prescaler| {
+            tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
+            tim.tccr1b.modify(|_, w| w.wgm1().bits(0b01));
+
+            tim.tccr1b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs1().direct(),
+                Prescaler::Prescale8 => w.cs1().prescale_8(),
+                Prescaler::Prescale64 => w.cs1().prescale_64(),
+                Prescaler::Prescale256 => w.cs1().prescale_256(),
+                Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+            });
+        },
+        pins: {
+            PA6: {
+                ocr: ocr1a,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_, w| w.com1a().bits(0b10));
+                } else {
+                    tim.tccr1a.modify(|_, w| w.com1a().disconnected());
+                },
+            },
+
+            PA5: {
+                ocr: ocr1b,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_, w| w.com1b().bits(0b10));
+                } else {
+                    tim.tccr1a.modify(|_, w| w.com1b().disconnected());
+                },
+            },
+        },
+    }
+}
+
 #[cfg(feature = "attiny85")]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC0` for PWM (pins `PB0`, `PB1`)

--- a/mcu/attiny-hal/src/simple_pwm.rs
+++ b/mcu/attiny-hal/src/simple_pwm.rs
@@ -1,0 +1,90 @@
+use avr_hal_generic::simple_pwm::Prescaler;
+
+use crate::port::*;
+
+#[cfg(feature = "attiny85")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC0` for PWM (pins `PB0`, `PB1`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+    ///
+    /// let mut d0 = portd.d0.into_output().into_pwm(&mut timer0);
+    /// let mut d1 = portd.d1.into_output().into_pwm(&mut timer0);
+    ///
+    /// d0.set_duty(128);
+    /// d0.enable();
+    /// ```
+    pub struct Timer0Pwm {
+        timer: crate::pac::TC0,
+        init: |tim, prescaler| {
+            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs0().direct(),
+                Prescaler::Prescale8 => w.cs0().prescale_8(),
+                Prescaler::Prescale64 => w.cs0().prescale_64(),
+                Prescaler::Prescale256 => w.cs0().prescale_256(),
+                Prescaler::Prescale1024 => w.cs0().prescale_1024(),
+            });
+        },
+        pins: {
+            PB0: {
+                ocr: ocr0a,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                },
+            },
+
+            PB1: {
+                ocr: ocr0b,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(feature = "attiny85")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC1` for PWM (pins `PB4`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
+    ///
+    /// let mut d4 = portd.d4.into_output().into_pwm(&mut timer1);
+    ///
+    /// d4.set_duty(128);
+    /// d4.enable();
+    /// ```
+    pub struct Timer1Pwm {
+        timer: crate::pac::TC1,
+        init: |tim, prescaler| {
+            tim.gtccr.modify(|_, w| w.pwm1b().bit(true));
+
+            tim.tccr1.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs1().direct(),
+                Prescaler::Prescale8 => w.cs1().prescale_8(),
+                Prescaler::Prescale64 => w.cs1().prescale_64(),
+                Prescaler::Prescale256 => w.cs1().prescale_256(),
+                Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+            });
+        },
+        pins: {
+            PB4: {
+                ocr: ocr1b,
+                into_pwm: |tim| if enable {
+                    tim.gtccr.modify(|_, w| w.com1b().bits(0b10));
+                } else {
+                    tim.gtccr.modify(|_, w| w.com1b().disconnected());
+                },
+            },
+        },
+    }
+}

--- a/mcu/attiny-hal/src/simple_pwm.rs
+++ b/mcu/attiny-hal/src/simple_pwm.rs
@@ -88,3 +88,53 @@ avr_hal_generic::impl_simple_pwm! {
         },
     }
 }
+
+#[cfg(feature = "attiny88")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC1` for PWM (pins `PB1`, 'PB2')
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
+    ///
+    /// let mut d9 = pins.d9.into_output().into_pwm(&mut timer1);
+    /// let mut d10 = pins.d10.into_output().into_pwm(&mut timer1);
+    ///
+    /// d9.set_duty(128);
+    /// d9.enable();
+    /// ```
+    pub struct Timer1Pwm {
+        timer: crate::pac::TC1,
+        init: |tim, prescaler| {
+            tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
+            tim.tccr1b.modify(|_, w| w.wgm1().bits(0b01));
+
+            tim.tccr1b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs1().direct(),
+                Prescaler::Prescale8 => w.cs1().prescale_8(),
+                Prescaler::Prescale64 => w.cs1().prescale_64(),
+                Prescaler::Prescale256 => w.cs1().prescale_256(),
+                Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+            });
+        },
+        pins: {
+            PB1: {
+                ocr: ocr1a,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_, w| w.com1a().bits(0b10));
+                } else {
+                    tim.tccr1a.modify(|_, w| w.com1a().disconnected());
+                },
+            },
+
+            PB2: {
+                ocr: ocr1b,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_, w| w.com1b().bits(0b10));
+                } else {
+                    tim.tccr1a.modify(|_, w| w.com1b().disconnected());
+                },
+            },
+        },
+    }
+}

--- a/mcu/attiny-hal/src/simple_pwm.rs
+++ b/mcu/attiny-hal/src/simple_pwm.rs
@@ -10,8 +10,8 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
     ///
-    /// let mut d0 = portd.d0.into_output().into_pwm(&mut timer0);
-    /// let mut d1 = portd.d1.into_output().into_pwm(&mut timer0);
+    /// let mut d0 = pins.d0.into_output().into_pwm(&mut timer0);
+    /// let mut d1 = pins.d1.into_output().into_pwm(&mut timer0);
     ///
     /// d0.set_duty(128);
     /// d0.enable();
@@ -58,7 +58,7 @@ avr_hal_generic::impl_simple_pwm! {
     /// ```
     /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
     ///
-    /// let mut d4 = portd.d4.into_output().into_pwm(&mut timer1);
+    /// let mut d4 = pins.d4.into_output().into_pwm(&mut timer1);
     ///
     /// d4.set_duty(128);
     /// d4.enable();


### PR DESCRIPTION
This is a reimplementation of the "simple" fastpwm functionality from the old-branch.

I've only been able to test this on a Arduino Uno, a Leonardo and a Trinket, but I've tried to add implementations for some of the other MCUs (atmega48p, atmega168, atmega328pb, atmega2650) as well, based on the code in the old-branch.

I also added implementations for atmega32u8, attiny85, attiny88 and atmega1280 as well, which wasn't available in the old branch IIRC.

Any feedback would be greatly appreciated.

Closes #251.