### PR TITLE
add initial `embedded-hal` v1 implementations for pins, delays & PWM

### DIFF
--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -27,8 +27,12 @@ nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", 
 
 [dependencies]
 cfg-if = "1"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
 ufmt = "0.2.0"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.void]
 version = "1.0.2"

--- a/arduino-hal/src/delay.rs
+++ b/arduino-hal/src/delay.rs
@@ -1,4 +1,4 @@
-use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal_v0::blocking::delay::{DelayMs, DelayUs};
 
 /// Delay type for `embedded-hal` compatibility.
 ///

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -11,9 +11,11 @@ ufmt = "0.2.0"
 paste = "1.0.0"
 avr-device = "0.5.3"
 embedded-storage = "0.2"
+embedded-hal = "1.0.0-rc.3"
 
-[dependencies.embedded-hal]
+[dependencies.embedded-hal-v0]
 version = "0.2.3"
+package = "embedded-hal"
 features = ["unproven"]
 
 [dependencies.void]

--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -1,7 +1,8 @@
 //! Delay implementations
 
 use core::marker;
-use hal::blocking::delay;
+use hal::blocking::delay as delay_v0;
+use embedded_hal::delay::DelayNs;
 
 #[cfg(all(target_arch = "avr", avr_hal_asm_macro))]
 use core::arch::asm;
@@ -76,7 +77,7 @@ cfg_if::cfg_if! {
 }
 
 // Clock-Specific Delay Implementations ----------------------------------- {{{
