### PR TITLE
Add support for Arduino Duemilanove (328p version).

### DIFF
--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -21,6 +21,7 @@ pub fn get_board(board: &str) -> Option<Box<dyn Board>> {
         "trinket-pro" => Box::new(TrinketPro),
         "trinket" => Box::new(Trinket),
         "nano168" => Box::new(Nano168),
+        "duemilanove" => Box::new(ArduinoDuemilanove),
         _ => return None,
     })
 }
@@ -382,6 +383,32 @@ impl Board for Nano168 {
             partno: "atmega168",
             baudrate: Some(19200),
             do_chip_erase: false,
+        }
+    }
+
+    fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
+        Some(Err(anyhow::anyhow!("Not able to guess port")))
+    }
+}
+
+
+struct ArduinoDuemilanove;
+
+impl Board for ArduinoDuemilanove {
+    fn display_name(&self) -> &str {
+        "Arduino Duemilanove"
+    }
+
+    fn needs_reset(&self) -> Option<&str> {
+        None
+    }
+
+    fn avrdude_options(&self) -> avrdude::AvrdudeOptions {
+        avrdude::AvrdudeOptions {
+            programmer: "arduino",
+            partno: "atmega328p",
+            baudrate: Some(57600),
+            do_chip_erase: true,
         }
     }
 

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -64,6 +64,7 @@ struct Args {
     /// * trinket-pro
     /// * trinket
     /// * nano168
+    /// * duemilanove
     #[structopt(name = "BOARD", verbatim_doc_comment)]
     board: String,
 


### PR DESCRIPTION
AIUI, the 328p version of the Duemilanove is essentially an Arduino Nano with a barrel jack. I want to add it because for better or worse, it is the only board I have :P (aside from a Sparkfun kit which only has ISP headers... btw, could `ravedude` in principle support "Arduino as ISP" or other programmers?).