### PR TITLE
Upgrade to rust nightly 2023-08-08

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-07-10"
+channel = "nightly-2023-08-08"
 components = [ "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
With https://github.com/rust-lang/rust/pull/106619 merged, we can finally start moving forward with the toolchain again.  Upgrade to the latest version and see how things go.