-impl delay::DelayUs<u16> for Delay<crate::clock::MHz24> {
+impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz24> {
     fn delay_us(&mut self, mut us: u16) {
         // for the 24 crate::clock::MHz clock for the aventurous ones, trying to overclock
 
@@ -99,7 +100,7 @@ impl delay::DelayUs<u16> for Delay<crate::clock::MHz24> {
     }
 }
 
-impl delay::DelayUs<u16> for Delay<crate::clock::MHz20> {
+impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz20> {
     fn delay_us(&mut self, mut us: u16) {
         // for the 20 crate::clock::MHz clock on rare Arduino boards
 
@@ -133,7 +134,7 @@ impl delay::DelayUs<u16> for Delay<crate::clock::MHz20> {
     }
 }
 
-impl delay::DelayUs<u16> for Delay<crate::clock::MHz16> {
+impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz16> {
     fn delay_us(&mut self, mut us: u16) {
         // for the 16 crate::clock::MHz clock on most Arduino boards
 
@@ -157,7 +158,7 @@ impl delay::DelayUs<u16> for Delay<crate::clock::MHz16> {
     }
 }
 
-impl delay::DelayUs<u16> for Delay<crate::clock::MHz12> {
+impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz12> {
     fn delay_us(&mut self, mut us: u16) {
         // for the 12 crate::clock::MHz clock if somebody is working with USB
 
@@ -181,7 +182,7 @@ impl delay::DelayUs<u16> for Delay<crate::clock::MHz12> {
     }
 }
 
-impl delay::DelayUs<u16> for Delay<crate::clock::MHz8> {
+impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz8> {
     fn delay_us(&mut self, mut us: u16) {
         // for the 8 crate::clock::MHz internal clock
 
@@ -205,7 +206,7 @@ impl delay::DelayUs<u16> for Delay<crate::clock::MHz8> {
     }
 }
 
-impl delay::DelayUs<u16> for Delay<crate::clock::MHz1> {
+impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz1> {
     fn delay_us(&mut self, mut us: u16) {
         // for the 1 crate::clock::MHz internal clock (default settings for common Atmega microcontrollers)
 
@@ -219,9 +220,9 @@ impl delay::DelayUs<u16> for Delay<crate::clock::MHz1> {
 
         // compensate for the time taken by the preceeding and next commands (about 22 cycles)
         us -= 22; // = 2 cycles
-                  // the following loop takes 4 microseconds (4 cycles)
-                  // per iteration, so execute it us/4 times
-                  // us is at least 4, divided by 4 gives us 1 (no zero delay bug)
+        // the following loop takes 4 microseconds (4 cycles)
+        // per iteration, so execute it us/4 times
+        // us is at least 4, divided by 4 gives us 1 (no zero delay bug)
         us >>= 2; // us div 4, = 4 cycles
 
         busy_loop(us);
@@ -230,18 +231,18 @@ impl delay::DelayUs<u16> for Delay<crate::clock::MHz1> {
 
 // ------------------------------------------------------------------------ }}}
 
-impl<SPEED> delay::DelayUs<u8> for Delay<SPEED>
-where
-    Delay<SPEED>: delay::DelayUs<u16>,
+impl<SPEED> delay_v0::DelayUs<u8> for Delay<SPEED>
+    where
+        Delay<SPEED>: delay_v0::DelayUs<u16>,
 {
     fn delay_us(&mut self, us: u8) {
-        delay::DelayUs::<u16>::delay_us(self, us as u16);
+        delay_v0::DelayUs::<u16>::delay_us(self, us as u16);
     }
 }
 
-impl<SPEED> delay::DelayUs<u32> for Delay<SPEED>
-where
-    Delay<SPEED>: delay::DelayUs<u16>,
+impl<SPEED> delay_v0::DelayUs<u32> for Delay<SPEED>
+    where
+        Delay<SPEED>: delay_v0::DelayUs<u16>,
 {
     fn delay_us(&mut self, us: u32) {
         // TODO: Somehow fix the overhead induced by this loop
@@ -252,27 +253,51 @@ where
         let iters = us >> 12;
         let mut i = 0;
         while i < iters {
-            delay::DelayUs::<u16>::delay_us(self, 0xfff);
+            delay_v0::DelayUs::<u16>::delay_us(self, 0xfff);
             i += 1;
         }
-        delay::DelayUs::<u16>::delay_us(self, (us & 0xfff) as u16);
+        delay_v0::DelayUs::<u16>::delay_us(self, (us & 0xfff) as u16);
     }
 }
 
-impl<SPEED> delay::DelayMs<u16> for Delay<SPEED>
-where
-    Delay<SPEED>: delay::DelayUs<u32>,
+impl<SPEED> delay_v0::DelayMs<u16> for Delay<SPEED>
+    where
+        Delay<SPEED>: delay_v0::DelayUs<u32>,
 {
     fn delay_ms(&mut self, ms: u16) {
-        delay::DelayUs::<u32>::delay_us(self, ms as u32 * 1000);
+        delay_v0::DelayUs::<u32>::delay_us(self, ms as u32 * 1000);
     }
 }
 
-impl<SPEED> delay::DelayMs<u8> for Delay<SPEED>
-where
-    Delay<SPEED>: delay::DelayMs<u16>,
+impl<SPEED> delay_v0::DelayMs<u8> for Delay<SPEED>
+    where
+        Delay<SPEED>: delay_v0::DelayMs<u16>,
 {
     fn delay_ms(&mut self, ms: u8) {
-        delay::DelayMs::<u16>::delay_ms(self, ms as u16);
+        delay_v0::DelayMs::<u16>::delay_ms(self, ms as u16);
+    }
+}
+
+impl<SPEED> DelayNs for Delay<SPEED>
+    where
+        Delay<SPEED>: delay_v0::DelayUs<u16>, {
+    fn delay_ns(&mut self, ns: u32) {
+        // quick-win to get an initial implementation.
+        // note that the trait does not guarantee nanosecond-accuracy.
+
+        let mut us = ns / 1000;
+
+        // ensure that we wait _at least_ as long as specified.
+        // (we truncate the integer, so if we don't do this we'd wait 1us instead of 2us when specifying 1999ns).
+        let diff = ns - (us * 1000);
+        if diff > 0 {
+            us += 1;
+        }
+
+        delay_v0::DelayUs::<u32>::delay_us(self, us);
+    }
+
+    fn delay_us(&mut self, us: u32) {
+        delay_v0::DelayUs::<u32>::delay_us(self, us);
     }
 }

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(avr_hal_asm_macro, feature(asm_experimental_arch))]
 #![cfg_attr(not(avr_hal_asm_macro), feature(llvm_asm))]
 
-pub extern crate embedded_hal as hal;
+pub extern crate embedded_hal_v0 as hal;
 
 #[doc(hidden)]
 pub extern crate avr_device;

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -3,7 +3,7 @@
 //! Please take a look at the documentation for [`Pin`] for a detailed explanation.
 
 use core::marker::PhantomData;
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal_v0::digital::v2::{InputPin, OutputPin};
 
 pub trait PinMode: crate::Sealed {}
 /// GPIO pin modes

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -3,7 +3,8 @@
 //! Please take a look at the documentation for [`Pin`] for a detailed explanation.
 
 use core::marker::PhantomData;
-use embedded_hal_v0::digital::v2::{InputPin, OutputPin};
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin, StatefulOutputPin};
+use embedded_hal_v0::digital::v2::{InputPin as InputPinV0, OutputPin as OutputPinV0};
 
 pub trait PinMode: crate::Sealed {}
 /// GPIO pin modes
@@ -318,8 +319,8 @@ impl<PIN: PinOps> Pin<mode::Output, PIN> {
     }
 }
 
-// Implements OutputPin from embedded-hal to make sure external libraries work
-impl<PIN: PinOps> OutputPin for Pin<mode::Output, PIN> {
+// Implements OutputPinV0 from embedded-hal to make sure external libraries work
+impl<PIN: PinOps> OutputPinV0 for Pin<mode::Output, PIN> {
     type Error = core::convert::Infallible;
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
@@ -330,6 +331,30 @@ impl<PIN: PinOps> OutputPin for Pin<mode::Output, PIN> {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         self.set_low();
         Ok(())
+    }
+}
+
+impl<PIN: PinOps> ErrorType for Pin<mode::Output, PIN> { type Error = core::convert::Infallible; }
+
+impl<PIN: PinOps> OutputPin for Pin<mode::Output, PIN> {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_low();
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_high();
+        Ok(())
+    }
+}
+
+impl<PIN: PinOps> StatefulOutputPin for Pin<mode::Output, PIN> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_set_high())
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_set_low())
     }
 }
 
@@ -364,8 +389,8 @@ impl<PIN: PinOps> Pin<mode::OpenDrain, PIN> {
     }
 }
 
-// Implements OutputPin from embedded-hal to make sure external libraries work
-impl<PIN: PinOps> OutputPin for Pin<mode::OpenDrain, PIN> {
+// Implements OutputPinV0 from embedded-hal to make sure external libraries work
+impl<PIN: PinOps> OutputPinV0 for Pin<mode::OpenDrain, PIN> {
     type Error = core::convert::Infallible;
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
@@ -379,8 +404,30 @@ impl<PIN: PinOps> OutputPin for Pin<mode::OpenDrain, PIN> {
     }
 }
 
-// Implements InputPin from embedded-hal to make sure external libraries work
-impl<PIN: PinOps> InputPin for Pin<mode::OpenDrain, PIN> {
+impl<PIN: PinOps> OutputPin for Pin<mode::OpenDrain, PIN> {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_low();
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_high();
+        Ok(())
+    }
+}
+
+impl<PIN: PinOps> StatefulOutputPin for Pin<mode::OpenDrain, PIN> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_high())
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_low())
+    }
+}
+
+// Implements InputPinV0 from embedded-hal to make sure external libraries work
+impl<PIN: PinOps> InputPinV0 for Pin<mode::OpenDrain, PIN> {
     type Error = core::convert::Infallible;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -392,8 +439,20 @@ impl<PIN: PinOps> InputPin for Pin<mode::OpenDrain, PIN> {
     }
 }
 
-// Implements InputPin from embedded-hal to make sure external libraries work
-impl<PIN: PinOps, IMODE: mode::InputMode> InputPin for Pin<mode::Input<IMODE>, PIN> {
+impl<PIN: PinOps> ErrorType for Pin<mode::OpenDrain, PIN> { type Error = core::convert::Infallible; }
+
+impl<PIN: PinOps> InputPin for Pin<mode::OpenDrain, PIN> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_high())
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_low())
+    }
+}
+
+// Implements InputPinV0 from embedded-hal to make sure external libraries work
+impl<PIN: PinOps, IMODE: mode::InputMode> InputPinV0 for Pin<mode::Input<IMODE>, PIN> {
     type Error = core::convert::Infallible;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -402,6 +461,18 @@ impl<PIN: PinOps, IMODE: mode::InputMode> InputPin for Pin<mode::Input<IMODE>, P
 
     fn is_low(&self) -> Result<bool, Self::Error> {
         Ok(self.is_low())
+    }
+}
+
+impl<PIN: PinOps, IMODE: mode::InputMode> ErrorType for Pin<mode::Input<IMODE>, PIN> { type Error = core::convert::Infallible; }
+
+impl<PIN: PinOps, IMODE: mode::InputMode> InputPin for Pin<mode::Input<IMODE>, PIN> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_high())
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_low())
     }
 }
 

