### PR TITLE
Fixed 370: the hanging i2c because of a faulty stop the twint is set by the avr itself.

### DIFF
--- a/avr-hal-generic/src/i2c.rs
+++ b/avr-hal-generic/src/i2c.rs
@@ -538,7 +538,7 @@ macro_rules! impl_i2c_twi {
             #[inline]
             fn raw_stop(&mut self) -> Result<(), Error> {
                 self.twcr
-                    .write(|w| w.twen().set_bit().twint().set_bit().twsto().set_bit());
+                    .write(|w| w.twen().set_bit().twsto().set_bit());
                 Ok(())
             }
         }


### PR DESCRIPTION
I had added the timouts that you requested for and i noticed that it always go stuck on start. 

So i assumed that it was one of the bits set at the stop which caused the i2c to fail. 
https://www.engineersgarage.com/avr-atmega32-twi-registers/