### PR TITLE
Feather 32u4 RFM support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "examples/sparkfun-promicro",
     "examples/trinket-pro",
     "examples/trinket",
+    "examples/feather-32u4-rfm"
 ]
 exclude = [
     # The RAVEDUDE! Yeah!

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -20,6 +20,7 @@ trinket-pro = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 trinket = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
 nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", "board-selected"]
+feather-32u4-rfm = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 
 [dependencies]
 cfg-if = "1"

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -25,6 +25,9 @@ pub(crate) mod default {
         feature = "nano168",
     ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz16;
-    #[cfg(feature = "trinket")]
+    #[cfg(any(
+        feature = "trinket",
+        feature = "feather-32u4-rfm"
+    ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz8;
 }

--- a/arduino-hal/src/port/feather_32u4_rfm.rs
+++ b/arduino-hal/src/port/feather_32u4_rfm.rs
@@ -1,0 +1,152 @@
+pub use atmega_hal::port::mode;
+pub use atmega_hal::port::Pin;
+
+avr_hal_generic::renamed_pins! {
+    type Pin = Pin;
+
+    /// Pins of the **Adafruit Feather 32u4 RFM69 and RFM9* **.
+    ///
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][pins] macro.
+    /// [Reference](https://github.com/adafruit/Adafruit-Feather-32u4-Basic-Proto-PCB/blob/master/Adafruit%20Feather%2032u4%20Basic%20Proto%20Pinout.pdf)
+    pub struct Pins from atmega_hal::Pins {
+        /// `A0`
+        ///
+        /// * ADC7 (ADC input channel 7)
+        /// * TDI
+        pub a0: atmega_hal::port::PF7 = pf7,
+        /// `A1`
+        ///
+        /// * ADC6 (ADC input channel 6)
+        /// * TDO
+        pub a1: atmega_hal::port::PF6 = pf6,
+        /// `A2`
+        ///
+        /// * ADC5 (ADC input channel 5)
+        /// * TMS
+        pub a2: atmega_hal::port::PF5 = pf5,
+        /// `A3`
+        ///
+        /// * ADC4 (ADC input channel 4)
+        /// * TCK
+        pub a3: atmega_hal::port::PF4 = pf4,
+        /// `A4`
+        ///
+        /// * ADC1 (ADC input channel 1)
+        pub a4: atmega_hal::port::PF1 = pf1,
+        /// `A5`
+        ///
+        /// * ADC0 (ADC input channel 0)
+        pub a5: atmega_hal::port::PF0 = pf0,
+
+        /// `SCK`
+        ///  (Used by radio module too)
+        ///  * PCINT1
+        pub sck: atmega_hal::port::PB1 = pb1,
+
+        /// `MOSI`
+        ///  (Used by radio module too)
+        /// * PCINT2
+        pub mosi: atmega_hal::port::PB2 = pb2,
+
+        /// `MISO`
+        ///  (Used by radio module too)
+        /// * PCINT3
+        pub miso: atmega_hal::port::PB3 = pb3,
+
+        /// `D0` / `RX`
+        ///
+        /// * RXD (USART input pin)
+        /// * INT2
+        pub d0: atmega_hal::port::PD2 = pd2,
+        /// `D1` / `TX`
+        ///
+        /// * TXD (USART output pin)
+        /// * INT3
+        pub d1: atmega_hal::port::PD3 = pd3,
+
+        /// `D2`
+        ///
+        /// * INT1 (external interrupt 1 input)
+        /// * SDA
+        pub d2: atmega_hal::port::PD1 = pd1,
+
+        /// `D3`
+        ///
+        /// * INT0 (external interrupt 1 input)
+        /// * OC0B
+        /// * SCL
+        pub d3: atmega_hal::port::PD0 = pd0,
+
+        /// `D5`
+        ///
+        /// * OC3A
+        /// * OC4A
+        pub d5: atmega_hal::port::PC6 = pc6,
+
+        /// `D6`
+        ///
+        /// * OC4D
+        /// * ADC10
+        pub d6: atmega_hal::port::PD7 = pd7,
+
+        /// `D9`
+        ///
+        /// * OC1A
+        /// * !OC4B
+        /// * PCINT5
+        /// * ADC12
+        pub d9: atmega_hal::port::PB5 = pb5,
+
+        /// `D10`
+        ///
+        /// * OC1B
+        /// * OC4B
+        /// * PCINT6
+        /// * ADC13
+        pub d10: atmega_hal::port::PB6 = pb6,
+
+        /// `D11`
+        ///
+        /// * OC0A
+        /// * OC1C
+        /// * PCINT7
+        pub d11: atmega_hal::port::PB7 = pb7,
+
+        /// `D12`
+        ///
+        /// * !OC4D
+        /// * ADC9
+        pub d12: atmega_hal::port::PD6 = pd6,
+
+        /// `D13`
+        ///
+        /// * OC4A
+        pub d13: atmega_hal::port::PC7 = pc7,
+    
+        /// `D8`
+        /// For radio module
+        /// 
+        /// * PCINT4
+        /// * CS
+        /// * ADC11
+        pub d8: atmega_hal::port::PB4 = pb4,
+
+        /// `D7`
+        /// For radio module
+        /// 
+        /// * INT6
+        /// * IRQ
+        /// * AIN0
+        pub d7: atmega_hal::port::PE6 = pe6,
+
+        /// `D4`
+        /// For radio module
+        /// 
+        /// * ICP1
+        /// * RST
+        /// * ADC8
+        pub d4: atmega_hal::port::PD4 = pd4,
+
+
+    }
+}

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -43,3 +43,7 @@ pub use trinket_pro::*;
 mod trinket;
 #[cfg(feature = "trinket")]
 pub use trinket::*;