--- a/avr-hal-generic/src/simple_pwm.rs
+++ b/avr-hal-generic/src/simple_pwm.rs
@@ -1,6 +1,8 @@
 //! PWM Implementation
 
 use core::marker::PhantomData;
+use embedded_hal::pwm;
+use embedded_hal::pwm::{ErrorKind, ErrorType, SetDutyCycle};
 
 use crate::port::mode;
 use crate::port::Pin;
@@ -79,6 +81,35 @@ impl<TC, PIN: PwmPinOps<TC>> Pin<mode::PwmOutput<TC>, PIN> {
 
     pub fn set_duty(&mut self, duty: u8) {
         self.pin.set_duty(duty);
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum PwmError {
+    /// `embedded-hal` supports duty cycles up to `u16`, however `avr` devices only support up to `u8`.
+    /// Passing a duty cycle larger than [`u8::MAX`] will result in this error.
+    DutyCycleTooLarge,
+}
+
+impl pwm::Error for PwmError {
+    fn kind(&self) -> ErrorKind {
+        ErrorKind::Other
+    }
+}
+
+impl<TC, PIN: PwmPinOps<TC>> ErrorType for Pin<mode::PwmOutput<TC>, PIN> { type Error = PwmError; }
+
+impl<TC, PIN: PwmPinOps<TC, Duty=u8>> SetDutyCycle for Pin<mode::PwmOutput<TC>, PIN> {
+    fn max_duty_cycle(&self) -> u16 {
+        self.get_max_duty() as u16
+    }
+
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        if duty > u8::MAX as u16 {
+            return Err(PwmError::DutyCycleTooLarge);
+        }
+        self.set_duty(duty as u8);
+        Ok(())
     }
 }
 

--- a/avr-hal-generic/src/spi.rs
+++ b/avr-hal-generic/src/spi.rs
@@ -1,7 +1,7 @@
 //! SPI Implementation
 use crate::port;
 use core::marker::PhantomData;
-use embedded_hal::spi;
+use embedded_hal_v0::spi;
 
 /// Oscillator Clock Frequency division options.
 ///

--- a/avr-hal-generic/src/usart.rs
+++ b/avr-hal-generic/src/usart.rs
@@ -375,7 +375,7 @@ impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> hal::serial::Read<u8>
 /// Created by calling [`Usart::split`].  Splitting a peripheral into reader and writer allows
 /// concurrently receiving and transmitting data from different contexts.
 ///
-/// The writer half most notably implements [`embedded_hal::serial::Write`] and [`ufmt::uWrite`]
+/// The writer half most notably implements [`embedded_hal_v0::serial::Write`] and [`ufmt::uWrite`]
 /// for transmitting data.
 pub struct UsartWriter<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> {
     p: USART,
@@ -390,7 +390,7 @@ pub struct UsartWriter<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> {
 /// Created by calling [`Usart::split`].  Splitting a peripheral into reader and writer allows
 /// concurrently receiving and transmitting data from different contexts.
 ///
-/// The reader half most notably implements [`embedded_hal::serial::Read`] for receiving data.
+/// The reader half most notably implements [`embedded_hal_v0::serial::Read`] for receiving data.
 pub struct UsartReader<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> {
     p: USART,
     rx: RX,

--- a/examples/arduino-diecimila/Cargo.toml
+++ b/examples/arduino-diecimila/Cargo.toml
@@ -9,7 +9,11 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/arduino-diecimila/src/bin/diecimila-spi-feedback.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-spi-feedback.rs
@@ -17,7 +17,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-use embedded_hal::spi::FullDuplex;
+use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]

--- a/examples/arduino-diecimila/src/bin/diecimila-usart.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/examples/arduino-leonardo/Cargo.toml
+++ b/examples/arduino-leonardo/Cargo.toml
@@ -9,7 +9,11 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/arduino-leonardo/src/bin/leonardo-spi-feedback.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-spi-feedback.rs
@@ -17,7 +17,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-use embedded_hal::spi::FullDuplex;
+use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]

--- a/examples/arduino-leonardo/src/bin/leonardo-usart.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/examples/arduino-mega1280/Cargo.toml
+++ b/examples/arduino-mega1280/Cargo.toml
@@ -9,7 +9,11 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/arduino-mega1280/src/bin/mega1280-usart.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/examples/arduino-mega1280/src/bin/mega1280spi-feedback.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280spi-feedback.rs
@@ -17,7 +17,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-use embedded_hal::spi::FullDuplex;
+use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]

--- a/examples/arduino-mega2560/Cargo.toml
+++ b/examples/arduino-mega2560/Cargo.toml
@@ -9,7 +9,11 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
@@ -17,7 +17,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-use embedded_hal::spi::FullDuplex;
+use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]

