### PR TITLE
atmega-hal: Add support for ATmega1284P

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
             spec: atmega48p
             crate: atmega-hal
           - type: mcu
+            name: atmega1284p
+            spec: atmega1284p
+            crate: atmega-hal
+          - type: mcu
             name: attiny85
             spec: attiny85
             crate: attiny-hal

--- a/avr-specs/avr-atmega1284p.json
+++ b/avr-specs/avr-atmega1284p.json
@@ -1,0 +1,25 @@
+{
+  "arch": "avr",
+  "atomic-cas": false,
+  "cpu": "atmega1284p",
+  "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "eh-frame-header": false,
+  "exe-suffix": ".elf",
+  "executables": true,
+  "late-link-args": {
+    "gcc": [
+      "-lgcc"
+    ]
+  },
+  "linker": "avr-gcc",
+  "llvm-target": "avr-unknown-unknown",
+  "max-atomic-width": 8,
+  "no-default-libraries": false,
+  "pre-link-args": {
+    "gcc": [
+      "-mmcu=atmega1284p"
+    ]
+  },
+  "target-c-int-width": "16",
+  "target-pointer-width": "16"
+}

--- a/avr-specs/sync-from-upstream.py
+++ b/avr-specs/sync-from-upstream.py
@@ -22,6 +22,9 @@ SPECS = {
     "atmega2560": {
         "cpu": "atmega2560",
     },
+    "atmega1284p": {
+        "cpu": "atmega1284p",
+    },
     "attiny85": {
         "cpu": "attiny85",
     },

--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -15,6 +15,7 @@ atmega328pb = ["avr-device/atmega328pb", "device-selected"]
 atmega32u4 = ["avr-device/atmega32u4", "device-selected"]
 atmega2560 = ["avr-device/atmega2560", "device-selected"]
 atmega1280 = ["avr-device/atmega1280", "device-selected"]
+atmega1284p = ["avr-device/atmega1284p", "device-selected"]
 
 # Allow certain downstream crates to overwrite the device selection error by themselves.
 disable-device-selection-error = []

--- a/mcu/atmega-hal/src/adc.rs
+++ b/mcu/atmega-hal/src/adc.rs
@@ -225,9 +225,7 @@ avr_hal_generic::impl_adc! {
     },
 }
 
-#[cfg(any(
-feature = "atmega1284p",
-))]
+#[cfg(any(feature = "atmega1284p"))]
 avr_hal_generic::impl_adc! {
     hal: crate::Atmega,
     peripheral: crate::pac::ADC,

--- a/mcu/atmega-hal/src/adc.rs
+++ b/mcu/atmega-hal/src/adc.rs
@@ -76,6 +76,7 @@ pub mod channel {
             feature = "atmega328p",
             feature = "atmega328pb",
             feature = "atmega48p",
+            feature = "atmega1284p",
         ),
         feature = "enable-extra-adc",
     ))]
@@ -85,7 +86,8 @@ pub mod channel {
             feature = "atmega168",
             feature = "atmega328p",
             feature = "atmega328pb",
-            feature = "atmega48p"
+            feature = "atmega48p",
+            feature = "atmega1284p",
         ),
         feature = "enable-extra-adc",
     ))]
@@ -98,6 +100,7 @@ pub mod channel {
         feature = "atmega328pb",
         feature = "atmega32u4",
         feature = "atmega48p",
+        feature = "atmega1284p",
     ))]
     pub struct Vbg;
     #[cfg(any(
@@ -108,6 +111,7 @@ pub mod channel {
         feature = "atmega328pb",
         feature = "atmega32u4",
         feature = "atmega48p",
+        feature = "atmega1284p",
     ))]
     pub struct Gnd;
     #[cfg(any(
