### PR TITLE
ravedude: Fix support for nix flakes on darwin

### DIFF
--- a/ravedude/README.md
+++ b/ravedude/README.md
@@ -24,9 +24,7 @@ Next, install the latest version from crates.io with the following command:
 cargo install ravedude
 ```
 
-(alternatively, if you're using NixOS + Flakes, you can install `ravedude` by
-adding `inputs.ravedude.url = "github:Rahix/avr-hal?dir=ravedude";` and then
-`environment.systemPackages = [ ravedude.defaultPackage."${system}" ];`.)
+Alternatively, if you're using Nix (the package manager) + Flakes, you can install `ravedude` by adding `inputs.ravedude.url = "github:Rahix/avr-hal?dir=ravedude";` and use the package `ravedude.packages."${system}".default`.
 
 Now you need to add *ravedude* to your project.  For example in a project for
 Arduino Uno, place the following into your `.cargo/config.toml` (**not in

--- a/ravedude/flake.lock
+++ b/ravedude/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1655042882,
-        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "lastModified": 1679567394,
+        "narHash": "sha256-ZvLuzPeARDLiQUt6zSZFGOs+HZmE+3g4QURc8mkBsfM=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "rev": "88cd22380154a2c36799fe8098888f0f59861a15",
         "type": "github"
       },
       "original": {
@@ -21,8 +21,8 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-O3wncIouj9x7gBPntzHeK/Hkmm9M1SGlYq7JI7saTAE=",
-        "path": "/nix/store/d84iknazpzwbjbj1j9zh9wnh6v6dzlfb-source",
+        "narHash": "sha256-eOnCn0o3I6LP48fAi8xWFcn49V2rL7oX5jCtJTeN1LI=",
+        "path": "/nix/store/jcb1zr0g47d0cd13jfvg64fwczy2cfd7-source",
         "type": "path"
       },
       "original": {
@@ -33,8 +33,8 @@
     "nixpkgs_2": {
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-O3wncIouj9x7gBPntzHeK/Hkmm9M1SGlYq7JI7saTAE=",
-        "path": "/nix/store/d84iknazpzwbjbj1j9zh9wnh6v6dzlfb-source",
+        "narHash": "sha256-eOnCn0o3I6LP48fAi8xWFcn49V2rL7oX5jCtJTeN1LI=",
+        "path": "/nix/store/jcb1zr0g47d0cd13jfvg64fwczy2cfd7-source",
         "type": "path"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1680776469,
+        "narHash": "sha256-3CXUDK/3q/kieWtdsYpDOBJw3Gw4Af6x+2EiSnIkNQw=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "411e8764155aa9354dbcd6d5faaeb97e9e3dce24",
         "type": "github"
       },
       "original": {

--- a/ravedude/flake.nix
+++ b/ravedude/flake.nix
@@ -18,13 +18,15 @@
 
         naersk' = pkgs.callPackage naersk {};
 
+        lib = pkgs.lib;
+
       in
       rec {
-        defaultPackage = naersk'.buildPackage {
+        packages.default = naersk'.buildPackage {
           pname = "ravedude";
           src = ./.;
 
-          buildInputs = with pkgs; [
+          buildInputs = with pkgs; lib.optionals pkgs.stdenv.isLinux [
             pkg-config
             udev
           ];


### PR DESCRIPTION
Previously, the `ravedude` would not install via nix flakes on Darwin / MacOS as the build dependencies unconditionally included `udev`, which is not available and not needed on Darwin. Other than this, nothing prevents it from being built and installed on Darwin.

But this is easily fixed with a check for the platform. So with this PR, `ravedude` can be installed via nix flakes on both Linux and Darwin.