### PR TITLE
ravedude: Add flake.nix

### DIFF
--- a/ravedude/README.md
+++ b/ravedude/README.md
@@ -24,6 +24,10 @@ Next, install the latest version from crates.io with the following command:
 cargo install ravedude
 ```
 
+(alternatively, if you're using NixOS + Flakes, you can install `ravedude` by
+adding `inputs.ravedude.url = "github:Rahix/avr-hal?dir=ravedude";` and then
+`environment.systemPackages = [ ravedude.defaultPackage."${system}" ];`.)
+
 Now you need to add *ravedude* to your project.  For example in a project for
 Arduino Uno, place the following into your `.cargo/config.toml` (**not in
 `Cargo.toml`**):

--- a/ravedude/flake.lock
+++ b/ravedude/flake.lock
@@ -1,0 +1,70 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1655042882,
+        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-O3wncIouj9x7gBPntzHeK/Hkmm9M1SGlYq7JI7saTAE=",
+        "path": "/nix/store/d84iknazpzwbjbj1j9zh9wnh6v6dzlfb-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-O3wncIouj9x7gBPntzHeK/Hkmm9M1SGlYq7JI7saTAE=",
+        "path": "/nix/store/d84iknazpzwbjbj1j9zh9wnh6v6dzlfb-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/ravedude/flake.nix
+++ b/ravedude/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs = {
+    utils = {
+      url = "github:numtide/flake-utils";
+    };
+
+    naersk = {
+      url = "github:nix-community/naersk";
+    };
+  };
+
+  outputs = { self, nixpkgs, utils, naersk }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        naersk' = pkgs.callPackage naersk {};
+
+      in
+      rec {
+        defaultPackage = naersk'.buildPackage {
+          pname = "ravedude";
+          src = ./.;
+
+          buildInputs = with pkgs; [
+            pkg-config
+            udev
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
(not sure if you'd be interested in a pull request like that, but I figured it won't hurt to try 🙂)

This PR adds a `flake.nix` that Nix / NixOS users can use to install ravedude on their machines (considering that compiling it requires udev and pkg-config, so it's not as straightforward as "regular" `cargo install`).

(btw, for NixOS flake users: that requires pulling the dependency as `inputs.ravedude.url = "github:Rahix/avr-hal?dir=ravedude";`)