### PR TITLE
Update toolchain, get rid of the std-features hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-05-10
+          toolchain: nightly-2022-06-13
           override: true
           components: rust-src
       - name: Install avr-gcc, binutils, and libc

--- a/examples/arduino-diecimila/.cargo/config.toml
+++ b/examples/arduino-diecimila/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude diecimila"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/examples/arduino-leonardo/.cargo/config.toml
+++ b/examples/arduino-leonardo/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude leonardo"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/examples/arduino-mega2560/.cargo/config.toml
+++ b/examples/arduino-mega2560/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude -cb 57600 mega2560"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/examples/arduino-nano/.cargo/config.toml
+++ b/examples/arduino-nano/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/examples/arduino-uno/.cargo/config.toml
+++ b/examples/arduino-uno/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude uno -cb 57600"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/examples/nano168/.cargo/config.toml
+++ b/examples/nano168/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude nano168 -cb 57600"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/examples/sparkfun-promicro/.cargo/config.toml
+++ b/examples/sparkfun-promicro/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude promicro"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/examples/trinket-pro/.cargo/config.toml
+++ b/examples/trinket-pro/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude trinket-pro"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/examples/trinket/.cargo/config.toml
+++ b/examples/trinket/.cargo/config.toml
@@ -6,4 +6,3 @@ runner = "ravedude trinket"
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-05-10"
+channel = "nightly-2022-06-13"
 components = [ "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
The `compiler-builtins-mangled-names` thingie[^1] is no longer needed, since `compiler_builtins` has been improved to avoid pulling the problematic functions:

- https://github.com/rust-lang/compiler-builtins/pull/462
- https://github.com/rust-lang/compiler-builtins/pull/466
- https://github.com/rust-lang/rust/pull/97435

[^1]: https://github.com/rust-lang/rust/issues/82242

Suggested-by: @Patryk27
Link: https://github.com/Rahix/avr-hal-template/pull/8