@@ -218,5 +222,35 @@ avr_hal_generic::impl_adc! {
     channels: {
         channel::Vbg: 0b011110,
         channel::Gnd: 0b011111,
+    },
+}
+
+#[cfg(any(
+feature = "atmega1284p",
+))]
+avr_hal_generic::impl_adc! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::ADC,
+    settings: AdcSettings,
+    apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
+    channel_id: crate::pac::adc::admux::MUX_A,
+    set_channel: |peripheral, id| {
+        peripheral.admux.modify(|_, w| w.mux().variant(id));
+    },
+    pins: {
+        port::PA0: (crate::pac::adc::admux::MUX_A::ADC0, didr0::adc0d),
+        port::PA1: (crate::pac::adc::admux::MUX_A::ADC1, didr0::adc1d),
+        port::PA2: (crate::pac::adc::admux::MUX_A::ADC2, didr0::adc2d),
+        port::PA3: (crate::pac::adc::admux::MUX_A::ADC3, didr0::adc3d),
+        port::PA4: (crate::pac::adc::admux::MUX_A::ADC4, didr0::adc4d),
+        port::PA5: (crate::pac::adc::admux::MUX_A::ADC5, didr0::adc5d),
+    },
+    channels: {
+        #[cfg(feature = "enable-extra-adc")]
+        channel::ADC6: crate::pac::adc::admux::MUX_A::ADC6,
+        #[cfg(feature = "enable-extra-adc")]
+        channel::ADC7: crate::pac::adc::admux::MUX_A::ADC7,
+        channel::Vbg: crate::pac::adc::admux::MUX_A::ADC_VBG,
+        channel::Gnd: crate::pac::adc::admux::MUX_A::ADC_GND,
     },
 }

--- a/mcu/atmega-hal/src/i2c.rs
+++ b/mcu/atmega-hal/src/i2c.rs
@@ -64,3 +64,19 @@ avr_hal_generic::impl_i2c_twi! {
     sda: port::PE0,
     scl: port::PE1,
 }
+
+#[cfg(any(feature = "atmega1284p"))]
+pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
+    crate::Atmega,
+    crate::pac::TWI,
+    port::Pin<port::mode::Input, port::PC1>,
+    port::Pin<port::mode::Input, port::PC0>,
+    CLOCK,
+>;
+#[cfg(any(feature = "atmega1284p"))]
+avr_hal_generic::impl_i2c_twi! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::TWI,
+    sda: port::PC1,
+    scl: port::PC0,
+}

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -12,6 +12,7 @@
 #![cfg_attr(feature = "atmega32u4", doc = "**ATmega32U4**.")]
 #![cfg_attr(feature = "atmega2560", doc = "**ATmega2560**.")]
 #![cfg_attr(feature = "atmega1280", doc = "**ATmega1280**.")]
+#![cfg_attr(feature = "atmega1284p", doc = "**ATmega1284P**.")]
 //! This means that only items which are available for this MCU are visible.  If you are using
 //! a different chip, try building the documentation locally with:
 //!
@@ -35,6 +36,7 @@ compile_error!(
     * atmega32u4
     * atmega1280
     * atmega2560
+    * atmega1284p
     "
 );
 
@@ -59,6 +61,9 @@ pub use avr_device::atmega32u4 as pac;
 /// Reexport of `atmega48p` from `avr-device`
 #[cfg(feature = "atmega48p")]
 pub use avr_device::atmega48p as pac;
+/// Reexport of `atmega1284p` from `avr-device`
+#[cfg(feature = "atmega1284p")]
+pub use avr_device::atmega1284p as pac;
 
 /// See [`avr_device::entry`](https://docs.rs/avr-device/latest/avr_device/attr.entry.html).
 #[cfg(feature = "rt")]
@@ -133,6 +138,16 @@ macro_rules! pins {
         $crate::Pins::new(
             $p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD, $p.PORTE, $p.PORTF, $p.PORTG, $p.PORTH,
             $p.PORTJ, $p.PORTK, $p.PORTL,
+        )
+    };
+}
+
+#[cfg(any(feature = "atmega1284p"))]
+#[macro_export]
+macro_rules! pins {
+    ($p:expr) => {
+        $crate::Pins::new(
+            $p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD,
         )
     };
 }

--- a/mcu/atmega-hal/src/port.rs
+++ b/mcu/atmega-hal/src/port.rs
@@ -218,3 +218,48 @@ avr_hal_generic::impl_port_traditional! {
         pl7: PL7 = (crate::pac::PORTL, PORTL, 7, portl, pinl, ddrl),
     }
 }
