### PR TITLE
Examples: Added proper sleep mode control register config to uno-timer.rs

### DIFF
--- a/examples/arduino-uno/src/bin/uno-timer.rs
+++ b/examples/arduino-uno/src/bin/uno-timer.rs
@@ -44,7 +44,12 @@ fn main() -> ! {
         core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
     }
 
-    //
+    // Enable sleep mode by setting the sleep bit in sleep mode control register (SMCR)
+    // https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7810-Automotive-Microcontrollers-ATmega328P_Datasheet.pdf
+    // Sections 9.1 and 9.11.1
+    dp.CPU.smcr.write(|w|{
+        w.se().set_bit()
+    });
 
     let tmr1: TC1 = dp.TC1;
 


### PR DESCRIPTION
Previously in the example the sleep mode control register was never configured for sleep mode. 

To do this, the sleep enable (SE) bit has to be set active. Due to the examples layout, it was not apparent that the controller didn't go to sleep, but it is easily proven by putting any kind of visible functionality inside the loop.