### PR TITLE
generic: port: Fix pin toggle implementation

### DIFF
--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -548,8 +548,8 @@ macro_rules! impl_port_traditional {
             #[inline]
             unsafe fn out_toggle(&mut self) {
                 match self.port {
-                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_pin_reg.modify(|r, w| {
-                        w.bits(r.bits() | self.mask)
+                    $(DynamicPort::$PortName => (*<$Port>::ptr()).$port_pin_reg.write(|w| {
+                        w.bits(self.mask)
                     }),)+
                 }
             }
@@ -623,9 +623,7 @@ macro_rules! impl_port_traditional {
 
                 #[inline]
                 unsafe fn out_toggle(&mut self) {
-                    (*<$PinPort>::ptr()).$pin_pin_reg.modify(|r, w| {
-                        w.bits(r.bits() | (1 << $pin_num))
-                    })
+                    (*<$PinPort>::ptr()).$pin_pin_reg.write(|w| w.bits(1 << $pin_num))
                 }
 
                 #[inline]


### PR DESCRIPTION
Only the bit for the pin to be toggled should be set in the PIN register.  The RMW-operation was incorrect here as it would also toggle unrelated pins which happen to read HIGH at that moment.

This went unnoticed because the code for the non-dynamic pin-variant was optimized down to an `sbi` instruction - thus "accidentally" behaving correctly.

I do not think it is a good idea to rely on this behavior though.  If the non-dynamic code should be optimized to an `sbi` again at some point in the future, I would prefer an implementation using inline assembly.

@blueberry-fan, I do not have hardware to test this in the next days, maybe you can quickly confirm that everything works with these changes?

Closes: #284