### PR TITLE
Add a few of the missing re-exports

### DIFF
--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -172,6 +172,8 @@ pub use usart::Usart;
 
 #[cfg(feature = "mcu-atmega")]
 pub mod prelude {
+    pub use crate::hal::prelude::*;
+
     cfg_if::cfg_if! {
         if #[cfg(any(
             feature = "arduino-diecimila",
@@ -183,10 +185,6 @@ pub mod prelude {
             pub use crate::hal::usart::BaudrateExt as _;
         }
     }
-
-    pub use ufmt::uWrite as _;
-    pub use void::ResultVoidErrExt as _;
-    pub use void::ResultVoidExt as _;
 }
 
 /// Convenience macro to instanciate the [`Pins`] struct for this board.

--- a/arduino-hal/src/port/diecimila.rs
+++ b/arduino-hal/src/port/diecimila.rs
@@ -1,5 +1,4 @@
-pub use atmega_hal::port::mode;
-pub use atmega_hal::port::Pin;
+pub use atmega_hal::port::{mode, Pin, PinOps, PinMode};
 
 avr_hal_generic::renamed_pins! {
     type Pin = Pin;

--- a/arduino-hal/src/port/diecimila.rs
+++ b/arduino-hal/src/port/diecimila.rs
@@ -5,7 +5,7 @@ avr_hal_generic::renamed_pins! {
 
     /// Pins of the **Arduino Diecimila**.
     ///
-    /// This struct is best initialized via the [`arduino_hal::pins!()`][pins] macro.
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][crate::pins] macro.
     pub struct Pins from atmega_hal::Pins {
         /// `A0`
         ///

--- a/arduino-hal/src/port/leonardo.rs
+++ b/arduino-hal/src/port/leonardo.rs
@@ -1,5 +1,4 @@
-pub use atmega_hal::port::mode;
-pub use atmega_hal::port::Pin;
+pub use atmega_hal::port::{mode, Pin, PinOps, PinMode};
 
 avr_hal_generic::renamed_pins! {
     type Pin = Pin;

--- a/arduino-hal/src/port/leonardo.rs
+++ b/arduino-hal/src/port/leonardo.rs
@@ -5,7 +5,7 @@ avr_hal_generic::renamed_pins! {
 
     /// Pins of the **Arduino Leonardo**.
     ///
-    /// This struct is best initialized via the [`arduino_hal::pins!()`][pins] macro.
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][crate::pins] macro.
     pub struct Pins from atmega_hal::Pins {
         /// `D0` / `RX`
         ///

--- a/arduino-hal/src/port/mega2560.rs
+++ b/arduino-hal/src/port/mega2560.rs
@@ -1,5 +1,4 @@
-pub use atmega_hal::port::mode;
-pub use atmega_hal::port::Pin;
+pub use atmega_hal::port::{mode, Pin, PinOps, PinMode};
 
 avr_hal_generic::renamed_pins! {
     type Pin = Pin;

--- a/arduino-hal/src/port/mega2560.rs
+++ b/arduino-hal/src/port/mega2560.rs
@@ -5,7 +5,7 @@ avr_hal_generic::renamed_pins! {
 
     /// Pins of the **Arduino Mega 2560**.
     ///
-    /// This struct is best initialized via the [`arduino_hal::pins!()`][pins] macro.
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][crate::pins] macro.
     pub struct Pins from atmega_hal::Pins {
         /// `D0` / `RX0`
         ///

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -1,7 +1,7 @@
 //! GPIO & Pin control.
 //!
 //! This module contains a [`Pins`] struct which represents all pins of the board.  The [`Pins`]
-//! struct is most easily constructed using the [`arduino_hal::pins!()`][pins] macro:
+//! struct is most easily constructed using the [`arduino_hal::pins!()`][crate::pins] macro:
 //!
 //! ```no_run
 //! let dp = arduino_hal::Peripherals::take().unwrap();

--- a/arduino-hal/src/port/promicro.rs
+++ b/arduino-hal/src/port/promicro.rs
@@ -1,5 +1,4 @@
-pub use atmega_hal::port::mode;
-pub use atmega_hal::port::Pin;
+pub use atmega_hal::port::{mode, Pin, PinOps, PinMode};
 
 avr_hal_generic::renamed_pins! {
     type Pin = Pin;

--- a/arduino-hal/src/port/promicro.rs
+++ b/arduino-hal/src/port/promicro.rs
@@ -5,7 +5,7 @@ avr_hal_generic::renamed_pins! {
 
     /// Pins of the **SparkFun ProMicro**.
     ///
-    /// This struct is best initialized via the [`arduino_hal::pins!()`][pins] macro.
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][crate::pins] macro.
     pub struct Pins from atmega_hal::Pins {
         /// `RX`
         ///

--- a/arduino-hal/src/port/trinket.rs
+++ b/arduino-hal/src/port/trinket.rs
@@ -1,5 +1,4 @@
-pub use attiny_hal::port::mode;
-pub use attiny_hal::port::Pin;
+pub use attiny_hal::port::{mode, Pin, PinOps, PinMode};
 
 avr_hal_generic::renamed_pins! {
     type Pin = Pin;

--- a/arduino-hal/src/port/trinket_pro.rs
+++ b/arduino-hal/src/port/trinket_pro.rs
@@ -1,5 +1,4 @@
-pub use atmega_hal::port::mode;
-pub use atmega_hal::port::Pin;
+pub use atmega_hal::port::{mode, Pin, PinOps, PinMode};
 
 avr_hal_generic::renamed_pins! {
     type Pin = Pin;

--- a/arduino-hal/src/port/trinket_pro.rs
+++ b/arduino-hal/src/port/trinket_pro.rs
@@ -5,7 +5,7 @@ avr_hal_generic::renamed_pins! {
 
     /// Pins of the **Trinket Pro**.
     ///
-    /// This struct is best initialized via the [`arduino_hal::pins!()`][pins] macro.
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][crate::pins] macro.
     pub struct Pins from atmega_hal::Pins {
         /// `A0`
         ///

--- a/arduino-hal/src/port/uno.rs
+++ b/arduino-hal/src/port/uno.rs
@@ -1,5 +1,4 @@
-pub use atmega_hal::port::mode;
-pub use atmega_hal::port::Pin;
+pub use atmega_hal::port::{mode, Pin, PinOps, PinMode};
 
 avr_hal_generic::renamed_pins! {
     type Pin = Pin;

--- a/arduino-hal/src/port/uno.rs
+++ b/arduino-hal/src/port/uno.rs
@@ -5,7 +5,7 @@ avr_hal_generic::renamed_pins! {
 
     /// Pins of the **Arduino Uno**.
     ///
-    /// This struct is best initialized via the [`arduino_hal::pins!()`][pins] macro.
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][crate::pins] macro.
     pub struct Pins from atmega_hal::Pins {
         /// `A0`
         ///

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -27,10 +27,6 @@ pub mod wdt;
 
 /// Prelude containing all HAL traits
 pub mod prelude {
-    pub use hal::digital::v2::InputPin as _;
-    pub use hal::digital::v2::OutputPin as _;
-    pub use hal::digital::v2::StatefulOutputPin as _;
-    pub use hal::digital::v2::ToggleableOutputPin as _;
     pub use hal::prelude::*;
     pub use ufmt::uWrite as _;
     pub use void::ResultVoidErrExt as _;

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -28,9 +28,9 @@ pub mod wdt;
 /// Prelude containing all HAL traits
 pub mod prelude {
     pub use hal::prelude::*;
-    pub use ufmt::uWrite as _;
-    pub use void::ResultVoidErrExt as _;
-    pub use void::ResultVoidExt as _;
+    pub use ufmt::uWrite as _ufmt_uWrite;
+    pub use void::ResultVoidErrExt as _void_ResultVoidErrExt;
+    pub use void::ResultVoidExt as _void_ResultVoidExt;
 }
 
 // For making certain traits unimplementable from outside this crate.

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -474,8 +474,6 @@ macro_rules! impl_port_traditional {
                                         $pin_ddr_reg:ident),)+
         }
     ) => {
-        pub use $crate::port::mode;
-
         /// Type-alias for a pin type which can represent any concrete pin.
         ///
         /// Sometimes it is easier to handle pins if they are all of the same type.  By default,

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -74,6 +74,7 @@ pub use pac::Peripherals;
 
 pub use avr_hal_generic::clock;
 pub use avr_hal_generic::delay;
+pub use avr_hal_generic::prelude;
 
 #[cfg(feature = "device-selected")]
 pub mod adc;

--- a/mcu/atmega-hal/src/port.rs
+++ b/mcu/atmega-hal/src/port.rs
@@ -1,3 +1,5 @@
+pub use avr_hal_generic::port::{mode, PinOps, PinMode};
+
 #[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
 avr_hal_generic::impl_port_traditional! {
     enum Ports {

--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -60,6 +60,7 @@ pub use pac::Peripherals;
 
 pub use avr_hal_generic::clock;
 pub use avr_hal_generic::delay;
+pub use avr_hal_generic::prelude;
 
 // ATtiny2313 does not have ADC and will not compile with this module
 #[cfg(all(feature = "device-selected", not(feature = "attiny2313")))]

--- a/mcu/attiny-hal/src/port.rs
+++ b/mcu/attiny-hal/src/port.rs
@@ -1,3 +1,5 @@
+pub use avr_hal_generic::port::{mode, PinOps, PinMode};
+
 #[cfg(feature = "attiny2313")]
 avr_hal_generic::impl_port_traditional! {
     enum Ports {


### PR DESCRIPTION
In #332 it was pointed out that some items are only reachable via the `avr-hal-generic` crate.  This crate isn't meant to be visible to downstream code so such situations should be avoided.  Ideally, all relevant items from `avr-hal-generic` should be re-rexported somewhere in the individual HAL crates.

Start by fixing up a few of the well-known problems.