### PR TITLE
Genuine Quickstart for Windows using Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Install dependencies:
   brew install avr-gcc avrdude
   ```
 - Windows
+
   Install Scoop
   ```PowerShell
   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install dependencies:
   ```
 - Windows
 
-  Install Scoop
+  Install Scoop using Powershell
   ```PowerShell
   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time
   irm get.scoop.sh | iex
@@ -29,7 +29,7 @@ Install dependencies:
   scoop install avr-gcc
   scoop install avrdude
   ```
-  [See here](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) for more information.
+  See [Setting up environment](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) for more information.
   
 Next, install ["ravedude"](./ravedude), a tool which seamlessly integrates flashing your board into the usual cargo workflow:
 

--- a/README.md
+++ b/README.md
@@ -11,20 +11,19 @@ Install dependencies:
 
   Install Scoop
   ```powershell
-  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Optional: Needed to run a remote script the first time
+  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time
   irm get.scoop.sh | iex
 
   ```
-Install scoop install avr-gcc and avrdude
+  Install scoop install avr-gcc and avrdude
 
 
   ```
-scoop install avr-gcc
-scoop install avrdude
-
+   scoop install avr-gcc
+   scoop install avrdude
   ```
 
-[See here](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) for more information.
+   [See here](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) for more information.
 
 - Ubuntu
   ```bash

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install dependencies:
   ```
 - Windows
 
-  Install {Scoop](https://scoop.sh/) using Powershell
+  Install [Scoop](https://scoop.sh/) using Powershell
   ```PowerShell
   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time
   irm get.scoop.sh | iex

--- a/README.md
+++ b/README.md
@@ -8,7 +8,23 @@ You need a nightly Rust compiler for compiling Rust code for AVR.  The correct v
 Install dependencies:
 
 - Windows
-[See here](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) on how to setup and install avr-gcc for windows.
+
+  Install Scoop
+  ```powershell
+  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Optional: Needed to run a remote script the first time
+  irm get.scoop.sh | iex
+
+  ```
+Install scoop install avr-gcc and avrdude
+
+
+  ```
+scoop install avr-gcc
+scoop install avrdude
+
+  ```
+
+[See here](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) for more information.
 
 - Ubuntu
   ```bash

--- a/README.md
+++ b/README.md
@@ -7,24 +7,6 @@ You need a nightly Rust compiler for compiling Rust code for AVR.  The correct v
 
 Install dependencies:
 
-- Windows
-
-  Install Scoop
-  ```powershell
-  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time
-  irm get.scoop.sh | iex
-
-  ```
-  Install scoop install avr-gcc and avrdude
-
-
-  ```
-   scoop install avr-gcc
-   scoop install avrdude
-  ```
-
-   [See here](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) for more information.
-
 - Ubuntu
   ```bash
   sudo apt install avr-libc gcc-avr pkg-config avrdude libudev-dev build-essential
@@ -35,6 +17,18 @@ Install dependencies:
   brew tap osx-cross/avr
   brew install avr-gcc avrdude
   ```
+- Windows
+  Install Scoop
+  ```PowerShell
+  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time
+  irm get.scoop.sh | iex
+  ```
+  Install avr-gcc and avrdude
+  ```
+  scoop install avr-gcc
+  scoop install avrdude
+  ```
+  [See here](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) for more information.
   
 Next, install ["ravedude"](./ravedude), a tool which seamlessly integrates flashing your board into the usual cargo workflow:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install dependencies:
   ```
 - Windows
 
-  Install Scoop using Powershell
+  Install {Scoop](https://scoop.sh/) using Powershell
   ```PowerShell
   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time
   irm get.scoop.sh | iex


### PR DESCRIPTION
Scoop seems to be the most painless way to get the dependencies into Windows (At least Windows 10), and working properly. Kept link to other page, it still might be useful.