+#[cfg(feature = "feather-32u4-rfm")]
+mod feather_32u4_rfm;
+#[cfg(feature = "feather-32u4-rfm")]
+pub use feather_32u4_rfm::*;

--- a/examples/feather-32u4-rfm/.cargo/config.toml
+++ b/examples/feather-32u4-rfm/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "../../avr-specs/avr-atmega32u4.json"
+
+[unstable]
+build-std = ["core"]

--- a/examples/feather-32u4-rfm/Cargo.toml
+++ b/examples/feather-32u4-rfm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "feather-32u4-rfm-examples"
+description = "Examples for the Adafruit Feather 32u4 RFM boards"
+version = "0.0.0"
+authors = ["Calvin Laurenson <calvin@laurenson.dev>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["feather-32u4-rfm"]

--- a/examples/feather-32u4-rfm/README.md
+++ b/examples/feather-32u4-rfm/README.md
@@ -1,0 +1,8 @@
+# Flashing on Linux
+
+Press the reset button on the Feather and then run the commands.
+```sh
+$ cargo build --bin feather-blink
+$ avrdude -v -p m32u4 -cavr109 -P /dev/ttyACM0 -D -Uflash:w:../../target avr-atmega32u4/debug/feather-blink.elf:e
+```
+You might need to use a different tty port (e.g. ttyACM1) or press the reset button multiple times to get it to download.

--- a/examples/feather-32u4-rfm/src/bin/feather-blink.rs
+++ b/examples/feather-32u4-rfm/src/bin/feather-blink.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    // Digital pin 13 is also connected to an onboard LED
+    let mut led = pins.d13.into_output();
+    led.set_high();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(800);
+    }
+}


### PR DESCRIPTION
Based off of #224. It should work with the RFM69 and RFM9x variants. I successfully got blinky to run on my RFM69 variant. I can't figure out how to get serial logging to work so someone else might want to give that a shot. Next I want to add ravedude support but since that requires serial logging support I might just work on adding more examples first.