### PR TITLE
Add digispark kickstarter Attiny85 board and cleanup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
             name: trinket
             examples: true
           - type: board
+            name: digispark
+            examples: true
+          - type: board
             name: arduino-nano
             examples: true
           - type: board
@@ -80,13 +83,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly-2022-06-13
-          override: true
           components: rust-src
       - name: Install avr-gcc, binutils, and libc
         run: sudo apt-get install -y avr-libc binutils-avr gcc-avr
@@ -105,17 +106,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
+          components: check
       - name: Install libudev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Check ravedude
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path ravedude/Cargo.toml
+        run: |
+          cargo check --manifest-path ravedude/Cargo.toml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "examples/sparkfun-promicro",
     "examples/trinket-pro",
     "examples/trinket",
+    "examples/digispark",
 ]
 exclude = [
     # The RAVEDUDE! Yeah!

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -20,6 +20,7 @@ arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 trinket-pro = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 trinket = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
+digispark = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
 nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", "board-selected"]
 
 [dependencies]

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -24,6 +24,7 @@ pub(crate) mod default {
         feature = "sparkfun-promicro",
         feature = "trinket-pro",
         feature = "nano168",
+        feature = "digispark",
     ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz16;
     #[cfg(feature = "trinket")]

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -15,6 +15,7 @@
 #![cfg_attr(feature = "sparkfun-promicro", doc = "**SparkFun ProMicro**.")]
 #![cfg_attr(feature = "trinket-pro", doc = "**Trinket Pro**.")]
 #![cfg_attr(feature = "trinket", doc = "**Trinket**.")]
+#![cfg_attr(feature = "digispark", doc = "**Digispark kickstarter attiny85**.")]
 #![cfg_attr(feature = "nano168", doc = "**Nano clone (ATmega168)**.")]
 //! This means that only items which are available for this board are visible.  If you are using a
 //! different board, try building the documentation locally with
@@ -58,6 +59,7 @@ compile_error!(
     * arduino-mega1280
     * arduino-nano
     * arduino-uno
+    * digispark
     * sparkfun-promicro
     * trinket-pro
     * trinket

--- a/arduino-hal/src/port/digispark.rs
+++ b/arduino-hal/src/port/digispark.rs
@@ -1,0 +1,20 @@
+pub use attiny_hal::port::{mode, Pin, PinOps, PinMode};
+
+avr_hal_generic::renamed_pins! {
+    type Pin = Pin;
+
+    pub struct Pins from attiny_hal::Pins {
+     /// `#0`: `PB0`, `DI`(SPI), `SDA`(I2C)
+     pub d0: attiny_hal::port::PB0 = pb0,
+     /// `#1`: `PB1`, `DO`(SPI), Builtin LED
+     pub d1: attiny_hal::port::PB1 = pb1,
+     /// `#2`: `PB2`, `SCK`(SPI), `SCL`(I2C)
+     pub d2: attiny_hal::port::PB2 = pb2,
+     /// `#3`: `PB3`
+     pub d3: attiny_hal::port::PB3 = pb3,
+     /// `#4`: `PB4`
+     pub d4: attiny_hal::port::PB4 = pb4,
+     /// `#5`: `PB5`
+     pub d5: attiny_hal::port::PB5 = pb5,
+    }
+}

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -43,3 +43,7 @@ pub use trinket_pro::*;
 mod trinket;
 #[cfg(feature = "trinket")]
 pub use trinket::*;
+#[cfg(feature = "digispark")]
+mod digispark;
+#[cfg(feature = "digispark")]
+pub use digispark::*;

--- a/examples/arduino-uno/src/bin/uno-watchdog.rs
+++ b/examples/arduino-uno/src/bin/uno-watchdog.rs
@@ -9,7 +9,6 @@
 #![no_main]
 
 use arduino_hal::hal::wdt;
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -20,7 +19,7 @@ fn main() -> ! {
     let mut led = pins.d13.into_output();
     led.set_high();
 
-    for i in 0..20 {
+    for _i in 0..20 {
         led.toggle();
         arduino_hal::delay_ms(100);
     }

--- a/examples/digispark/.cargo/config.toml
+++ b/examples/digispark/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-attiny85.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "ravedude trinket"
+
+[unstable]
+build-std = ["core"]

--- a/examples/digispark/Cargo.toml
+++ b/examples/digispark/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "digispark-examples"
+version = "0.0.0"
+authors = ["Jan Paw <jpaw@virtuslab.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["digispark"]

--- a/examples/digispark/src/bin/digispark-blink.rs
+++ b/examples/digispark/src/bin/digispark-blink.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    // Digital pin 1 is also connected to an onboard LED marked "L"
+    let mut led = pins.d1.into_output();
+    led.set_high();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(800);
+    }
+}

--- a/examples/digispark/src/bin/digispark-simple-pwm.rs
+++ b/examples/digispark/src/bin/digispark-simple-pwm.rs
@@ -1,0 +1,28 @@
+/*!
+ * Example of using simple_pwm to fade the built-in LED in and out.
+ */
+
+#![no_std]
+#![no_main]
+
+use arduino_hal::simple_pwm::*;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    let timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+
+    // Digital pin 1 is also connected to an onboard LED marked "L"
+    let mut pwm_led = pins.d1.into_output().into_pwm(&timer0);
+    pwm_led.enable();
+
+    loop {
+        for x in (0..=255).chain((0..=254).rev()) {
+            pwm_led.set_duty(x);
+            arduino_hal::delay_ms(10);
+        }
+    }
+}

--- a/examples/nano168/src/bin/nano168-ldr.rs
+++ b/examples/nano168/src/bin/nano168-ldr.rs
@@ -28,8 +28,6 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use arduino_hal::adc;
-
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
@@ -54,7 +52,7 @@ fn main() -> ! {
             x if x > 250 => "dimmly lit",
             x if x > 50 => "rather dark",
             x if x <= 50 => "very dark",
-            x => "invalid", // to satisfy the compiler ()
+            _ => "invalid", // to satisfy the compiler ()
         };
 
         // output to the serial

--- a/examples/nano168/src/bin/nano168-watchdog.rs
+++ b/examples/nano168/src/bin/nano168-watchdog.rs
@@ -16,7 +16,7 @@ fn main() -> ! {
 
     ufmt::uwriteln!(&mut serial, "Setup started...").void_unwrap();
 
-    for i in 0..20 {
+    for _i in 0..20 {
         ufmt::uwrite!(&mut serial, ".").void_unwrap();
         led.toggle();
         arduino_hal::delay_ms(100);

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -960,7 +960,7 @@ avr_hal_generic::impl_simple_pwm! {
         init: |tim, prescaler| {
             tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
             tim.tccr3b.modify(|_r, w| {
-                unsafe { w.wgm3().bits(0b01) };
+                w.wgm3().bits(0b01);
 
                 match prescaler {
                     Prescaler::Direct => w.cs3().direct(),

--- a/mcu/attiny-hal/src/adc.rs
+++ b/mcu/attiny-hal/src/adc.rs
@@ -1,3 +1,4 @@
+#![allow(non_camel_case_types)]
 //! Analog-to-Digital Converter
 
 use crate::port;

--- a/mcu/attiny-hal/src/simple_pwm.rs
+++ b/mcu/attiny-hal/src/simple_pwm.rs
@@ -1,5 +1,6 @@
 pub use avr_hal_generic::simple_pwm::{PwmPinOps, Prescaler};
 
+#[cfg(any(feature = "attiny85",feature = "attiny84",feature="attiny88"))]
 use crate::port::*;
 
 #[cfg(feature = "attiny84")]


### PR DESCRIPTION
* Add digispark kickstarter Attiny85 board Digispark board is almost same as trinket, but all 6 GPIO are accessible
* Update workflows Remove unmaintained actions-rs
* Chore: silence warnings
   CI builds with warnings are errors, all existing warnings were either solved or silenced.