### PR TITLE
Update avr-device dependencies to 0.4

### DIFF
--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -48,7 +48,7 @@ path = "../mcu/attiny-hal/"
 optional = true
 
 [dependencies.avr-device]
-version = "0.3"
+version = "0.4"
 
 # Because this crate has its own check that at least one device is selected, we
 # can safely "circumvent" the check in `avr-device`.

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -9,7 +9,7 @@ cfg-if = "0.1.7"
 nb = "0.1.2"
 ufmt = "0.1.0"
 paste = "1.0.0"
-avr-device = "0.3.4"
+avr-device = "0.4"
 
 [dependencies.embedded-hal]
 version = "0.2.3"

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -18,7 +18,7 @@ path = "../../arduino-hal/"
 features = ["arduino-uno"]
 
 [dependencies.avr-device]
-version = "0.3"
+version = "0.4"
 
 [dependencies.either]
 version = "1.6.1"

--- a/examples/nano168/Cargo.toml
+++ b/examples/nano168/Cargo.toml
@@ -17,4 +17,4 @@ path = "../../arduino-hal/"
 features = ["nano168"]
 
 [dependencies.avr-device]
-version = "0.3"
+version = "0.4"

--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -24,7 +24,7 @@ disable-device-selection-error = []
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-version = "0.3"
+version = "0.4"
 
 # Because this crate has its own check that at least one device is selected, we
 # can safely "circumvent" the check in `avr-device`.

--- a/mcu/attiny-hal/Cargo.toml
+++ b/mcu/attiny-hal/Cargo.toml
@@ -20,7 +20,7 @@ disable-device-selection-error = []
 avr-hal-generic = { path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
-version = "0.3"
+version = "0.4"
 
 # Because this crate has its own check that at least one device is selected, we
 # can safely "circumvent" the check in `avr-device`.


### PR DESCRIPTION
I updated the `avr-device` dependency for the following crates in this repo to 0.4:

- avr-hal-generic
- atmega-hal
- attiny-hal

Things built locally (followed the cargo build command in the CI workflow) so hopefully this is all that's needed!