### PR TITLE
Add support for atmega324pa

### DIFF
--- a/mcu/atmega-hal/src/adc.rs
+++ b/mcu/atmega-hal/src/adc.rs
@@ -73,10 +73,12 @@ pub mod channel {
     #[cfg(all(
         any(
             feature = "atmega168",
+            feature = "atmega324pa",
             feature = "atmega328p",
             feature = "atmega328pb",
             feature = "atmega48p",
             feature = "atmega1284p",
+            feature = "atmega32"
         ),
         feature = "enable-extra-adc",
     ))]
@@ -84,6 +86,7 @@ pub mod channel {
     #[cfg(all(
         any(
             feature = "atmega168",
+            feature = "atmega324pa",
             feature = "atmega328p",
             feature = "atmega328pb",
             feature = "atmega48p",
@@ -96,6 +99,7 @@ pub mod channel {
         feature = "atmega1280",
         feature = "atmega168",
         feature = "atmega2560",
+        feature = "atmega324pa",
         feature = "atmega328p",
         feature = "atmega328pb",
         feature = "atmega32u4",
@@ -107,6 +111,7 @@ pub mod channel {
         feature = "atmega1280",
         feature = "atmega168",
         feature = "atmega2560",
+        feature = "atmega324pa",
         feature = "atmega328p",
         feature = "atmega328pb",
         feature = "atmega32u4",
@@ -225,7 +230,7 @@ avr_hal_generic::impl_adc! {
     },
 }
 
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 avr_hal_generic::impl_adc! {
     hal: crate::Atmega,
     peripheral: crate::pac::ADC,

--- a/mcu/atmega-hal/src/eeprom.rs
+++ b/mcu/atmega-hal/src/eeprom.rs
@@ -26,6 +26,7 @@ avr_hal_generic::impl_eeprom_atmega! {
 }
 
 #[cfg(any(
+    feature = "atmega324pa",
     feature = "atmega328pb",
     feature = "atmega328p",
     feature = "atmega32u4"

--- a/mcu/atmega-hal/src/i2c.rs
+++ b/mcu/atmega-hal/src/i2c.rs
@@ -65,7 +65,7 @@ avr_hal_generic::impl_i2c_twi! {
     scl: port::PE1,
 }
 
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
     crate::Atmega,
     crate::pac::TWI,
@@ -73,7 +73,7 @@ pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
     port::Pin<port::mode::Input, port::PC0>,
     CLOCK,
 >;
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 avr_hal_generic::impl_i2c_twi! {
     hal: crate::Atmega,
     peripheral: crate::pac::TWI,

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(feature = "atmega48p", doc = "**ATmega48P**.")]
 #![cfg_attr(feature = "atmega168", doc = "**ATmega168**.")]
 #![cfg_attr(feature = "atmega328p", doc = "**ATmega328P**.")]
+#![cfg_attr(feature = "atmega324pa", doc = "**ATmega324PA**.")]
 #![cfg_attr(feature = "atmega328pb", doc = "**ATmega328PB**.")]
 #![cfg_attr(feature = "atmega32u4", doc = "**ATmega32U4**.")]
 #![cfg_attr(feature = "atmega2560", doc = "**ATmega2560**.")]
@@ -31,6 +32,7 @@ compile_error!(
 
     * atmega48p
     * atmega168
+    * atmega324pa
     * atmega328p
     * atmega328pb
     * atmega32u4
@@ -49,6 +51,8 @@ pub use avr_device::atmega168 as pac;
 /// Reexport of `atmega2560` from `avr-device`
 #[cfg(feature = "atmega2560")]
 pub use avr_device::atmega2560 as pac;
+/// Reexport of `atmega324pa` from `avr-device`
+#[cfg(feature = "atmega324pa")]
 /// Reexport of `atmega328p` from `avr-device`
 #[cfg(feature = "atmega328p")]
 pub use avr_device::atmega328p as pac;
@@ -149,7 +153,7 @@ macro_rules! pins {
     };
 }
 
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 #[macro_export]
 macro_rules! pins {
     ($p:expr) => {

--- a/mcu/atmega-hal/src/port.rs
+++ b/mcu/atmega-hal/src/port.rs
@@ -221,7 +221,7 @@ avr_hal_generic::impl_port_traditional! {
     }
 }
 
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 avr_hal_generic::impl_port_traditional! {
     enum Ports {
         PORTA: (crate::pac::PORTA, porta, pina, ddra),

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -804,7 +804,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC0` for PWM (pins `PB3`, `PB4`)
     ///
@@ -852,7 +852,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC1` for PWM (pins `PD5`, `PD4`)
     ///
@@ -904,7 +904,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC2` for PWM (pins `PD7`, `PD6`)
     ///

--- a/mcu/atmega-hal/src/spi.rs
+++ b/mcu/atmega-hal/src/spi.rs
@@ -77,7 +77,7 @@ avr_hal_generic::impl_spi! {
     cs: port::PE2,
 }
 
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 pub type Spi = avr_hal_generic::spi::Spi<
     crate::Atmega,
     crate::pac::SPI,
@@ -86,7 +86,7 @@ pub type Spi = avr_hal_generic::spi::Spi<
     port::PB6,
     port::PB4,
 >;
-#[cfg(any(feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega1284p", feature = "atmega324pa"))]
 avr_hal_generic::impl_spi! {
     hal: crate::Atmega,
     peripheral: crate::pac::SPI,

--- a/mcu/atmega-hal/src/usart.rs
+++ b/mcu/atmega-hal/src/usart.rs
@@ -9,14 +9,14 @@ pub type UsartWriter<USART, RX, TX, CLOCK> =
 pub type UsartReader<USART, RX, TX, CLOCK> =
     avr_hal_generic::usart::UsartReader<crate::Atmega, USART, RX, TX, CLOCK>;
 
-#[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb", feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega168", feature = "atmega324pa", feature = "atmega328p", feature = "atmega328pb", feature = "atmega1284p"))]
 pub type Usart0<CLOCK> = Usart<
     crate::pac::USART0,
     port::Pin<port::mode::Input, port::PD0>,
     port::Pin<port::mode::Output, port::PD1>,
     CLOCK,
 >;
-#[cfg(any(feature = "atmega168", feature = "atmega328p", feature = "atmega328pb", feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega168", feature = "atmega324pa", feature = "atmega328p", feature = "atmega328pb", feature = "atmega1284p"))]
 avr_hal_generic::impl_usart_traditional! {
     hal: crate::Atmega,
     peripheral: crate::pac::USART0,
@@ -41,14 +41,14 @@ avr_hal_generic::impl_usart_traditional! {
     tx: port::PB3,
 }
 
-#[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560", feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega32u4", feature = "atmega324pa", feature = "atmega1280", feature = "atmega2560", feature = "atmega1284p"))]
 pub type Usart1<CLOCK> = Usart<
     crate::pac::USART1,
     port::Pin<port::mode::Input, port::PD2>,
     port::Pin<port::mode::Output, port::PD3>,
     CLOCK,
 >;
-#[cfg(any(feature = "atmega32u4", feature = "atmega1280", feature = "atmega2560", feature = "atmega1284p"))]
+#[cfg(any(feature = "atmega32u4", feature = "atmega324pa", feature = "atmega1280", feature = "atmega2560", feature = "atmega1284p"))]
 avr_hal_generic::impl_usart_traditional! {
     hal: crate::Atmega,
     peripheral: crate::pac::USART1,


### PR DESCRIPTION
This PR add support for the atmega324pa based on the microcontrollers of the same family the atmega1284p.
It depends on this [PR](https://github.com/Rahix/avr-device/pull/119) in avr-device.