### PR TITLE
Support the SparkFun ProMini 5V

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
             name: sparkfun-promicro
             examples: true
           - type: board
+            name: sparkfun-promini-5v
+            examples: true
+          - type: board
             name: trinket-pro
             examples: true
           - type: board

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "examples/arduino-uno",
     "examples/nano168",
     "examples/sparkfun-promicro",
+    "examples/sparkfun-promini-5v",
     "examples/trinket-pro",
     "examples/trinket",
 ]

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -21,6 +21,7 @@ arduino-nano = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-
 arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 trinket-pro = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
+sparkfun-promini-5v = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 trinket = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
 nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", "board-selected"]
 

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -21,7 +21,7 @@ arduino-nano = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-
 arduino-uno = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 trinket-pro = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
 sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
-sparkfun-promini-5v = ["mcu-atmega", "atmega-hal/atmega328p", "board-selected"]
+sparkfun-promini-5v = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-adc", "board-selected"]
 trinket = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
 nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", "board-selected"]
 

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -22,6 +22,7 @@ pub(crate) mod default {
         feature = "arduino-nano",
         feature = "arduino-uno",
         feature = "sparkfun-promicro",
+        feature = "sparkfun-promini-5v",
         feature = "trinket-pro",
         feature = "nano168",
     ))]

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(feature = "arduino-nano", doc = "**Arduino Nano**.")]
 #![cfg_attr(feature = "arduino-uno", doc = "**Arduino Uno**.")]
 #![cfg_attr(feature = "sparkfun-promicro", doc = "**SparkFun ProMicro**.")]
+#![cfg_attr(feature = "sparkfun-promini-5v", doc = "**SparkFun ProMini 5V (16MHz)**.")]
 #![cfg_attr(feature = "trinket-pro", doc = "**Trinket Pro**.")]
 #![cfg_attr(feature = "trinket", doc = "**Trinket**.")]
 #![cfg_attr(feature = "nano168", doc = "**Nano clone (ATmega168)**.")]
@@ -59,6 +60,7 @@ compile_error!(
     * arduino-nano
     * arduino-uno
     * sparkfun-promicro
+    * sparkfun-promini-5v
     * trinket-pro
     * trinket
     * nano168
@@ -257,7 +259,7 @@ macro_rules! default_serial {
         )
     };
 }
-#[cfg(any(feature = "arduino-nano", feature = "nano168"))]
+#[cfg(any(feature = "arduino-nano", feature = "nano168", feature = "sparkfun-promini-5v"))]
 #[macro_export]
 macro_rules! default_serial {
     ($p:expr, $pins:expr, $baud:expr) => {

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -27,9 +27,9 @@ pub use leonardo::*;
 mod mega;
 #[cfg(any(feature = "arduino-mega2560", feature = "arduino-mega1280"))]
 pub use mega::*;
-#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168"))]
+#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168", feature = "sparkfun-promini-5v"))]
 mod uno;
-#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168"))]
+#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168", feature = "sparkfun-promini-5v"))]
 pub use uno::*;
 #[cfg(feature = "sparkfun-promicro")]
 mod promicro;

--- a/arduino-hal/src/port/uno.rs
+++ b/arduino-hal/src/port/uno.rs
@@ -3,7 +3,7 @@ pub use atmega_hal::port::{mode, Pin, PinOps, PinMode};
 avr_hal_generic::renamed_pins! {
     type Pin = Pin;
 
-    /// Pins of the **Arduino Uno**.
+    /// Pins of the **Arduino Uno**, **Arduino Nano**, and **SparkFun ProMini 5V (16MHz)**.
     ///
     /// This struct is best initialized via the [`arduino_hal::pins!()`][crate::pins] macro.
     pub struct Pins from atmega_hal::Pins {

--- a/examples/sparkfun-promini-5v/.cargo/config.toml
+++ b/examples/sparkfun-promini-5v/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-atmega328p.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "ravedude promini-5v"
+
+[unstable]
+build-std = ["core"]

--- a/examples/sparkfun-promini-5v/Cargo.toml
+++ b/examples/sparkfun-promini-5v/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sparkfun-promini-5v-examples"
+version = "0.0.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+ufmt = "0.1.0"
+nb = "0.1.2"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["sparkfun-promini-5v"]

--- a/examples/sparkfun-promini-5v/src/bin/promini-5v-blink.rs
+++ b/examples/sparkfun-promini-5v/src/bin/promini-5v-blink.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    // Digital pin 13 is also connected to an onboard LED marked "L"
+    let mut led = pins.d13.into_output();
+    led.set_high();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(800);
+    }
+}

--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -18,6 +18,7 @@ pub fn get_board(board: &str) -> Option<Box<dyn Board>> {
         "mega1280" => Box::new(ArduinoMega1280),
         "diecimila" => Box::new(ArduinoDiecimila),
         "promicro" => Box::new(SparkFunProMicro),
+        "promini-5v" => Box::new(SparkFunProMini5V),
         "trinket-pro" => Box::new(TrinketPro),
         "trinket" => Box::new(Trinket),
         "nano168" => Box::new(Nano168),
@@ -313,6 +314,31 @@ impl Board for SparkFunProMicro {
             (0x1B4F, 0x9203), //3.3V
             (0x1B4F, 0x9204), //3.3V
         ]))
+    }
+}
+
+struct SparkFunProMini5V;
+
+impl Board for SparkFunProMini5V {
+    fn display_name(&self) -> &str {
+        "SparkFun Pro Mini 5V (16MHz)"
+    }
+
+    fn needs_reset(&self) -> Option<&str> {
+        None
+    }
+
+    fn avrdude_options(&self) -> avrdude::AvrdudeOptions {
+        avrdude::AvrdudeOptions {
+            programmer: "arduino",
+            partno: "atmega328p",
+            baudrate: Some(57600),
+            do_chip_erase: true,
+        }
+    }
+
+    fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
+        Some(find_port_from_vid_pid_list(&[(0x0403, 0x6001)]))
     }
 }
 

--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -338,7 +338,7 @@ impl Board for SparkFunProMini5V {
     }
 
     fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
-        Some(find_port_from_vid_pid_list(&[(0x0403, 0x6001)]))
+        Some(Err(anyhow::anyhow!("Not able to guess port")))
     }
 }
 

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -61,6 +61,7 @@ struct Args {
     /// * mega1280
     /// * diecimila
     /// * promicro
+    /// * promini-5v
     /// * trinket-pro
     /// * trinket
     /// * nano168


### PR DESCRIPTION
This PR adds a new feature to *arduino-hal*, `sparkfun-promini-5v`, and a new board to ravedude, `promini-5v`. It is a copy, in nearly all respects, of the Arduino Nano implementation. I have used [this datasheet](https://cdn.sparkfun.com/assets/d/5/2/f/0/ProMini16MHzv2.pdf) as reference.

In the ravedude board config `SparkFunProMini5V` I  have implemented `guess_port` with a VID/PID pair I derived experimentally from my Pro Mini*, but I'm not sure if that is the correct approach.

Related issue: #425

*It is listed in <http://www.linux-usb.org/usb.ids> as "FT232 Serial (UART) IC" by FTDI.