--- a/examples/arduino-mega2560/src/bin/mega2560-usart.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/examples/arduino-nano/Cargo.toml
+++ b/examples/arduino-nano/Cargo.toml
@@ -9,7 +9,11 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -9,10 +9,14 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
 pwm-pca9685 = "0.3.1"
 infrared = "0.14.1"
 embedded-storage = "0.2"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/arduino-uno/src/bin/uno-blink-embedded-hal.rs
+++ b/examples/arduino-uno/src/bin/uno-blink-embedded-hal.rs
@@ -1,0 +1,39 @@
+/*!
+ * Blink the builtin LED - the "Hello World" of embedded programming, but with a twist:
+ * the blink function is not aware of `avr-hal` and only uses `embedded-hal` traits.
+ */
+#![no_std]
+#![no_main]
+
+use embedded_hal::delay::DelayNs;
+use embedded_hal::digital::OutputPin;
+
+use panic_halt as _;
+
+fn blink(led: &mut impl OutputPin, delay: &mut impl DelayNs) -> ! {
+    loop {
+        // TODO: once embedded-hal v1.0.0 is released switch to `StatefulOutputPin` & use `toggle` (not part of RC 3)
+        led.set_low().unwrap();
+        delay.delay_ms(100);
+        led.set_high().unwrap();
+        delay.delay_ms(100);
+        led.set_low().unwrap();
+        delay.delay_ms(100);
+        led.set_high().unwrap();
+        delay.delay_ms(800);
+    }
+}
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    // Digital pin 13 is also connected to an onboard LED marked "L"
+    let mut led = pins.d13.into_output();
+    led.set_high();
+
+    let mut delay = arduino_hal::Delay::new();
+
+    blink(&mut led, &mut delay);
+}

