### PR TITLE
update to Rust Edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ exclude = [
     # The RAVEDUDE! Yeah!
     "ravedude",
 ]
+resolver = "2"

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arduino-hal"
 version = "0.1.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["rt"]

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -2,7 +2,7 @@
 name = "avr-hal-generic"
 version = "0.1.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cfg-if = "0.1.7"

--- a/examples/arduino-diecimila/Cargo.toml
+++ b/examples/arduino-diecimila/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arduino-diecimila-examples"
 version = "0.0.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/arduino-leonardo/Cargo.toml
+++ b/examples/arduino-leonardo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arduino-leonardo-examples"
 version = "0.0.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/arduino-mega1280/Cargo.toml
+++ b/examples/arduino-mega1280/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arduino-mega1280-examples"
 version = "0.0.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/arduino-mega2560/Cargo.toml
+++ b/examples/arduino-mega2560/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arduino-mega2560-examples"
 version = "0.0.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/arduino-nano/Cargo.toml
+++ b/examples/arduino-nano/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arduino-nano-examples"
 version = "0.0.0"
 authors = ["David R. Morrison <drmorr@evokewonder.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arduino-uno-examples"
 version = "0.0.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/nano168/Cargo.toml
+++ b/examples/nano168/Cargo.toml
@@ -3,7 +3,7 @@ name = "nano168-examples"
 description = "Examples for the arduino clones with Atmega168 chip"
 version = "0.0.0"
 authors = ["David R. Morrison <drmorr@evokewonder.com>", "Franz Dietrich <dietrich@teilgedanken.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/sparkfun-promicro/Cargo.toml
+++ b/examples/sparkfun-promicro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sparkfun-promicro-examples"
 version = "0.0.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/sparkfun-promini-5v/Cargo.toml
+++ b/examples/sparkfun-promini-5v/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sparkfun-promini-5v-examples"
 version = "0.0.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/trinket-pro/Cargo.toml
+++ b/examples/trinket-pro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trinket-pro-examples"
 version = "0.0.0"
 authors = ["Gaute Hope <eg@gaute.vetsj.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/examples/trinket/Cargo.toml
+++ b/examples/trinket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trinket-examples"
 version = "0.0.0"
 authors = ["Jan Paw <jpaw@virtuslab.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atmega-hal"
 version = "0.1.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 
 [features]
 rt = ["avr-device/rt"]

--- a/mcu/attiny-hal/Cargo.toml
+++ b/mcu/attiny-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "attiny-hal"
 version = "0.1.0"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 
 [features]
 rt = ["avr-device/rt"]

--- a/ravedude/Cargo.toml
+++ b/ravedude/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ravedude"
 version = "0.1.6"
 authors = ["Rahix <rahix@rahix.de>"]
-edition = "2018"
+edition = "2021"
 description = "Tool to easily flash code onto an AVR microcontroller with avrdude"
 readme = "README.md"
 repository = "https://github.com/Rahix/avr-hal/tree/main/ravedude"


### PR DESCRIPTION
this does not involve any code changes, it just sets the new edition, allowing to use newer features in the future.

as the crate is anyway only compiling with a recent nightly compiler there's no problem with requiring edition 2021 (it was first introduced in Rust 1.56).

note that running `cargo fix --edition` (as suggested by the [migration guide]) isn't possible as workspace-level cargo commands fail in this repository due to the feature flags :(

the resolver has been specified in the workspace due to the following build warning being issued if it's not present:

> warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
> note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
> note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest

[migration guide]: https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html