### PR TITLE
Upgrade rust-toolchain.toml to fix CVE-2022-46176

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-07-10"
+channel = "nightly-2023-01-10"
 components = [ "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
This upgrades the used Rust toolchain to fix CVE-2022-46176, a security bug with SSH host key checking in cargo.

I haven't tested it fully, so I understand if you don't want to incorporate it yet.  Because it's such a jump in versions, it may create other issues.  You have a larger community of great users, maybe some can test it before pushing it to main.

I'd love for more selective cherry-picking of patches in Rust, but this is the world we live in.

Have a great day, and thank you for this wonderful project!