### PR TITLE
Add Attiny84 to attiny-hal

### DIFF
--- a/mcu/attiny-hal/Cargo.toml
+++ b/mcu/attiny-hal/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 rt = ["avr-device/rt"]
 device-selected = []
+attiny84 = ["avr-device/attiny84", "device-selected"]
 attiny85 = ["avr-device/attiny85", "device-selected"]
 attiny88 = ["avr-device/attiny88", "device-selected"]
 

--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -28,6 +28,9 @@ compile_error!(
     "
 );
 
+#[cfg(feature = "attiny84")]
+pub use avr_device::attiny84 as pac;
+
 /// Reexport of `attiny85` from `avr-device`
 #[cfg(feature = "attiny85")]
 pub use avr_device::attiny85 as pac;
@@ -53,6 +56,13 @@ pub use port::Pins;
 
 pub struct Attiny;
 
+#[cfg(feature = "attiny84")]
+#[macro_export]
+macro_rules! pins {
+    ($p:expr) => {
+        $crate::Pins::new($p.PORTA, $p.PORTB)
+    };
+}
 #[cfg(feature = "attiny85")]
 #[macro_export]
 macro_rules! pins {

--- a/mcu/attiny-hal/src/port.rs
+++ b/mcu/attiny-hal/src/port.rs
@@ -1,3 +1,26 @@
+#[cfg(feature = "attiny84")]
+avr_hal_generic::impl_port_traditional! {
+    enum Ports {
+        PORTA: (crate::pac::PORTA, porta, pina, ddra),
+        PORTB: (crate::pac::PORTB, portb, pinb, ddrb),
+    }
+
+    pub struct Pins {
+        pa0: PA0 = (crate::pac::PORTA, PORTA, 0, porta, pina, ddra),
+        pa1: PA1 = (crate::pac::PORTA, PORTA, 1, porta, pina, ddra),
+        pa2: PA2 = (crate::pac::PORTA, PORTA, 2, porta, pina, ddra),
+        pa3: PA3 = (crate::pac::PORTA, PORTA, 3, porta, pina, ddra),
+        pa4: PA4 = (crate::pac::PORTA, PORTA, 4, porta, pina, ddra),
+        pa5: PA5 = (crate::pac::PORTA, PORTA, 5, porta, pina, ddra),
+        pa6: PA6 = (crate::pac::PORTA, PORTA, 6, porta, pina, ddra),
+        pa7: PA7 = (crate::pac::PORTA, PORTA, 7, porta, pina, ddra),
+        pb0: PB0 = (crate::pac::PORTB, PORTB, 0, portb, pinb, ddrb),
+        pb1: PB1 = (crate::pac::PORTB, PORTB, 1, portb, pinb, ddrb),
+        pb2: PB2 = (crate::pac::PORTB, PORTB, 2, portb, pinb, ddrb),
+        pb3: PB3 = (crate::pac::PORTB, PORTB, 3, portb, pinb, ddrb),
+    }
+}
+
 #[cfg(feature = "attiny85")]
 avr_hal_generic::impl_port_traditional! {
     enum Ports {


### PR DESCRIPTION
This adds feature _attiny84_ to attiny-hal. The `pins` macro and necessary types are implemented like the ones for attiny85/88.