### PR TITLE
README: Genuine Windows Quickstart with Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ You need a nightly Rust compiler for compiling Rust code for AVR.  The correct v
 
 Install dependencies:
 
-- Windows
-[See here](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) on how to setup and install avr-gcc for windows.
-
 - Ubuntu
   ```bash
   sudo apt install avr-libc gcc-avr pkg-config avrdude libudev-dev build-essential
@@ -20,6 +17,19 @@ Install dependencies:
   brew tap osx-cross/avr
   brew install avr-gcc avrdude
   ```
+- Windows
+
+  Install [Scoop](https://scoop.sh/) using Powershell
+  ```PowerShell
+  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time
+  irm get.scoop.sh | iex
+  ```
+  Install avr-gcc and avrdude
+  ```
+  scoop install avr-gcc
+  scoop install avrdude
+  ```
+  See [Setting up environment](https://github.com/Rahix/avr-hal/wiki/Setting-up-environment) for more information.
   
 Next, install ["ravedude"](./ravedude), a tool which seamlessly integrates flashing your board into the usual cargo workflow:
 


### PR DESCRIPTION
Scoop seems to be the quickest way to install our dependencies and making them work on Windows(10).