### PR TITLE
Add support for Adafruit Circuit Playground Classic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "examples/arduino-mega1280",
     "examples/arduino-nano",
     "examples/arduino-uno",
+    "examples/circuit-playground-classic",
     "examples/nano168",
     "examples/sparkfun-promicro",
     "examples/sparkfun-promini-5v",

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -24,6 +24,7 @@ sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 sparkfun-promini-5v = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-adc", "board-selected"]
 trinket = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
 nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", "board-selected"]
+circuit-playground-classic = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 
 [dependencies]
 cfg-if = "1"

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -27,6 +27,9 @@ pub(crate) mod default {
         feature = "nano168",
     ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz16;
-    #[cfg(feature = "trinket")]
+    #[cfg(any(
+        feature = "trinket",
+        feature = "circuit-playground-classic",
+    ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz8;
 }

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -17,6 +17,7 @@
 #![cfg_attr(feature = "trinket-pro", doc = "**Trinket Pro**.")]
 #![cfg_attr(feature = "trinket", doc = "**Trinket**.")]
 #![cfg_attr(feature = "nano168", doc = "**Nano clone (ATmega168)**.")]
+#![cfg_attr(feature = "circuit-playground-classic", doc = "**Adafruit Circuit Playground Classic (ATmega32u4)**.")]
 //! This means that only items which are available for this board are visible.  If you are using a
 //! different board, try building the documentation locally with
 //!
@@ -64,6 +65,7 @@ compile_error!(
     * trinket-pro
     * trinket
     * nano168
+    * circuit-playground-classic
     "
 );
 

--- a/arduino-hal/src/port/circuit_playground_classic.rs
+++ b/arduino-hal/src/port/circuit_playground_classic.rs
@@ -1,0 +1,18 @@
+pub use atmega_hal::port::{mode, Pin, PinMode, PinOps};
+
+avr_hal_generic::renamed_pins! {
+    /// Pins of the **Circuit Playground Classic**.
+    ///
+    /// This struct is best initialized via the [`arduino_hal::pins!()`][crate::pins] macro.
+    pub struct Pins {
+        /// `#11`: `PB7`
+        pub d11: atmega_hal::port::PB7 = pb7,
+        /// `#13`: `PC7`, Builtin LED
+        pub d13: atmega_hal::port::PC7 = pc7,
+    }
+
+    impl Pins {
+        type Pin = Pin;
+        type McuPins = atmega_hal::Pins;
+    }
+}

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -43,3 +43,7 @@ pub use trinket_pro::*;
 mod trinket;
 #[cfg(feature = "trinket")]
 pub use trinket::*;
+#[cfg(feature = "circuit-playground-classic")]
+mod circuit_playground_classic;
+#[cfg(feature = "circuit-playground-classic")]
+pub use circuit_playground_classic::*;

--- a/examples/circuit-playground-classic/.cargo/config.toml
+++ b/examples/circuit-playground-classic/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-atmega32u4.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "ravedude circuit-playground-classic"
+
+[unstable]
+build-std = ["core"]

--- a/examples/circuit-playground-classic/Cargo.toml
+++ b/examples/circuit-playground-classic/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "circuit-playground-classic-examples"
+version = "0.0.0"
+authors = ["Danilo Bargen <mail@dbrgn.ch>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+embedded-hal = "0.2.3"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal"
+features = ["circuit-playground-classic"]

--- a/examples/circuit-playground-classic/src/bin/circuit-playground-classic-blink.rs
+++ b/examples/circuit-playground-classic/src/bin/circuit-playground-classic-blink.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    // Device peripherals
+    let dp = arduino_hal::Peripherals::take().unwrap();
+
+    let pins = arduino_hal::pins!(dp);
+
+    // Digital pin 13 is also connected to an onboard LED
+    let mut led = pins.d13.into_output();
+    led.set_high();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(100);
+        led.toggle();
+        arduino_hal::delay_ms(800);
+    }
+}

--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -23,6 +23,7 @@ pub fn get_board(board: &str) -> Option<Box<dyn Board>> {
         "trinket" => Box::new(Trinket),
         "nano168" => Box::new(Nano168),
         "duemilanove" => Box::new(ArduinoDuemilanove),
+        "circuit-playground-classic" => Box::new(CircuitPlaygroundClassic),
         _ => return None,
     })
 }
@@ -440,5 +441,32 @@ impl Board for ArduinoDuemilanove {
 
     fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
         Some(Err(anyhow::anyhow!("Not able to guess port")))
+    }
+}
+
+struct CircuitPlaygroundClassic;
+
+impl Board for CircuitPlaygroundClassic {
+    fn display_name(&self) -> &str {
+        "Circuit Playground Classic"
+    }
+
+    fn needs_reset(&self) -> Option<&str> {
+        Some("Reset the board by pressing the reset button once.")
+    }
+
+    fn dude_options(&self) -> avrdude::AvrdudeOptions {
+        avrdude::AvrdudeOptions {
+            programmer: "avr109",
+            partno: "atmega32u4",
+            baudrate: None,
+            do_chip_erase: true,
+        }
+    }
+
+    fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
+        Some(find_port_from_vid_pid_list(&[
+            (0x239a, 0x8011),
+        ]))
     }
 }


### PR DESCRIPTION
This should add support for the Adafruit Circuit Playground Classic (atmega32u4): https://www.adafruit.com/product/3000

The place where I'm stuck is uploading. Flashing via ravedude results in:

```
avrdude error: programmer is not responding
avrdude warning: attempt 1 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 2 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 3 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 4 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 5 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 6 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 7 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 8 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 9 of 10: not in sync: resp=0x00
avrdude error: programmer is not responding
avrdude warning: attempt 10 of 10: not in sync: resp=0x00
avrdude error: unable to open programmer arduino on port /dev/ttyACM0

avrdude done.  Thank you.
```

When I run the avrdude command manually:

    avrdude -v -patmega32u4 -cavr109 -P/dev/ttyACM0 -b57600 -D -Uflash:w:/home/danilo/Projects/avr-hal/target/avr-atmega32u4/debug/circuit-playground-classic-blink.elf:i

...I get the same result.

However, flashing via Arduino IDE works fine. When I look at Arduino IDE logs, the invocation is the same, but there's a reset sequence first:

```
Forcing reset using 1200bps open/close on port /dev/ttyACM0
PORTS {/dev/ttyACM0, /dev/ttyS0, /dev/ttyUSB0, /dev/ttyUSB1, } / {/dev/ttyS0, /dev/ttyUSB0, /dev/ttyUSB1, } => {}
PORTS {/dev/ttyS0, /dev/ttyUSB0, /dev/ttyUSB1, } / {/dev/ttyS0, /dev/ttyUSB0, /dev/ttyUSB1, } => {}
PORTS {/dev/ttyS0, /dev/ttyUSB0, /dev/ttyUSB1, } / {/dev/ttyACM0, /dev/ttyS0, /dev/ttyUSB0, /dev/ttyUSB1, } => {/dev/ttyACM0, }
Found upload port: /dev/ttyACM0
//bin/avrdude -C//etc/avrdude.conf -v -patmega32u4 -cavr109 -P/dev/ttyACM0 -b57600 -D -Uflash:w:/tmp/arduino_build_486653/Blink.ino.hex:i
...
avrdude done.  Thank you.
```

Does ravedude support such a reset sequence somehow?