### PR TITLE
Use adafruit's values for attiny85 in avrdude.conf

### DIFF
--- a/ravedude/src/avrdude/avrdude.conf
+++ b/ravedude/src/avrdude/avrdude.conf
@@ -9745,7 +9745,7 @@ part
      avr910_devcode   = 0x20;
      signature        = 0x1e 0x93 0x0b;
      reset            = io;
-     chip_erase_delay = 4500;
+     chip_erase_delay = 900000;
 
      pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
@@ -9780,7 +9780,7 @@ part
     hvleavestabdelay    = 100;
     resetdelay          = 25;
     chiperasepolltimeout = 40;
-    chiperasetime       = 0;
+    chiperasetime       = 900000;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
 
@@ -9811,7 +9811,7 @@ part
 			  "  x   x   x   x      x   x   x   x";
 
 	mode		= 0x41;
-	delay		= 6;
+	delay		= 12;
 	blocksize	= 4;
 	readsize	= 256;
        ;
@@ -9820,8 +9820,8 @@ part
          size            = 8192;
          page_size       = 64;
          num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
+         min_write_delay = 30000;
+         max_write_delay = 30000;
          readback_p1     = 0xff;
          readback_p2     = 0xff;
          read_lo         = "  0   0   1   0    0   0   0   0",
@@ -9864,8 +9864,6 @@ part
          size            = 1;
          write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  1 1 i i  i i i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
        ;
@@ -9904,7 +9902,7 @@ part
      ;
 
      memory "calibration"
-         size            = 1;
+         size            = 2;
          read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  a0   o o o o  o o o o";
      ;


### PR DESCRIPTION
The changes in this PR makes sure that ravedude uses a avrdude.conf that works with the Adafruit Trinket.

Closes #273 .