### PR TITLE
Add Digistump Digispark board

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "examples/sparkfun-promicro",
     "examples/trinket-pro",
     "examples/trinket",
+    "examples/digispark"
 ]
 exclude = [
     # The RAVEDUDE! Yeah!

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -20,6 +20,7 @@ trinket-pro = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 trinket = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
 nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", "board-selected"]
+digispark = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
 
 [dependencies]
 cfg-if = "1"

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -23,6 +23,7 @@ pub(crate) mod default {
         feature = "sparkfun-promicro",
         feature = "trinket-pro",
         feature = "nano168",
+        feature = "digispark"
     ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz16;
     #[cfg(feature = "trinket")]

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -15,6 +15,7 @@
 #![cfg_attr(feature = "trinket-pro", doc = "**Trinket Pro**.")]
 #![cfg_attr(feature = "trinket", doc = "**Trinket**.")]
 #![cfg_attr(feature = "nano168", doc = "**Nano clone (ATmega168)**.")]
+#![cfg_attr(feature = "digispark",doc = "**Digistump Digispark**.")]
 //! This means that only items which are available for this board are visible.  If you are using a
 //! different board, try building the documentation locally with
 //!
@@ -60,6 +61,7 @@ compile_error!(
     * trinket-pro
     * trinket
     * nano168
+    * digispark
     "
 );
 

--- a/arduino-hal/src/port/digispark.rs
+++ b/arduino-hal/src/port/digispark.rs
@@ -1,0 +1,20 @@
+pub use attiny_hal::port::{mode, Pin, PinMode, PinOps};
+
+avr_hal_generic::renamed_pins! {
+    type Pin = Pin;
+
+    pub struct Pins from attiny_hal::Pins {
+        /// `#0`: `PB0`, `DI`(SPI), `SDA`(I2C)
+        pub d0: attiny_hal::port::PB0 = pb0,
+        /// `#1`: `PB1`, `DO`(SPI), Builtin LED
+        pub d1: attiny_hal::port::PB1 = pb1,
+        /// `#2`: `PB2`, `SCK`(SPI), `SCL`(I2C)
+        pub d2: attiny_hal::port::PB2 = pb2,
+        /// `#3`: `PB3`, USB-
+        pub d3: attiny_hal::port::PB3 = pb3,
+        /// `#4`: `PB4`, USB+
+        pub d4: attiny_hal::port::PB4 = pb4,
+        /// `#5`: `PB5`, Reset
+        pub d5: attiny_hal::port::PB5 = pb5,
+    }
+}

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -43,3 +43,7 @@ pub use trinket_pro::*;
 mod trinket;
 #[cfg(feature = "trinket")]
 pub use trinket::*;
+#[cfg(feature = "digispark")]
+mod digispark;
+#[cfg(feature = "digispark")]
+pub use digispark::*;

--- a/examples/digispark/.cargo/config.toml
+++ b/examples/digispark/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-attiny85.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "micronucleus-runner"
+
+[unstable]
+build-std = ["core"]

--- a/examples/digispark/Cargo.toml
+++ b/examples/digispark/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "digispark-examples"
+version = "0.0.0"
+authors = ["Jan Paw <jpaw@virtuslab.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["digispark"]

--- a/examples/digispark/src/bin/digispark-blink.rs
+++ b/examples/digispark/src/bin/digispark-blink.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    // Digital pin 1 is also connected to an onboard LED marked "L"
+    let mut led = pins.d1.into_output();
+    led.set_high();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(800);
+    }
+}

--- a/examples/digispark/src/bin/digispark-simple-pwm.rs
+++ b/examples/digispark/src/bin/digispark-simple-pwm.rs
@@ -1,0 +1,28 @@
+/*!
+ * Example of using simple_pwm to fade the built-in LED in and out.
+ */
+
+#![no_std]
+#![no_main]
+
+use arduino_hal::simple_pwm::*;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    let timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+
+    // Digital pin 1 is also connected to an onboard LED marked "L"
+    let mut pwm_led = pins.d1.into_output().into_pwm(&timer0);
+    pwm_led.enable();
+
+    loop {
+        for x in (0..=255).chain((0..=254).rev()) {
+            pwm_led.set_duty(x);
+            arduino_hal::delay_ms(10);
+        }
+    }
+}


### PR DESCRIPTION
Adds a Digispark board. 

In the past I used the Trinket board configuration on my Digisparks, but that was buggy.

Now the Digispark has the correct clock frequency and the missing pin added.
Also its documentation now mentions which pins USB and Reset are connected to.
