### PR TITLE
Update ufmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,3 @@ exclude = [
     # The RAVEDUDE! Yeah!
     "ravedude",
 ]
-
-[patch.crates-io]
-# XXX: Temporary fix for avr-rust/rust#148
-ufmt = { git = "https://github.com/Rahix/ufmt.git", rev = "12225dc1678e42fecb0e8635bf80f501e24817d9" }

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -28,7 +28,7 @@ nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", 
 [dependencies]
 cfg-if = "1"
 embedded-hal = "0.2.3"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 
 [dependencies.void]
 version = "1.0.2"

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "0.1.7"
 nb = "0.1.2"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 paste = "1.0.0"
 avr-device = "0.5.1"
 embedded-storage = "0.2"

--- a/examples/arduino-diecimila/Cargo.toml
+++ b/examples/arduino-diecimila/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 

--- a/examples/arduino-leonardo/Cargo.toml
+++ b/examples/arduino-leonardo/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 

--- a/examples/arduino-mega1280/Cargo.toml
+++ b/examples/arduino-mega1280/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 

--- a/examples/arduino-mega2560/Cargo.toml
+++ b/examples/arduino-mega2560/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 

--- a/examples/arduino-nano/Cargo.toml
+++ b/examples/arduino-nano/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 pwm-pca9685 = "0.3.1"

--- a/examples/nano168/Cargo.toml
+++ b/examples/nano168/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 

--- a/examples/sparkfun-promicro/Cargo.toml
+++ b/examples/sparkfun-promicro/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 

--- a/examples/sparkfun-promini-5v/Cargo.toml
+++ b/examples/sparkfun-promini-5v/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 nb = "0.1.2"
 embedded-hal = "0.2.3"
 


### PR DESCRIPTION
This project is currently depending on fork of a relatively old version of `ufmt`. The reason for that fork and the hack doesn't seem to exist anymore as [the rust legacy fork issue 148](https://github.com/avr-rust/rust-legacy-fork/issues/148) was closed as being unreproducible over 3 years ago. 

This change updates `ufmt` to the latest version. 