### PR TITLE
add note about `winget` to README (for windows installations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Install dependencies:
   ```
 - Windows
 
-  Install [Scoop](https://scoop.sh/) using Powershell
+  Use [`winget`](https://learn.microsoft.com/en-us/windows/package-manager/winget/) on Windows 10 & Windows 11:
+  ```
+  winget install AVRDudes.AVRDUDE ZakKemble.avr-gcc
+  ```
+  On older systems you can use [Scoop](https://scoop.sh/) which you first have to install using Powershell:
   ```PowerShell
   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser # Needed to run a remote script the first time
   irm get.scoop.sh | iex


### PR DESCRIPTION
[winget] is the official command-line package manager for Windows starting with Windows 10, thus there's no need to use 3rd party package managers anymore.
both `avr-gcc` and `avrdude` are packaged in winget.

installing them this way works fine and no further manual modifications of the environment are needed (tested in Git Bash and Powershell).

the note about scoop has been left in the README as i wasn't sure whether there were still any `var-hal` users left on older Windows releases, though at some point it can/should be removed for being obsolete.

[winget]: https://learn.microsoft.com/en-us/windows/package-manager/winget/