--- a/examples/arduino-uno/src/bin/uno-millis.rs
+++ b/examples/arduino-uno/src/bin/uno-millis.rs
@@ -16,7 +16,7 @@ use arduino_hal::prelude::*;
 use core::cell;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 // Possible Values:
 //

--- a/examples/arduino-uno/src/bin/uno-simple-pwm-embedded-hal.rs
+++ b/examples/arduino-uno/src/bin/uno-simple-pwm-embedded-hal.rs
@@ -1,0 +1,36 @@
+/*!
+ * Example of using simple_pwm to fade a LED in and out on pin d5, but with a twist:
+ * the fade function is not aware of `avr-hal` and only uses `embedded-hal` traits.
+ */
+#![no_std]
+#![no_main]
+
+use embedded_hal::delay::DelayNs;
+use embedded_hal::pwm::SetDutyCycle;
+use arduino_hal::simple_pwm::*;
+use panic_halt as _;
+
+fn fade(led: &mut impl SetDutyCycle, delay: &mut impl DelayNs) -> ! {
+    loop {
+        for pct in (0..=100).chain((0..100).rev()) {
+            led.set_duty_cycle_percent(pct).unwrap();
+            delay.delay_ms(10);
+        }
+    }
+}
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    let timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Prescale64);
+
+    // Digital pin 5 is connected to a LED and a resistor in series
+    let mut pwm_led = pins.d5.into_output().into_pwm(&timer0);
+    pwm_led.enable();
+
+    let mut delay = arduino_hal::Delay::new();
+
+    fade(&mut pwm_led, &mut delay);
+}

