### PR TITLE
Ravedude: Allow skipping the reset question for automated resets

### DIFF
--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -92,7 +92,7 @@ fn ravedude() -> anyhow::Result<()> {
 
     if let Some(wait_time) = args.reset_delay{
         if wait_time > 0 {
-            task_message!("Waiting {} seconds before proceeding", "{}", wait_time);
+            println!("Waiting {} ms before proceeding", wait_time);
             let wait_time = Duration::from_millis(wait_time);
             thread::sleep(wait_time);
         }else{


### PR DESCRIPTION
This commit allows us to bypass the "reset" instructions by providing a additional command-line arguments to ravedude.

This adds one additional option:
<pre>
    -d, --reset-delay <reset-delay>    
            This assumes the board is already resetting. Instead of giving the reset instructions and waiting for user
            confirmation, we wait the amount in milliseconds before proceeding. Set this value to 0 to skip the board
            reset question instantly
</pre>


Why this change: I needed this myself as I had already implemented a self-reset function through the USB interface which I can call before flashing.

Thank you so much for all your hard work for Rust on AVR. I am loving it!