+
+#[cfg(any(feature = "atmega1284p"))]
+avr_hal_generic::impl_port_traditional! {
+    enum Ports {
+        PORTA: (crate::pac::PORTA, porta, pina, ddra),
+        PORTB: (crate::pac::PORTB, portb, pinb, ddrb),
+        PORTC: (crate::pac::PORTC, portc, pinc, ddrc),
+        PORTD: (crate::pac::PORTD, portd, pind, ddrd),
+    }
+
+    pub struct Pins {
+        pa0: PA0 = (crate::pac::PORTA, PORTA, 0, porta, pina, ddra),
+        pa1: PA1 = (crate::pac::PORTA, PORTA, 1, porta, pina, ddra),
+        pa2: PA2 = (crate::pac::PORTA, PORTA, 2, porta, pina, ddra),
+        pa3: PA3 = (crate::pac::PORTA, PORTA, 3, porta, pina, ddra),
+        pa4: PA4 = (crate::pac::PORTA, PORTA, 4, porta, pina, ddra),
+        pa5: PA5 = (crate::pac::PORTA, PORTA, 5, porta, pina, ddra),
+        pa6: PA6 = (crate::pac::PORTA, PORTA, 6, porta, pina, ddra),
+        pa7: PA7 = (crate::pac::PORTA, PORTA, 7, porta, pina, ddra),
+        pb0: PB0 = (crate::pac::PORTB, PORTB, 0, portb, pinb, ddrb),
+        pb1: PB1 = (crate::pac::PORTB, PORTB, 1, portb, pinb, ddrb),
+        pb2: PB2 = (crate::pac::PORTB, PORTB, 2, portb, pinb, ddrb),
+        pb3: PB3 = (crate::pac::PORTB, PORTB, 3, portb, pinb, ddrb),
+        pb4: PB4 = (crate::pac::PORTB, PORTB, 4, portb, pinb, ddrb),
+        pb5: PB5 = (crate::pac::PORTB, PORTB, 5, portb, pinb, ddrb),
+        pb6: PB6 = (crate::pac::PORTB, PORTB, 6, portb, pinb, ddrb),
+        pb7: PB7 = (crate::pac::PORTB, PORTB, 7, portb, pinb, ddrb),
+        pc0: PC0 = (crate::pac::PORTC, PORTC, 0, portc, pinc, ddrc),
+        pc1: PC1 = (crate::pac::PORTC, PORTC, 1, portc, pinc, ddrc),
+        pc2: PC2 = (crate::pac::PORTC, PORTC, 2, portc, pinc, ddrc),
+        pc3: PC3 = (crate::pac::PORTC, PORTC, 3, portc, pinc, ddrc),
+        pc4: PC4 = (crate::pac::PORTC, PORTC, 4, portc, pinc, ddrc),
+        pc5: PC5 = (crate::pac::PORTC, PORTC, 5, portc, pinc, ddrc),
+        pc6: PC6 = (crate::pac::PORTC, PORTC, 6, portc, pinc, ddrc),
+        pc7: PC7 = (crate::pac::PORTC, PORTC, 7, portc, pinc, ddrc),
+        pd0: PD0 = (crate::pac::PORTD, PORTD, 0, portd, pind, ddrd),
+        pd1: PD1 = (crate::pac::PORTD, PORTD, 1, portd, pind, ddrd),
+        pd2: PD2 = (crate::pac::PORTD, PORTD, 2, portd, pind, ddrd),
+        pd3: PD3 = (crate::pac::PORTD, PORTD, 3, portd, pind, ddrd),
+        pd4: PD4 = (crate::pac::PORTD, PORTD, 4, portd, pind, ddrd),
+        pd5: PD5 = (crate::pac::PORTD, PORTD, 5, portd, pind, ddrd),
+        pd6: PD6 = (crate::pac::PORTD, PORTD, 6, portd, pind, ddrd),
+        pd7: PD7 = (crate::pac::PORTD, PORTD, 7, portd, pind, ddrd),
+    }
+}

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -803,3 +803,191 @@ avr_hal_generic::impl_simple_pwm! {
         },
     }
 }
