### PR TITLE
uno: Eeprom example fix

### DIFF
--- a/examples/arduino-uno/src/bin/uno-eeprom.rs
+++ b/examples/arduino-uno/src/bin/uno-eeprom.rs
@@ -17,7 +17,10 @@ fn main() -> ! {
     let ep_capacity = ep.capacity();
     ufmt::uwriteln!(&mut serial, "eeprom capacity is:{}\r", ep_capacity).void_unwrap();
 
-    let mut data = [0_u8; arduino_hal::Eeprom::CAPACITY as usize];
+    // KNOWN ISSUE: Avoid to read entire eeprom capacity at once
+    // See: https://github.com/Rahix/avr-hal/issues/410
+    let mut data = [0_u8; 10];
+    
     let _start_address: u16 = 0;
 
     if ep.read(0, &mut data).is_err() {


### PR DESCRIPTION
This is just a *fast fix*. So users can avoid experiencing a bug at first place.