### PR TITLE
update toolchain to `nightly-2023-12-28`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-08-08"
+channel = "nightly-2023-12-28"
 components = [ "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
today Rust 1.75.0 has been released. this is the basis for the upcoming `embedded-hal` v1.0 release (at least for the `embedded-hal-async` traits). by updating to the latest available nightly build we ensure that it'll be possible to implement these traits in the future.

PS: that doesn't mean that i plan on implementing these traits 😉. i'm just laying the groundwork for whoever wants to do this in the future.