### PR TITLE
attiny84a: add eeprom support

### DIFF
--- a/mcu/attiny-hal/Cargo.toml
+++ b/mcu/attiny-hal/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 rt = ["avr-device/rt"]
 device-selected = []
 attiny84 = ["avr-device/attiny84", "device-selected"]
+attiny84a = ["avr-device/attiny84a", "device-selected"]
 attiny85 = ["avr-device/attiny85", "device-selected"]
 attiny88 = ["avr-device/attiny88", "device-selected"]
 attiny167 = ["avr-device/attiny167", "device-selected"]

--- a/mcu/attiny-hal/src/adc.rs
+++ b/mcu/attiny-hal/src/adc.rs
@@ -68,6 +68,7 @@ pub mod channel {
     pub struct Temperature;
 }
 
+#[cfg(not(feature = "attiny84a"))]
 fn apply_clock(peripheral: &crate::pac::ADC, settings: AdcSettings) {
     peripheral.adcsra.write(|w| {
         w.aden().set_bit();

--- a/mcu/attiny-hal/src/eeprom.rs
+++ b/mcu/attiny-hal/src/eeprom.rs
@@ -24,6 +24,17 @@ avr_hal_generic::impl_eeprom_attiny! {
     },
 }
 
+#[cfg(feature = "attiny84a")]
+avr_hal_generic::impl_eeprom_attiny! {
+    hal: crate::Attiny,
+    peripheral: crate::pac::EEPROM,
+    capacity: 512,
+    addr_width: u16,
+    set_address: |peripheral, address| {
+        peripheral.eear.write(|w| w.bits(address));
+    },
+}
+
 #[cfg(feature = "attiny88")]
 avr_hal_generic::impl_eeprom_attiny! {
     hal: crate::Attiny,

--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -5,6 +5,7 @@
 //! Common HAL (hardware abstraction layer) for ATtiny* microcontrollers.
 //!
 //! **Note**: This version of the documentation was built for
+#![cfg_attr(feature = "attiny84a", doc = "**ATtiny84a**.")]
 #![cfg_attr(feature = "attiny85", doc = "**ATtiny85**.")]
 #![cfg_attr(feature = "attiny88", doc = "**ATtiny88**.")]
 #![cfg_attr(feature = "attiny167", doc = "**ATtiny167**.")]
@@ -25,6 +26,7 @@ compile_error!(
 
     Please select one of the following
 
+    * attiny84a
     * attiny85
     * attiny88
     * attiny167
@@ -34,6 +36,9 @@ compile_error!(
 
 #[cfg(feature = "attiny84")]
 pub use avr_device::attiny84 as pac;
+
+#[cfg(feature = "attiny84a")]
+pub use avr_device::attiny84a as pac;
 
 /// Reexport of `attiny85` from `avr-device`
 #[cfg(feature = "attiny85")]
@@ -90,6 +95,13 @@ pub use eeprom::Eeprom;
 pub struct Attiny;
 
 #[cfg(feature = "attiny84")]
+#[macro_export]
+macro_rules! pins {
+    ($p:expr) => {
+        $crate::Pins::new($p.PORTA, $p.PORTB)
+    };
+}
+#[cfg(feature = "attiny84a")]
 #[macro_export]
 macro_rules! pins {
     ($p:expr) => {

--- a/mcu/attiny-hal/src/port.rs
+++ b/mcu/attiny-hal/src/port.rs
@@ -24,6 +24,13 @@ avr_hal_generic::impl_port_traditional! {
         B: crate::pac::PORTB = [0, 1, 2, 3],
     }
 }
+#[cfg(feature = "attiny84a")]
+avr_hal_generic::impl_port_traditional! {
+    enum Ports {
+        A: crate::pac::PORTA = [0, 1, 2, 3, 4, 5, 6, 7],
+        B: crate::pac::PORTB = [0, 1, 2, 3],
+    }
+}
 
 #[cfg(feature = "attiny85")]
 avr_hal_generic::impl_port_traditional! {


### PR DESCRIPTION
## Overview

These changes add the ATtiny84a chip with EEPROM support.

## Status

These changes are blocked on [attiny84a support](https://github.com/Rahix/avr-device/pull/143) in [avr-device](https://github.com/Rahix/avr-device). Once that PR is merged, a new version is released, and the [avr-hal](https://github.com/Rahix/avr-hal) packages rely on that new version, these changes will be ready for proper review.

## Risks

I'm not very familiar with this library yet, and my confidence in the correctness of these changes is low. I've only tested these changes with an ATtiny84a - there may be unintentional side effects for other chips.

In one case, I had to include the config attribute `#[cfg(not(feature = "attiny84a"))]`. I assume there's a better option available, perhaps by implementing the `prescaler_n` functions for the Attiny84a. I am unsure how to do this - is there some documentation I'm missing?

## Testing

Locally, I've modified the relevant `Cargo.toml` files to target [the relevant `avr-hal` version](https://github.com/Rahix/avr-device/pull/143). Then, I was able to successfully read from and write to the EEPROM with the `avr_hal_generic` and `attiny_hal` libraries. I've included a simplified example below, and the full code can be found [here](https://github.com/MichaelDarr/liclock/tree/main/firmware) (this code in this repo is very messy - it's a proof of concept which will be fully rewritten).

```rust
use attiny_hal;
use avr_device::attiny84a;
use avr_hal_generic;

type Eeprom = avr_hal_generic::eeprom::Eeprom<attiny_hal::Attiny, attiny84a::EEPROM>;

#[avr_device::entry]
fn main() -> ! {
    let dp = attiny84a::Peripherals::take().unwrap();
    let eeprom = Eeprom::new(dp.EEPROM);

    let mut read_data = [0_u8; 16];
    if eeprom.read(0, &mut read_data).is_err() {
        panic!("eeprom read failed")
    }

    let mut write_data = [0_u8; 16];
    if eeprom.read(0, &mut write_data).is_err() {
        panic!("eeprom write failed")
    }
}
```