+
+#[cfg(any(feature = "atmega1284p"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC0` for PWM (pins `PB3`, `PB4`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+    ///
+    /// let mut b3 = pins.b3.into_output().into_pwm(&mut timer0);
+    /// let mut b4 = pins.b4.into_output().into_pwm(&mut timer0);
+    ///
+    /// b3.set_duty(128);
+    /// b4.enable();
+    /// ```
+    pub struct Timer0Pwm {
+        timer: crate::pac::TC0,
+        init: |tim, prescaler| {
+            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b.modify(|_r, w| match prescaler {
+                Prescaler::Direct => w.cs0().direct(),
+                Prescaler::Prescale8 => w.cs0().prescale_8(),
+                Prescaler::Prescale64 => w.cs0().prescale_64(),
+                Prescaler::Prescale256 => w.cs0().prescale_256(),
+                Prescaler::Prescale1024 => w.cs0().prescale_1024(),
+            });
+        },
+        pins: {
+            PB3: {
+                ocr: ocr0a,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                },
+            },
+
+            PB4: {
+                ocr: ocr0b,
+                into_pwm: |tim| if enable {
+                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                } else {
+                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(feature = "atmega1284p")]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC1` for PWM (pins `PD5`, `PD4`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Prescale64);
+    ///
+    /// let mut d5 = pins.d5.into_output().into_pwm(&mut timer1);
+    /// let mut d4 = pins.d4.into_output().into_pwm(&mut timer1);
+    ///
+    /// d5.set_duty(128);
+    /// d5.enable();
+    /// ```
+    pub struct Timer1Pwm {
+        timer: crate::pac::TC1,
+        init: |tim, prescaler| {
+            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
+            tim.tccr1b.modify(|_r, w| {
+                w.wgm1().bits(0b01);
+
+                match prescaler {
+                    Prescaler::Direct => w.cs1().direct(),
+                    Prescaler::Prescale8 => w.cs1().prescale_8(),
+                    Prescaler::Prescale64 => w.cs1().prescale_64(),
+                    Prescaler::Prescale256 => w.cs1().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs1().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PD5: {
+                ocr: ocr1a,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                },
+            },
+
+            PD4: {
+                ocr: ocr1b,
+                into_pwm: |tim| if enable {
+                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                } else {
+                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+#[cfg(any(feature = "atmega1284p"))]
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC2` for PWM (pins `PD7`, `PD6`)
+    ///
+    /// # Example
+    /// ```
+    /// let mut timer2 = Timer2Pwm::new(dp.TC2, Prescaler::Prescale64);
+    ///
+    /// let mut d7 = pins.d7.into_output().into_pwm(&mut timer2);
+    /// let mut d6 = pins.d6.into_output().into_pwm(&mut timer2);
+    ///
+    /// d7.set_duty(128);
+    /// d7.enable();
+    /// ```
+    pub struct Timer2Pwm {
+        timer: crate::pac::TC2,
+        init: |tim, prescaler| {
+            tim.tccr2a.modify(|_r, w| w.wgm2().pwm_fast());
+            tim.tccr2b.modify(|_r, w| match prescaler {
+                    Prescaler::Direct => w.cs2().direct(),
+                    Prescaler::Prescale8 => w.cs2().prescale_8(),
+                    Prescaler::Prescale64 => w.cs2().prescale_64(),
+                    Prescaler::Prescale256 => w.cs2().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs2().prescale_1024(),
+            });
+        },
+        pins: {
+            PD7: {
+                ocr: ocr2a,
+                into_pwm: |tim| if enable {
+                    tim.tccr2a.modify(|_r, w| w.com2a().match_clear());
+                } else {
+                    tim.tccr2a.modify(|_r, w| w.com2a().disconnected());
+                },
+            },
+
+            PD6: {
+                ocr: ocr2b,
+                into_pwm: |tim| if enable {
+                    tim.tccr2a.modify(|_r, w| w.com2b().match_clear());
+                } else {
+                    tim.tccr2a.modify(|_r, w| w.com2b().disconnected());
+                },
+            },
+        },
+    }
+}
+
+avr_hal_generic::impl_simple_pwm! {
+    /// Use `TC3` for PWM (pins `PB6`, `PB7`)
+    pub struct Timer3Pwm {
+        timer: crate::pac::TC3,
+        init: |tim, prescaler| {
+            tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
+            tim.tccr3b.modify(|_r, w| {
+                unsafe { w.wgm3().bits(0b01) };
+
+                match prescaler {
+                    Prescaler::Direct => w.cs3().direct(),
+                    Prescaler::Prescale8 => w.cs3().prescale_8(),
+                    Prescaler::Prescale64 => w.cs3().prescale_64(),
+                    Prescaler::Prescale256 => w.cs3().prescale_256(),
+                    Prescaler::Prescale1024 => w.cs3().prescale_1024(),
+                }
+            });
+        },
+        pins: {
+            PB6: {
+                ocr: ocr3a,
+                into_pwm: |tim| if enable {
+                    tim.tccr3a.modify(|_r, w| w.com3a().match_clear());
+                } else {
+                    tim.tccr3a.modify(|_r, w| w.com3a().disconnected());
+                },
+            },
+
+            PB7: {
+                ocr: ocr3b,
+                into_pwm: |tim| if enable {
+                    tim.tccr3a.modify(|_r, w| w.com3b().match_clear());
+                } else {
+                    tim.tccr3a.modify(|_r, w| w.com3b().disconnected());
+                },
+            },
+        },
+    }
+}

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -952,6 +952,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
+#[cfg(any(feature = "atmega1284p"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC3` for PWM (pins `PB6`, `PB7`)
     pub struct Timer3Pwm {

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -852,7 +852,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(feature = "atmega1284p")]
+#[cfg(any(feature = "atmega1284p"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC1` for PWM (pins `PD5`, `PD4`)
     ///

--- a/mcu/atmega-hal/src/spi.rs
+++ b/mcu/atmega-hal/src/spi.rs
@@ -76,3 +76,22 @@ avr_hal_generic::impl_spi! {
     miso: port::PC0,
     cs: port::PE2,
 }
+
+#[cfg(any(feature = "atmega1284p"))]
+pub type Spi = avr_hal_generic::spi::Spi<
+    crate::Atmega,
+    crate::pac::SPI,
+    port::PB7,
+    port::PB5,
+    port::PB6,
+    port::PB4,
+>;
+#[cfg(any(feature = "atmega1284p"))]
+avr_hal_generic::impl_spi! {
+    hal: crate::Atmega,
+    peripheral: crate::pac::SPI,
+    sclk: port::PB7,
+    mosi: port::PB5,
+    miso: port::PB6,
+    cs: port::PB4,
+}

--- a/mcu/atmega-hal/src/usart.rs
+++ b/mcu/atmega-hal/src/usart.rs
@@ -9,14 +9,14 @@ pub type UsartWriter<USART, RX, TX, CLOCK> =
 pub type UsartReader<USART, RX, TX, CLOCK> =
     avr_hal_generic::usart::UsartReader<crate::Atmega, USART, RX, TX, CLOCK>;
 
-#[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb"))]
+#[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb", feature = "atmega1284p"))]
 pub type Usart0<CLOCK> = Usart<
     crate::pac::USART0,
     port::Pin<port::mode::Input, port::PD0>,
     port::Pin<port::mode::Output, port::PD1>,
     CLOCK,
 >;
-#[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb"))]
+#[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb", feature = "atmega1284p"))]
 avr_hal_generic::impl_usart_traditional! {
     hal: crate::Atmega,
     peripheral: crate::pac::USART0,
@@ -41,14 +41,14 @@ avr_hal_generic::impl_usart_traditional! {
     tx: port::PB3,
 }
 
-#[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560"))]
+#[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560", feature = "atmega1284p"))]
 pub type Usart1<CLOCK> = Usart<
     crate::pac::USART1,
     port::Pin<port::mode::Input, port::PD2>,
     port::Pin<port::mode::Output, port::PD3>,
     CLOCK,
 >;
-#[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560"))]
+#[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560", feature = "atmega1284p"))]
 avr_hal_generic::impl_usart_traditional! {
     hal: crate::Atmega,
     peripheral: crate::pac::USART1,


### PR DESCRIPTION
Added support for the ATmega1284P by following [the datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/doc8059.pdf).