--- a/examples/arduino-uno/src/bin/uno-spi-feedback.rs
+++ b/examples/arduino-uno/src/bin/uno-spi-feedback.rs
@@ -16,7 +16,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-use embedded_hal::spi::FullDuplex;
+use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -7,7 +7,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/examples/nano168/Cargo.toml
+++ b/examples/nano168/Cargo.toml
@@ -10,7 +10,11 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/nano168/src/bin/nano168-millis.rs
+++ b/examples/nano168/src/bin/nano168-millis.rs
@@ -14,7 +14,7 @@ use arduino_hal::prelude::*;
 use core::cell;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 // Possible Values:
 //

--- a/examples/nano168/src/bin/nano168-usart.rs
+++ b/examples/nano168/src/bin/nano168-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/examples/sparkfun-promicro/Cargo.toml
+++ b/examples/sparkfun-promicro/Cargo.toml
@@ -9,7 +9,11 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/sparkfun-promicro/src/bin/promicro-spi-feedback.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-spi-feedback.rs
@@ -17,7 +17,7 @@
 
 use arduino_hal::prelude::*;
 use arduino_hal::spi;
-use embedded_hal::spi::FullDuplex;
+use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
 
 #[arduino_hal::entry]

--- a/examples/sparkfun-promicro/src/bin/promicro-usart.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-usart.rs
@@ -4,7 +4,7 @@
 use arduino_hal::prelude::*;
 use panic_halt as _;
 
-use embedded_hal::serial::Read;
+use embedded_hal_v0::serial::Read;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/examples/sparkfun-promini-5v/Cargo.toml
+++ b/examples/sparkfun-promini-5v/Cargo.toml
@@ -9,7 +9,11 @@ publish = false
 panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/trinket-pro/Cargo.toml
+++ b/examples/trinket-pro/Cargo.toml
@@ -7,7 +7,11 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"

--- a/examples/trinket/Cargo.toml
+++ b/examples/trinket/Cargo.toml
@@ -7,7 +7,11 @@ publish = false
 
 [dependencies]
 panic-halt = "0.2.0"
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0-rc.3"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
 
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"


### PR DESCRIPTION
this is a first step towards implementing `embedded-hal` v1 traits.

see the individual commit messages for further details.

this is as far as i'll take it in terms of implementation, as i only have an arduino uno lying around and currently don't have any peripherals to test with. however, this is a starting point for others to add the trait implementations which they'll need.

namely the SPI & I2C traits are not implemented. all other traits from `embedded-hal` should be implemented with this PR. note that some traits from v0 were moved to other crates (e.g. `embedded-io`) or were removed in v1.

see also #468