### PR TITLE
migrate `extern crate` to `pub use`

### DIFF
--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -1,7 +1,7 @@
 //! Delay implementations
 
 use core::marker;
-use hal::blocking::delay as delay_v0;
+use embedded_hal_v0::blocking::delay as delay_v0;
 use embedded_hal::delay::DelayNs;
 
 #[cfg(all(target_arch = "avr", avr_hal_asm_macro))]
@@ -18,9 +18,9 @@ use core::arch::asm;
 /// // use attiny_hal as hal;
 ///
 /// use arduino_hal as hal;
-/// use hal::prelude::*;
+/// use embedded_hal_v0::prelude::*;
 ///
-/// let mut delay = hal::delay::Delay::<hal::clock::MHz16>::new();
+/// let mut delay = embedded_hal_v0::delay::Delay::<hal::clock::MHz16>::new();
 ///
 /// // Wait 1 second
 /// delay.delay_ms(1000);

--- a/avr-hal-generic/src/i2c.rs
+++ b/avr-hal-generic/src/i2c.rs
@@ -257,7 +257,7 @@ where
 impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> I2c<H, I2C, SDA, SCL, CLOCK>
 where
     CLOCK: crate::clock::Clock,
-    crate::delay::Delay<CLOCK>: hal::blocking::delay::DelayMs<u16>,
+    crate::delay::Delay<CLOCK>: embedded_hal_v0::blocking::delay::DelayMs<u16>,
 {
     /// Test whether a device answers on a certain address.
     pub fn ping_device(&mut self, address: u8, direction: Direction) -> Result<bool, Error> {
@@ -292,7 +292,7 @@ where
         w: &mut W,
         direction: Direction,
     ) -> Result<(), W::Error> {
-        use hal::blocking::delay::DelayMs;
+        use embedded_hal_v0::blocking::delay::DelayMs;
         let mut delay = crate::delay::Delay::<CLOCK>::new();
 
         w.write_str(
@@ -342,7 +342,7 @@ where
     }
 }
 
-impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> hal::blocking::i2c::Write
+impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> embedded_hal_v0::blocking::i2c::Write
     for I2c<H, I2C, SDA, SCL, CLOCK>
 {
     type Error = Error;
@@ -355,7 +355,7 @@ impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> hal::blocking::i2c::Write
     }
 }
 
-impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> hal::blocking::i2c::Read
+impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> embedded_hal_v0::blocking::i2c::Read
     for I2c<H, I2C, SDA, SCL, CLOCK>
 {
     type Error = Error;
@@ -368,7 +368,7 @@ impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> hal::blocking::i2c::Read
     }
 }
 
-impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> hal::blocking::i2c::WriteRead
+impl<H, I2C: I2cOps<H, SDA, SCL>, SDA, SCL, CLOCK> embedded_hal_v0::blocking::i2c::WriteRead
     for I2c<H, I2C, SDA, SCL, CLOCK>
 {
     type Error = Error;

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -10,8 +10,6 @@ pub use avr_device;
 pub use nb;
 #[doc(hidden)]
 pub use paste;
-#[doc(hidden)]
-pub use ufmt;
 
 pub mod adc;
 pub mod clock;

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -2,16 +2,16 @@
 #![cfg_attr(avr_hal_asm_macro, feature(asm_experimental_arch))]
 #![cfg_attr(not(avr_hal_asm_macro), feature(llvm_asm))]
 
-pub extern crate embedded_hal_v0 as hal;
+pub use embedded_hal_v0 as hal;
 
 #[doc(hidden)]
-pub extern crate avr_device;
+pub use avr_device;
 #[doc(hidden)]
-pub extern crate nb;
+pub use nb;
 #[doc(hidden)]
-pub extern crate paste;
+pub use paste;
 #[doc(hidden)]
-pub extern crate ufmt;
+pub use ufmt;
 
 pub mod adc;
 pub mod clock;
@@ -26,7 +26,7 @@ pub mod wdt;
 
 /// Prelude containing all HAL traits
 pub mod prelude {
-    pub use hal::prelude::*;
+    pub use crate::hal::prelude::*;
     pub use ufmt::uWrite as _ufmt_uWrite;
     pub use unwrap_infallible::UnwrapInfallible as _unwrap_infallible_UnwrapInfallible;
 }

--- a/avr-hal-generic/src/spi.rs
+++ b/avr-hal-generic/src/spi.rs
@@ -85,7 +85,7 @@ pub trait SpiOps<H, SCLK, MOSI, MISO, CS> {
 /// output pin, because it implements all the same traits from embedded-hal.
 pub struct ChipSelectPin<CSPIN>(port::Pin<port::mode::Output, CSPIN>);
 
-impl<CSPIN: port::PinOps> hal::digital::v2::OutputPin for ChipSelectPin<CSPIN> {
+impl<CSPIN: port::PinOps> embedded_hal_v0::digital::v2::OutputPin for ChipSelectPin<CSPIN> {
     type Error = core::convert::Infallible;
     fn set_low(&mut self) -> Result<(), Self::Error> {
         self.0.set_low();
@@ -97,7 +97,7 @@ impl<CSPIN: port::PinOps> hal::digital::v2::OutputPin for ChipSelectPin<CSPIN> {
     }
 }
 
-impl<CSPIN: port::PinOps> hal::digital::v2::StatefulOutputPin for ChipSelectPin<CSPIN> {
+impl<CSPIN: port::PinOps> embedded_hal_v0::digital::v2::StatefulOutputPin for ChipSelectPin<CSPIN> {
     fn is_set_low(&self) -> Result<bool, Self::Error> {
         Ok(self.0.is_set_low())
     }
@@ -106,7 +106,7 @@ impl<CSPIN: port::PinOps> hal::digital::v2::StatefulOutputPin for ChipSelectPin<
     }
 }
 
-impl<CSPIN: port::PinOps> hal::digital::v2::ToggleableOutputPin for ChipSelectPin<CSPIN> {
+impl<CSPIN: port::PinOps> embedded_hal_v0::digital::v2::ToggleableOutputPin for ChipSelectPin<CSPIN> {
     type Error = core::convert::Infallible;
     fn toggle(&mut self) -> Result<(), Self::Error> {
         self.0.toggle();
@@ -267,7 +267,7 @@ where
 }
 
 /// Default Transfer trait implementation. Only 8-bit word size is supported for now.
-impl<H, SPI, SCLKPIN, MOSIPIN, MISOPIN, CSPIN> hal::blocking::spi::transfer::Default<u8>
+impl<H, SPI, SCLKPIN, MOSIPIN, MISOPIN, CSPIN> embedded_hal_v0::blocking::spi::transfer::Default<u8>
     for Spi<H, SPI, SCLKPIN, MOSIPIN, MISOPIN, CSPIN>
 where
     SPI: SpiOps<H, SCLKPIN, MOSIPIN, MISOPIN, CSPIN>,
@@ -279,7 +279,7 @@ where
 }
 
 /// Default Write trait implementation. Only 8-bit word size is supported for now.
-impl<H, SPI, SCLKPIN, MOSIPIN, MISOPIN, CSPIN> hal::blocking::spi::write::Default<u8>
+impl<H, SPI, SCLKPIN, MOSIPIN, MISOPIN, CSPIN> embedded_hal_v0::blocking::spi::write::Default<u8>
     for Spi<H, SPI, SCLKPIN, MOSIPIN, MISOPIN, CSPIN>
 where
     SPI: SpiOps<H, SCLKPIN, MOSIPIN, MISOPIN, CSPIN>,

--- a/avr-hal-generic/src/usart.rs
+++ b/avr-hal-generic/src/usart.rs
@@ -346,7 +346,7 @@ impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> ufmt::uWrite for Usart<H, USA
     }
 }
 
-impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> hal::serial::Write<u8>
+impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> embedded_hal_v0::serial::Write<u8>
     for Usart<H, USART, RX, TX, CLOCK>
 {
     type Error = core::convert::Infallible;
@@ -360,7 +360,7 @@ impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> hal::serial::Write<u8>
     }
 }
 
-impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> hal::serial::Read<u8>
+impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> embedded_hal_v0::serial::Read<u8>
     for Usart<H, USART, RX, TX, CLOCK>
 {
     type Error = core::convert::Infallible;
@@ -444,7 +444,7 @@ impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> ufmt::uWrite
     }
 }
 
-impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> hal::serial::Write<u8>
+impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> embedded_hal_v0::serial::Write<u8>
     for UsartWriter<H, USART, RX, TX, CLOCK>
 {
     type Error = core::convert::Infallible;
@@ -458,7 +458,7 @@ impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> hal::serial::Write<u8>
     }
 }
 
-impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> hal::serial::Read<u8>
+impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> embedded_hal_v0::serial::Read<u8>
     for UsartReader<H, USART, RX, TX, CLOCK>
 {
     type Error = core::convert::Infallible;


### PR DESCRIPTION
`extern crate` is from the old rust 2015 edition. since the 2018 edition `extern crate` is no longer needed.
here it was used to re-export certain crates (through `pub extern crate`) which are being referenced mainly in macros (which is why e.g. `paste` is re-exported).
this can also be achieved using `pub use`.

`avr-hal-generic` internally now has to use `crate::hal` in some cases where it could previously just use `hal` as the renaming is now bound to the usage in the crate and not to the imported crate. in most cases i've just replaced `hal::` usage with `embedded_hal_v0::` usage since it makes it more obvious which e-h version it is about (and in the future `hal` should either be removed or be replaced with e-h v1.0).

note: i've explicitly dropped the re-export of `ufmt` as it's not used in this repository and i don't see `ufmt` as an integral part of these crates. consumers can (and should) just add it as their own dependency. this is a breaking change for consumers which currently do something like `use avr_hal_generic::ufmt`.

for external consumers nothing changes besides the removed `ufmt` re-export.