### PR TITLE
remove `void` dep, use `core::convert::Infallible` instead

### DIFF
--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -34,10 +34,6 @@ ufmt = "0.2.0"
 version = "0.2.3"
 package = "embedded-hal"
 
-[dependencies.void]
-version = "1.0.2"
-default-features = false
-
 [dependencies.avr-hal-generic]
 path = "../avr-hal-generic/"
 

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -12,6 +12,7 @@ paste = "1.0.0"
 avr-device = "0.5.3"
 embedded-storage = "0.2"
 embedded-hal = "1.0"
+unwrap-infallible = "0.1.5"
 
 [dependencies.embedded-hal-v0]
 version = "0.2.3"

--- a/avr-hal-generic/Cargo.toml
+++ b/avr-hal-generic/Cargo.toml
@@ -18,9 +18,5 @@ version = "0.2.3"
 package = "embedded-hal"
 features = ["unproven"]
 
-[dependencies.void]
-version = "1.0.2"
-default-features = false
-
 [build-dependencies]
 rustversion = "1.0"

--- a/avr-hal-generic/src/adc.rs
+++ b/avr-hal-generic/src/adc.rs
@@ -132,7 +132,7 @@ impl<H, ADC: AdcOps<H>> AdcChannel<H, ADC> for Channel<H, ADC> {
 /// let voltage = adc.read_blocking(&a0);
 ///
 /// // alternatively, a non-blocking interface exists
-/// let voltage = nb::block!(adc.read_nonblocking(&a0)).unwrap();
+/// let voltage = nb::block!(adc.read_nonblocking(&a0)).unwrap_infallible();
 /// ```
 pub struct Adc<H, ADC: AdcOps<H>, CLOCK> {
     p: ADC,

--- a/avr-hal-generic/src/adc.rs
+++ b/avr-hal-generic/src/adc.rs
@@ -132,7 +132,7 @@ impl<H, ADC: AdcOps<H>> AdcChannel<H, ADC> for Channel<H, ADC> {
 /// let voltage = adc.read_blocking(&a0);
 ///
 /// // alternatively, a non-blocking interface exists
-/// let voltage = nb::block!(adc.read_nonblocking(&a0)).void_unwrap();
+/// let voltage = nb::block!(adc.read_nonblocking(&a0)).unwrap();
 /// ```
 pub struct Adc<H, ADC: AdcOps<H>, CLOCK> {
     p: ADC,
@@ -177,7 +177,7 @@ where
     pub fn read_nonblocking<PIN: AdcChannel<H, ADC>>(
         &mut self,
         pin: &PIN,
-    ) -> nb::Result<u16, void::Void> {
+    ) -> nb::Result<u16, core::convert::Infallible> {
         match (&self.reading_channel, self.p.raw_is_converting()) {
             // Measurement on current pin is ongoing
             (Some(channel), true) if *channel == pin.channel() => Err(nb::Error::WouldBlock),

--- a/avr-hal-generic/src/eeprom.rs
+++ b/avr-hal-generic/src/eeprom.rs
@@ -40,7 +40,7 @@ where
     pub fn new(p: EEPROM) -> Self {
         Self {
             p,
-            _h: ::core::marker::PhantomData,
+            _h: marker::PhantomData,
         }
     }
     #[inline]

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -28,6 +28,7 @@ pub mod wdt;
 pub mod prelude {
     pub use hal::prelude::*;
     pub use ufmt::uWrite as _ufmt_uWrite;
+    pub use unwrap_infallible::UnwrapInfallible as _unwrap_infallible_UnwrapInfallible;
 }
 
 // For making certain traits unimplementable from outside this crate.

--- a/avr-hal-generic/src/lib.rs
+++ b/avr-hal-generic/src/lib.rs
@@ -12,8 +12,6 @@ pub extern crate nb;
 pub extern crate paste;
 #[doc(hidden)]
 pub extern crate ufmt;
-#[doc(hidden)]
-pub extern crate void;
 
 pub mod adc;
 pub mod clock;
@@ -30,8 +28,6 @@ pub mod wdt;
 pub mod prelude {
     pub use hal::prelude::*;
     pub use ufmt::uWrite as _ufmt_uWrite;
-    pub use void::ResultVoidErrExt as _void_ResultVoidErrExt;
-    pub use void::ResultVoidExt as _void_ResultVoidExt;
 }
 
 // For making certain traits unimplementable from outside this crate.

--- a/avr-hal-generic/src/spi.rs
+++ b/avr-hal-generic/src/spi.rs
@@ -193,7 +193,7 @@ where
     }
 
     /// Reconfigure the SPI peripheral after initializing
-    pub fn reconfigure(&mut self, settings: Settings) -> nb::Result<(), crate::void::Void> {
+    pub fn reconfigure(&mut self, settings: Settings) -> nb::Result<(), core::convert::Infallible> {
         // wait for any in-flight writes to complete
         self.flush()?;
         self.p.raw_setup(&settings);
@@ -217,7 +217,7 @@ where
         (self.p, self.sclk, self.mosi, self.miso, cs.0)
     }
 
-    fn flush(&mut self) -> nb::Result<(), void::Void> {
+    fn flush(&mut self) -> nb::Result<(), core::convert::Infallible> {
         if self.write_in_progress {
             if self.p.raw_check_iflag() {
                 self.write_in_progress = false;
@@ -250,7 +250,7 @@ where
     MISOPIN: port::PinOps,
     CSPIN: port::PinOps,
 {
-    type Error = void::Void;
+    type Error = core::convert::Infallible;
 
     /// Sets up the device for transmission and sends the data
     fn send(&mut self, byte: u8) -> nb::Result<(), Self::Error> {

--- a/avr-hal-generic/src/usart.rs
+++ b/avr-hal-generic/src/usart.rs
@@ -4,6 +4,7 @@
 
 use core::cmp::Ordering;
 use core::marker;
+use crate::prelude::*;
 
 use crate::port;
 
@@ -219,11 +220,11 @@ pub trait UsartOps<H, RX, TX> {
 ///     57600.into_baudrate(),
 /// );
 ///
-/// ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+/// ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 ///
 /// loop {
-///     let b = nb::block!(serial.read()).unwrap();
-///     ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+///     let b = nb::block!(serial.read()).unwrap_infallible();
+///     ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
 /// }
 /// ```
 pub struct Usart<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> {
@@ -278,7 +279,7 @@ impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> Usart<H, USART, RX, TX, CLOCK
 
     /// Block until all remaining data has been transmitted.
     pub fn flush(&mut self) {
-        nb::block!(self.p.raw_flush()).unwrap()
+        nb::block!(self.p.raw_flush()).unwrap_infallible()
     }
 
     /// Transmit a byte.
@@ -286,14 +287,14 @@ impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> Usart<H, USART, RX, TX, CLOCK
     /// This method will block until the byte has been enqueued for transmission but **not** until
     /// it was entirely sent.
     pub fn write_byte(&mut self, byte: u8) {
-        nb::block!(self.p.raw_write(byte)).unwrap()
+        nb::block!(self.p.raw_write(byte)).unwrap_infallible()
     }
 
     /// Receive a byte.
     ///
     /// This method will block until a byte could be received.
     pub fn read_byte(&mut self) -> u8 {
-        nb::block!(self.p.raw_read()).unwrap()
+        nb::block!(self.p.raw_read()).unwrap_infallible()
     }
 
     /// Enable the interrupt for [`Event`].
@@ -437,7 +438,7 @@ impl<H, USART: UsartOps<H, RX, TX>, RX, TX, CLOCK> ufmt::uWrite
 
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         for b in s.as_bytes().iter() {
-            nb::block!(self.p.raw_write(*b)).unwrap()
+            nb::block!(self.p.raw_write(*b)).unwrap_infallible()
         }
         Ok(())
     }

--- a/examples/arduino-diecimila/src/bin/diecimila-adc.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-adc.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -17,8 +18,8 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Vbg),
         adc.read_blocking(&adc::channel::Gnd),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
 
     // To store multiple channels in an array, we use the `into_channel()` method.
     let channels: [adc::Channel; 6] = [
@@ -33,10 +34,10 @@ fn main() -> ! {
     loop {
         for (i, ch) in channels.iter().enumerate() {
             let v = adc.read_blocking(ch);
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
         }
 
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-diecimila/src/bin/diecimila-adc.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-adc.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -18,8 +17,8 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Vbg),
         adc.read_blocking(&adc::channel::Gnd),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
 
     // To store multiple channels in an array, we use the `into_channel()` method.
     let channels: [adc::Channel; 6] = [
@@ -34,10 +33,10 @@ fn main() -> ! {
     loop {
         for (i, ch) in channels.iter().enumerate() {
             let v = adc.read_blocking(ch);
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-diecimila/src/bin/diecimila-i2cdetect.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-i2cdetect.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -17,12 +16,12 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
     i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write)
-        .void_unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+        .unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
     i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read)
-        .void_unwrap();
+        .unwrap();
 
     loop {}
 }

--- a/examples/arduino-diecimila/src/bin/diecimila-i2cdetect.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-i2cdetect.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -16,12 +17,12 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
     i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write)
-        .unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
+        .unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
     i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read)
-        .unwrap();
+        .unwrap_infallible();
 
     loop {}
 }

--- a/examples/arduino-diecimila/src/bin/diecimila-spi-feedback.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-spi-feedback.rs
@@ -15,7 +15,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -40,11 +39,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).void_unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).void_unwrap();
+        let data = nb::block!(spi.read()).unwrap();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-diecimila/src/bin/diecimila-spi-feedback.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-spi-feedback.rs
@@ -15,6 +15,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -39,11 +40,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap_infallible();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).unwrap();
+        let data = nb::block!(spi.read()).unwrap_infallible();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-diecimila/src/bin/diecimila-usart.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-usart.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -12,13 +11,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
 
     loop {
         // Read a byte from the serial connection default
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
     }
 }

--- a/examples/arduino-diecimila/src/bin/diecimila-usart.rs
+++ b/examples/arduino-diecimila/src/bin/diecimila-usart.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -11,13 +12,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 
     loop {
         // Read a byte from the serial connection default
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
     }
 }

--- a/examples/arduino-leonardo/src/bin/leonardo-adc.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-adc.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -18,9 +19,9 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         adc.read_blocking(&adc::channel::Temperature),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap_infallible();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -40,10 +41,10 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
         }
 
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-leonardo/src/bin/leonardo-adc.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-adc.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -19,9 +18,9 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         adc.read_blocking(&adc::channel::Temperature),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -41,10 +40,10 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-leonardo/src/bin/leonardo-i2cdetect.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-i2cdetect.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -16,10 +17,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap_infallible();
 
     loop {}
 }

--- a/examples/arduino-leonardo/src/bin/leonardo-i2cdetect.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-i2cdetect.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -17,10 +16,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
 
     loop {}
 }

--- a/examples/arduino-leonardo/src/bin/leonardo-spi-feedback.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-spi-feedback.rs
@@ -15,7 +15,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -40,11 +39,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).void_unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).void_unwrap();
+        let data = nb::block!(spi.read()).unwrap();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-leonardo/src/bin/leonardo-spi-feedback.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-spi-feedback.rs
@@ -15,6 +15,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -39,11 +40,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap_infallible();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).unwrap();
+        let data = nb::block!(spi.read()).unwrap_infallible();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-leonardo/src/bin/leonardo-usart.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-usart.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -11,13 +12,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
     }
 }

--- a/examples/arduino-leonardo/src/bin/leonardo-usart.rs
+++ b/examples/arduino-leonardo/src/bin/leonardo-usart.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -12,13 +11,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
     }
 }

--- a/examples/arduino-mega1280/src/bin/mega1280-adc.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280-adc.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -17,8 +18,8 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Vbg),
         adc.read_blocking(&adc::channel::Gnd),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
 
     // To store multiple channels in an array, we use the `into_channel()` method.
     let channels: [adc::Channel; 16] = [
@@ -43,10 +44,10 @@ fn main() -> ! {
     loop {
         for (i, ch) in channels.iter().enumerate() {
             let v = adc.read_blocking(ch);
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
         }
 
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega1280/src/bin/mega1280-adc.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280-adc.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -18,8 +17,8 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Vbg),
         adc.read_blocking(&adc::channel::Gnd),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
 
     // To store multiple channels in an array, we use the `into_channel()` method.
     let channels: [adc::Channel; 16] = [
@@ -44,10 +43,10 @@ fn main() -> ! {
     loop {
         for (i, ch) in channels.iter().enumerate() {
             let v = adc.read_blocking(ch);
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega1280/src/bin/mega1280-i2cdetect.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280-i2cdetect.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -16,10 +17,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap_infallible();
 
     loop {}
 }

--- a/examples/arduino-mega1280/src/bin/mega1280-i2cdetect.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280-i2cdetect.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -17,10 +16,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
 
     loop {}
 }

--- a/examples/arduino-mega1280/src/bin/mega1280-usart.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280-usart.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -11,13 +12,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
     }
 }

--- a/examples/arduino-mega1280/src/bin/mega1280-usart.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280-usart.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -12,13 +11,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
     }
 }

--- a/examples/arduino-mega1280/src/bin/mega1280spi-feedback.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280spi-feedback.rs
@@ -15,7 +15,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -40,11 +39,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).void_unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).void_unwrap();
+        let data = nb::block!(spi.read()).unwrap();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega1280/src/bin/mega1280spi-feedback.rs
+++ b/examples/arduino-mega1280/src/bin/mega1280spi-feedback.rs
@@ -15,6 +15,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -39,11 +40,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap_infallible();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).unwrap();
+        let data = nb::block!(spi.read()).unwrap_infallible();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-adc.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-adc.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -17,8 +18,8 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Vbg),
         adc.read_blocking(&adc::channel::Gnd),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
 
     // To store multiple channels in an array, we use the `into_channel()` method.
     let channels: [adc::Channel; 16] = [
@@ -43,10 +44,10 @@ fn main() -> ! {
     loop {
         for (i, ch) in channels.iter().enumerate() {
             let v = adc.read_blocking(ch);
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
         }
 
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-adc.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-adc.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -18,8 +17,8 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Vbg),
         adc.read_blocking(&adc::channel::Gnd),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
 
     // To store multiple channels in an array, we use the `into_channel()` method.
     let channels: [adc::Channel; 16] = [
@@ -44,10 +43,10 @@ fn main() -> ! {
     loop {
         for (i, ch) in channels.iter().enumerate() {
             let v = adc.read_blocking(ch);
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-i2cdetect.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-i2cdetect.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -16,10 +17,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap_infallible();
 
     loop {}
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-i2cdetect.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-i2cdetect.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -17,10 +16,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
 
     loop {}
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
@@ -15,7 +15,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -40,11 +39,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).void_unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).void_unwrap();
+        let data = nb::block!(spi.read()).unwrap();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-spi-feedback.rs
@@ -15,6 +15,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -39,11 +40,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap_infallible();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).unwrap();
+        let data = nb::block!(spi.read()).unwrap_infallible();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-usart.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-usart.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -11,13 +12,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
     }
 }

--- a/examples/arduino-mega2560/src/bin/mega2560-usart.rs
+++ b/examples/arduino-mega2560/src/bin/mega2560-usart.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -12,13 +11,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
     }
 }

--- a/examples/arduino-nano/src/bin/nano-adc.rs
+++ b/examples/arduino-nano/src/bin/nano-adc.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -19,9 +18,9 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         adc.read_blocking(&adc::channel::Temperature),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -41,7 +40,7 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
         // Arduino Nano has two more ADC pins A6 and A7.  Accessing them works a bit different from
@@ -50,9 +49,9 @@ fn main() -> ! {
             adc.read_blocking(&adc::channel::ADC6),
             adc.read_blocking(&adc::channel::ADC7),
         );
-        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).void_unwrap();
+        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).unwrap();
 
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-nano/src/bin/nano-adc.rs
+++ b/examples/arduino-nano/src/bin/nano-adc.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -18,9 +19,9 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         adc.read_blocking(&adc::channel::Temperature),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap_infallible();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -40,7 +41,7 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
         }
 
         // Arduino Nano has two more ADC pins A6 and A7.  Accessing them works a bit different from
@@ -49,9 +50,9 @@ fn main() -> ! {
             adc.read_blocking(&adc::channel::ADC6),
             adc.read_blocking(&adc::channel::ADC7),
         );
-        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).unwrap();
+        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).unwrap_infallible();
 
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-nano/src/bin/nano-panic.rs
+++ b/examples/arduino-nano/src/bin/nano-panic.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 
 // Documentation build does not like this and fails with the following error, even though
 // everything is fine when compiling the binary.
@@ -31,7 +32,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
     // Print out panic location
-    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").unwrap_infallible();
     if let Some(loc) = info.location() {
         ufmt::uwriteln!(
             &mut serial,
@@ -40,7 +41,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
             loc.line(),
             loc.column(),
         )
-        .unwrap();
+        .unwrap_infallible();
     }
 
     // Blink LED rapidly
@@ -57,8 +58,8 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
-    ufmt::uwriteln!(&mut serial, "Panic in 5 seconds!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Panic in 5 seconds!\r").unwrap_infallible();
 
     arduino_hal::delay_ms(5000);
 

--- a/examples/arduino-nano/src/bin/nano-panic.rs
+++ b/examples/arduino-nano/src/bin/nano-panic.rs
@@ -7,7 +7,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 
 // Documentation build does not like this and fails with the following error, even though
 // everything is fine when compiling the binary.
@@ -32,7 +31,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
     // Print out panic location
-    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").unwrap();
     if let Some(loc) = info.location() {
         ufmt::uwriteln!(
             &mut serial,
@@ -41,7 +40,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
             loc.line(),
             loc.column(),
         )
-        .void_unwrap();
+        .unwrap();
     }
 
     // Blink LED rapidly
@@ -58,8 +57,8 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Panic in 5 seconds!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Panic in 5 seconds!\r").unwrap();
 
     arduino_hal::delay_ms(5000);
 

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -28,7 +28,3 @@ version = "0.5.3"
 [dependencies.either]
 version = "1.6.1"
 default-features = false
-
-[dependencies.void]
-version = "*"
-default-features = false

--- a/examples/arduino-uno/src/bin/uno-adc.rs
+++ b/examples/arduino-uno/src/bin/uno-adc.rs
@@ -12,7 +12,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -30,9 +29,9 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         adc.read_blocking(&adc::channel::Temperature),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -52,10 +51,10 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-uno/src/bin/uno-adc.rs
+++ b/examples/arduino-uno/src/bin/uno-adc.rs
@@ -12,6 +12,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -29,9 +30,9 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         adc.read_blocking(&adc::channel::Temperature),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap_infallible();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -51,10 +52,10 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
         }
 
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-uno/src/bin/uno-eeprom.rs
+++ b/examples/arduino-uno/src/bin/uno-eeprom.rs
@@ -4,6 +4,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -14,7 +15,7 @@ fn main() -> ! {
 
     let mut ep = arduino_hal::Eeprom::new(dp.EEPROM);
     let ep_capacity = ep.capacity();
-    ufmt::uwriteln!(&mut serial, "eeprom capacity is:{}\r", ep_capacity).unwrap();
+    ufmt::uwriteln!(&mut serial, "eeprom capacity is:{}\r", ep_capacity).unwrap_infallible();
 
     // KNOWN ISSUE: Avoid to read entire eeprom capacity at once
     // See: https://github.com/Rahix/avr-hal/issues/410
@@ -23,13 +24,13 @@ fn main() -> ! {
     let _start_address: u16 = 0;
 
     if ep.read(0, &mut data).is_err() {
-        ufmt::uwriteln!(&mut serial, "read eeprom fail:\r").unwrap();
+        ufmt::uwriteln!(&mut serial, "read eeprom fail:\r").unwrap_infallible();
         loop {}
     }
 
-    ufmt::uwriteln!(&mut serial, "Got:\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Got:\r").unwrap_infallible();
     for i in data {
-        ufmt::uwriteln!(&mut serial, "{}", i).unwrap();
+        ufmt::uwriteln!(&mut serial, "{}", i).unwrap_infallible();
     }
 
     let _=ep.erase(0, arduino_hal::Eeprom::CAPACITY);

--- a/examples/arduino-uno/src/bin/uno-eeprom.rs
+++ b/examples/arduino-uno/src/bin/uno-eeprom.rs
@@ -4,7 +4,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -15,7 +14,7 @@ fn main() -> ! {
 
     let mut ep = arduino_hal::Eeprom::new(dp.EEPROM);
     let ep_capacity = ep.capacity();
-    ufmt::uwriteln!(&mut serial, "eeprom capacity is:{}\r", ep_capacity).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "eeprom capacity is:{}\r", ep_capacity).unwrap();
 
     // KNOWN ISSUE: Avoid to read entire eeprom capacity at once
     // See: https://github.com/Rahix/avr-hal/issues/410
@@ -24,13 +23,13 @@ fn main() -> ! {
     let _start_address: u16 = 0;
 
     if ep.read(0, &mut data).is_err() {
-        ufmt::uwriteln!(&mut serial, "read eeprom fail:\r").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "read eeprom fail:\r").unwrap();
         loop {}
     }
 
-    ufmt::uwriteln!(&mut serial, "Got:\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Got:\r").unwrap();
     for i in data {
-        ufmt::uwriteln!(&mut serial, "{}", i).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "{}", i).unwrap();
     }
 
     let _=ep.erase(0, arduino_hal::Eeprom::CAPACITY);

--- a/examples/arduino-uno/src/bin/uno-hc-sr04.rs
+++ b/examples/arduino-uno/src/bin/uno-hc-sr04.rs
@@ -13,7 +13,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -50,7 +49,7 @@ fn main() -> ! {
                     &mut serial,
                     "Nothing was detected and jump to outer loop.\r"
                 )
-                .void_unwrap();
+                .unwrap();
                 continue 'outer;
             }
         }
@@ -73,7 +72,7 @@ fn main() -> ! {
                     &mut serial,
                     "Nothing was detected and jump to outer loop.\r"
                 )
-                .void_unwrap();
+                .unwrap();
                 continue 'outer;
             }
             _ => temp_timer / 58,
@@ -88,6 +87,6 @@ fn main() -> ! {
             "Hello, we are {} cms away from target!\r",
             value
         )
-        .void_unwrap();
+        .unwrap();
     }
 }

--- a/examples/arduino-uno/src/bin/uno-hc-sr04.rs
+++ b/examples/arduino-uno/src/bin/uno-hc-sr04.rs
@@ -13,6 +13,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -49,7 +50,7 @@ fn main() -> ! {
                     &mut serial,
                     "Nothing was detected and jump to outer loop.\r"
                 )
-                .unwrap();
+                .unwrap_infallible();
                 continue 'outer;
             }
         }
@@ -72,7 +73,7 @@ fn main() -> ! {
                     &mut serial,
                     "Nothing was detected and jump to outer loop.\r"
                 )
-                .unwrap();
+                .unwrap_infallible();
                 continue 'outer;
             }
             _ => temp_timer / 58,
@@ -87,6 +88,6 @@ fn main() -> ! {
             "Hello, we are {} cms away from target!\r",
             value
         )
-        .unwrap();
+        .unwrap_infallible();
     }
 }

--- a/examples/arduino-uno/src/bin/uno-i2cdetect.rs
+++ b/examples/arduino-uno/src/bin/uno-i2cdetect.rs
@@ -17,7 +17,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -33,12 +32,12 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
     i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write)
-        .void_unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
+        .unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
     i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read)
-        .void_unwrap();
+        .unwrap();
 
     loop {
         arduino_hal::delay_ms(1000);

--- a/examples/arduino-uno/src/bin/uno-i2cdetect.rs
+++ b/examples/arduino-uno/src/bin/uno-i2cdetect.rs
@@ -17,6 +17,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -32,12 +33,12 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
     i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write)
-        .unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
+        .unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
     i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read)
-        .unwrap();
+        .unwrap_infallible();
 
     loop {
         arduino_hal::delay_ms(1000);

--- a/examples/arduino-uno/src/bin/uno-infrared.rs
+++ b/examples/arduino-uno/src/bin/uno-infrared.rs
@@ -27,6 +27,7 @@ use arduino_hal::{
     pac::tc0::tccr0b::CS0_A,
     port::mode::{Floating, Input, Output},
     port::Pin,
+    prelude::*,
 };
 use avr_device::interrupt::Mutex;
 
@@ -77,7 +78,7 @@ fn main() -> ! {
     // Enable interrupts globally
     unsafe { avr_device::interrupt::enable() };
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino and Irdroino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino and Irdroino!\r").unwrap_infallible();
 
     loop {
         if let Some(cmd) = avr_device::interrupt::free(|cs| CMD.borrow(cs).take()) {
@@ -88,7 +89,7 @@ fn main() -> ! {
                 cmd.cmd,
                 cmd.repeat
             )
-            .unwrap();
+            .unwrap_infallible();
         }
 
         arduino_hal::delay_ms(100);

--- a/examples/arduino-uno/src/bin/uno-infrared.rs
+++ b/examples/arduino-uno/src/bin/uno-infrared.rs
@@ -27,7 +27,6 @@ use arduino_hal::{
     pac::tc0::tccr0b::CS0_A,
     port::mode::{Floating, Input, Output},
     port::Pin,
-    prelude::*,
 };
 use avr_device::interrupt::Mutex;
 
@@ -78,7 +77,7 @@ fn main() -> ! {
     // Enable interrupts globally
     unsafe { avr_device::interrupt::enable() };
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino and Irdroino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino and Irdroino!\r").unwrap();
 
     loop {
         if let Some(cmd) = avr_device::interrupt::free(|cs| CMD.borrow(cs).take()) {
@@ -89,7 +88,7 @@ fn main() -> ! {
                 cmd.cmd,
                 cmd.repeat
             )
-            .void_unwrap();
+            .unwrap();
         }
 
         arduino_hal::delay_ms(100);

--- a/examples/arduino-uno/src/bin/uno-millis.rs
+++ b/examples/arduino-uno/src/bin/uno-millis.rs
@@ -12,6 +12,7 @@
 #![no_main]
 #![feature(abi_avr_interrupt)]
 
+use arduino_hal::prelude::*;
 use core::cell;
 use panic_halt as _;
 
@@ -84,9 +85,9 @@ fn main() -> ! {
 
     // Wait for a character and print current time once it is received
     loop {
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         let time = millis();
-        ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).unwrap_infallible();
     }
 }

--- a/examples/arduino-uno/src/bin/uno-millis.rs
+++ b/examples/arduino-uno/src/bin/uno-millis.rs
@@ -12,7 +12,6 @@
 #![no_main]
 #![feature(abi_avr_interrupt)]
 
-use arduino_hal::prelude::*;
 use core::cell;
 use panic_halt as _;
 
@@ -85,9 +84,9 @@ fn main() -> ! {
 
     // Wait for a character and print current time once it is received
     loop {
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         let time = millis();
-        ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).unwrap();
     }
 }

--- a/examples/arduino-uno/src/bin/uno-panic.rs
+++ b/examples/arduino-uno/src/bin/uno-panic.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 
 // Documentation build does not like this and fails with the following error, even though
 // everything is fine when compiling the binary.
@@ -31,7 +32,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
     // Print out panic location
-    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").unwrap_infallible();
     if let Some(loc) = info.location() {
         ufmt::uwriteln!(
             &mut serial,
@@ -40,7 +41,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
             loc.line(),
             loc.column(),
         )
-        .unwrap();
+        .unwrap_infallible();
     }
 
     // Blink LED rapidly
@@ -57,8 +58,8 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
-    ufmt::uwriteln!(&mut serial, "Panic in 5 seconds!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Panic in 5 seconds!\r").unwrap_infallible();
 
     arduino_hal::delay_ms(5000);
 

--- a/examples/arduino-uno/src/bin/uno-panic.rs
+++ b/examples/arduino-uno/src/bin/uno-panic.rs
@@ -7,7 +7,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 
 // Documentation build does not like this and fails with the following error, even though
 // everything is fine when compiling the binary.
@@ -32,7 +31,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
     // Print out panic location
-    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Firmware panic!\r").unwrap();
     if let Some(loc) = info.location() {
         ufmt::uwriteln!(
             &mut serial,
@@ -41,7 +40,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
             loc.line(),
             loc.column(),
         )
-        .void_unwrap();
+        .unwrap();
     }
 
     // Blink LED rapidly
@@ -58,8 +57,8 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Panic in 5 seconds!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Panic in 5 seconds!\r").unwrap();
 
     arduino_hal::delay_ms(5000);
 

--- a/examples/arduino-uno/src/bin/uno-spi-feedback.rs
+++ b/examples/arduino-uno/src/bin/uno-spi-feedback.rs
@@ -14,6 +14,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -38,11 +39,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap_infallible();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).unwrap();
+        let data = nb::block!(spi.read()).unwrap_infallible();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-uno/src/bin/uno-spi-feedback.rs
+++ b/examples/arduino-uno/src/bin/uno-spi-feedback.rs
@@ -14,7 +14,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -39,11 +38,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).void_unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).void_unwrap();
+        let data = nb::block!(spi.read()).unwrap();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/arduino-uno/src/bin/uno-timer.rs
+++ b/examples/arduino-uno/src/bin/uno-timer.rs
@@ -11,6 +11,7 @@ and then modernized to account for API drift since 2020
 
 use arduino_hal::port::mode::Output;
 use arduino_hal::port::Pin;
+use arduino_hal::prelude::*;
 use avr_device::atmega328p::tc1::tccr1b::CS1_A;
 use avr_device::atmega328p::TC1;
 use core::mem;
@@ -29,7 +30,7 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
 
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 
     let led = pins.d13.into_output();
 
@@ -61,7 +62,7 @@ fn main() -> ! {
         "configured timer output compare register = {}",
         tmr1.ocr1a.read().bits()
     )
-    .unwrap();
+    .unwrap_infallible();
 
     loop {
         avr_device::asm::sleep()
@@ -76,7 +77,7 @@ pub const fn calc_overflow(clock_hz: u32, target_hz: u32, prescale: u32) -> u32 
     clock_hz / target_hz / prescale - 1
 }
 
-pub fn rig_timer<W: uWrite<Error = core::convert::Infallible>>(tmr1: &TC1, serial: &mut W) {
+pub fn rig_timer<W: uWrite<Error = ::core::convert::Infallible>>(tmr1: &TC1, serial: &mut W) {
     /*
      https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7810-Automotive-Microcontrollers-ATmega328P_Datasheet.pdf
      section 15.11
@@ -93,7 +94,7 @@ pub fn rig_timer<W: uWrite<Error = core::convert::Infallible>>(tmr1: &TC1, seria
         CS1_A::PRESCALE_1024 => 1024,
         CS1_A::NO_CLOCK | CS1_A::EXT_FALLING | CS1_A::EXT_RISING => {
             uwriteln!(serial, "uhoh, code tried to set the clock source to something other than a static prescaler {}", CLOCK_SOURCE as usize)
-                .unwrap();
+                .unwrap_infallible();
             1
         }
     };
@@ -104,7 +105,7 @@ pub fn rig_timer<W: uWrite<Error = core::convert::Infallible>>(tmr1: &TC1, seria
         "configuring timer output compare register = {}",
         ticks
     )
-    .unwrap();
+    .unwrap_infallible();
 
     tmr1.tccr1a.write(|w| w.wgm1().bits(0b00));
     tmr1.tccr1b.write(|w| {

--- a/examples/arduino-uno/src/bin/uno-timer.rs
+++ b/examples/arduino-uno/src/bin/uno-timer.rs
@@ -11,7 +11,6 @@ and then modernized to account for API drift since 2020
 
 use arduino_hal::port::mode::Output;
 use arduino_hal::port::Pin;
-use arduino_hal::prelude::*;
 use avr_device::atmega328p::tc1::tccr1b::CS1_A;
 use avr_device::atmega328p::TC1;
 use core::mem;
@@ -30,7 +29,7 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
 
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
 
     let led = pins.d13.into_output();
 
@@ -62,7 +61,7 @@ fn main() -> ! {
         "configured timer output compare register = {}",
         tmr1.ocr1a.read().bits()
     )
-    .void_unwrap();
+    .unwrap();
 
     loop {
         avr_device::asm::sleep()
@@ -77,7 +76,7 @@ pub const fn calc_overflow(clock_hz: u32, target_hz: u32, prescale: u32) -> u32 
     clock_hz / target_hz / prescale - 1
 }
 
-pub fn rig_timer<W: uWrite<Error = void::Void>>(tmr1: &TC1, serial: &mut W) {
+pub fn rig_timer<W: uWrite<Error = core::convert::Infallible>>(tmr1: &TC1, serial: &mut W) {
     /*
      https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7810-Automotive-Microcontrollers-ATmega328P_Datasheet.pdf
      section 15.11
@@ -94,7 +93,7 @@ pub fn rig_timer<W: uWrite<Error = void::Void>>(tmr1: &TC1, serial: &mut W) {
         CS1_A::PRESCALE_1024 => 1024,
         CS1_A::NO_CLOCK | CS1_A::EXT_FALLING | CS1_A::EXT_RISING => {
             uwriteln!(serial, "uhoh, code tried to set the clock source to something other than a static prescaler {}", CLOCK_SOURCE as usize)
-                .void_unwrap();
+                .unwrap();
             1
         }
     };
@@ -105,7 +104,7 @@ pub fn rig_timer<W: uWrite<Error = void::Void>>(tmr1: &TC1, serial: &mut W) {
         "configuring timer output compare register = {}",
         ticks
     )
-    .void_unwrap();
+    .unwrap();
 
     tmr1.tccr1a.write(|w| w.wgm1().bits(0b00));
     tmr1.tccr1b.write(|w| {

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -4,6 +4,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -14,13 +15,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
     }
 }

--- a/examples/arduino-uno/src/bin/uno-usart.rs
+++ b/examples/arduino-uno/src/bin/uno-usart.rs
@@ -4,7 +4,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -15,13 +14,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
     }
 }

--- a/examples/nano168/src/bin/nano168-adc.rs
+++ b/examples/nano168/src/bin/nano168-adc.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -18,8 +19,8 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         // The ATmega168 chip does not support the temperature functionality.
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -39,7 +40,7 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
         }
 
         // Nano clone (with ATmega168) has two more ADC pins A6 and A7.  Accessing them works a bit different from
@@ -48,9 +49,9 @@ fn main() -> ! {
             adc.read_blocking(&adc::channel::ADC6),
             adc.read_blocking(&adc::channel::ADC7),
         );
-        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).unwrap();
+        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).unwrap_infallible();
 
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/nano168/src/bin/nano168-adc.rs
+++ b/examples/nano168/src/bin/nano168-adc.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -19,8 +18,8 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         // The ATmega168 chip does not support the temperature functionality.
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -40,7 +39,7 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
         // Nano clone (with ATmega168) has two more ADC pins A6 and A7.  Accessing them works a bit different from
@@ -49,9 +48,9 @@ fn main() -> ! {
             adc.read_blocking(&adc::channel::ADC6),
             adc.read_blocking(&adc::channel::ADC7),
         );
-        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).void_unwrap();
+        ufmt::uwrite!(&mut serial, "A6: {} A7: {}", a6, a7).unwrap();
 
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/nano168/src/bin/nano168-i2cdetect.rs
+++ b/examples/nano168/src/bin/nano168-i2cdetect.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -16,10 +17,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap_infallible();
 
     loop {}
 }

--- a/examples/nano168/src/bin/nano168-i2cdetect.rs
+++ b/examples/nano168/src/bin/nano168-i2cdetect.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -17,10 +16,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
 
     loop {}
 }

--- a/examples/nano168/src/bin/nano168-ldr.rs
+++ b/examples/nano168/src/bin/nano168-ldr.rs
@@ -25,6 +25,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -55,9 +56,9 @@ fn main() -> ! {
         };
 
         // output to the serial
-        ufmt::uwrite!(&mut serial, "This is a {} room! – ", worded).unwrap();
-        ufmt::uwrite!(&mut serial, "Raw value: {} ", sensor_value).unwrap();
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwrite!(&mut serial, "This is a {} room! – ", worded).unwrap_infallible();
+        ufmt::uwrite!(&mut serial, "Raw value: {} ", sensor_value).unwrap_infallible();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
 
         // wait for half a second then measure again
         arduino_hal::delay_ms(500);

--- a/examples/nano168/src/bin/nano168-ldr.rs
+++ b/examples/nano168/src/bin/nano168-ldr.rs
@@ -25,7 +25,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -56,9 +55,9 @@ fn main() -> ! {
         };
 
         // output to the serial
-        ufmt::uwrite!(&mut serial, "This is a {} room! – ", worded).void_unwrap();
-        ufmt::uwrite!(&mut serial, "Raw value: {} ", sensor_value).void_unwrap();
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwrite!(&mut serial, "This is a {} room! – ", worded).unwrap();
+        ufmt::uwrite!(&mut serial, "Raw value: {} ", sensor_value).unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
 
         // wait for half a second then measure again
         arduino_hal::delay_ms(500);

--- a/examples/nano168/src/bin/nano168-millis.rs
+++ b/examples/nano168/src/bin/nano168-millis.rs
@@ -10,7 +10,6 @@
 #![no_main]
 #![feature(abi_avr_interrupt)]
 
-use arduino_hal::prelude::*;
 use core::cell;
 use panic_halt as _;
 
@@ -83,10 +82,10 @@ fn main() -> ! {
 
     // Wait for a character and print current time once it is received
     loop {
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         let time = millis();
-        ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).unwrap();
     }
 }
 

--- a/examples/nano168/src/bin/nano168-millis.rs
+++ b/examples/nano168/src/bin/nano168-millis.rs
@@ -10,6 +10,7 @@
 #![no_main]
 #![feature(abi_avr_interrupt)]
 
+use arduino_hal::prelude::*;
 use core::cell;
 use panic_halt as _;
 
@@ -82,10 +83,10 @@ fn main() -> ! {
 
     // Wait for a character and print current time once it is received
     loop {
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         let time = millis();
-        ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {} after {} ms!\r", b, time).unwrap_infallible();
     }
 }
 

--- a/examples/nano168/src/bin/nano168-usart.rs
+++ b/examples/nano168/src/bin/nano168-usart.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -11,13 +12,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
     }
 }

--- a/examples/nano168/src/bin/nano168-usart.rs
+++ b/examples/nano168/src/bin/nano168-usart.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -12,13 +11,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
     }
 }

--- a/examples/nano168/src/bin/nano168-watchdog.rs
+++ b/examples/nano168/src/bin/nano168-watchdog.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use arduino_hal::hal::wdt;
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -14,22 +13,22 @@ fn main() -> ! {
     let mut led = pins.d13.into_output();
     led.set_high();
 
-    ufmt::uwriteln!(&mut serial, "Setup started...").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Setup started...").unwrap();
 
     for _ in 0..20 {
-        ufmt::uwrite!(&mut serial, ".").void_unwrap();
+        ufmt::uwrite!(&mut serial, ".").unwrap();
         led.toggle();
         arduino_hal::delay_ms(100);
     }
-    ufmt::uwriteln!(&mut serial, "\nEnabling watchdog...").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\nEnabling watchdog...").unwrap();
 
     let mut watchdog = wdt::Wdt::new(dp.WDT, &dp.CPU.mcusr);
     watchdog.start(wdt::Timeout::Ms4000).unwrap();
 
-    ufmt::uwriteln!(&mut serial, "\nWatchdog on watch...").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "\nWatchdog on watch...").unwrap();
 
     loop {
-        ufmt::uwriteln!(&mut serial, "\nWaiting...").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "\nWaiting...").unwrap();
 
         led.toggle();
         arduino_hal::delay_ms(1000);

--- a/examples/nano168/src/bin/nano168-watchdog.rs
+++ b/examples/nano168/src/bin/nano168-watchdog.rs
@@ -2,6 +2,7 @@
 #![no_main]
 
 use arduino_hal::hal::wdt;
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -13,22 +14,22 @@ fn main() -> ! {
     let mut led = pins.d13.into_output();
     led.set_high();
 
-    ufmt::uwriteln!(&mut serial, "Setup started...").unwrap();
+    ufmt::uwriteln!(&mut serial, "Setup started...").unwrap_infallible();
 
     for _ in 0..20 {
-        ufmt::uwrite!(&mut serial, ".").unwrap();
+        ufmt::uwrite!(&mut serial, ".").unwrap_infallible();
         led.toggle();
         arduino_hal::delay_ms(100);
     }
-    ufmt::uwriteln!(&mut serial, "\nEnabling watchdog...").unwrap();
+    ufmt::uwriteln!(&mut serial, "\nEnabling watchdog...").unwrap_infallible();
 
     let mut watchdog = wdt::Wdt::new(dp.WDT, &dp.CPU.mcusr);
     watchdog.start(wdt::Timeout::Ms4000).unwrap();
 
-    ufmt::uwriteln!(&mut serial, "\nWatchdog on watch...").unwrap();
+    ufmt::uwriteln!(&mut serial, "\nWatchdog on watch...").unwrap_infallible();
 
     loop {
-        ufmt::uwriteln!(&mut serial, "\nWaiting...").unwrap();
+        ufmt::uwriteln!(&mut serial, "\nWaiting...").unwrap_infallible();
 
         led.toggle();
         arduino_hal::delay_ms(1000);

--- a/examples/sparkfun-promicro/src/bin/promicro-adc.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-adc.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -18,9 +19,9 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         adc.read_blocking(&adc::channel::Temperature),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap_infallible();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -36,10 +37,10 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
         }
 
-        ufmt::uwriteln!(&mut serial, "").unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/sparkfun-promicro/src/bin/promicro-adc.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-adc.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use arduino_hal::adc;
@@ -19,9 +18,9 @@ fn main() -> ! {
         adc.read_blocking(&adc::channel::Gnd),
         adc.read_blocking(&adc::channel::Temperature),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
+    ufmt::uwriteln!(&mut serial, "Temperature: {}", tmp).unwrap();
 
     let a0 = pins.a0.into_analog_input(&mut adc);
     let a1 = pins.a1.into_analog_input(&mut adc);
@@ -37,10 +36,10 @@ fn main() -> ! {
         ];
 
         for (i, v) in values.iter().enumerate() {
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).void_unwrap();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
-        ufmt::uwriteln!(&mut serial, "").void_unwrap();
+        ufmt::uwriteln!(&mut serial, "").unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/sparkfun-promicro/src/bin/promicro-i2cdetect.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-i2cdetect.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -16,10 +17,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap_infallible();
 
     loop {}
 }

--- a/examples/sparkfun-promicro/src/bin/promicro-i2cdetect.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-i2cdetect.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 #[arduino_hal::entry]
@@ -17,10 +16,10 @@ fn main() -> ! {
         50000,
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).void_unwrap();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").void_unwrap();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap();
 
     loop {}
 }

--- a/examples/sparkfun-promicro/src/bin/promicro-spi-feedback.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-spi-feedback.rs
@@ -15,7 +15,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -40,11 +39,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).void_unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).void_unwrap();
+        let data = nb::block!(spi.read()).unwrap();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/sparkfun-promicro/src/bin/promicro-spi-feedback.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-spi-feedback.rs
@@ -15,6 +15,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use arduino_hal::spi;
 use embedded_hal_v0::spi::FullDuplex;
 use panic_halt as _;
@@ -39,11 +40,11 @@ fn main() -> ! {
 
     loop {
         // Send a byte
-        nb::block!(spi.send(0b00001111)).unwrap();
+        nb::block!(spi.send(0b00001111)).unwrap_infallible();
         // Because MISO is connected to MOSI, the read data should be the same
-        let data = nb::block!(spi.read()).unwrap();
+        let data = nb::block!(spi.read()).unwrap_infallible();
 
-        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap();
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap_infallible();
         arduino_hal::delay_ms(1000);
     }
 }

--- a/examples/sparkfun-promicro/src/bin/promicro-usart.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-usart.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -11,13 +12,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap();
+        let b = nb::block!(serial.read()).unwrap_infallible();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
     }
 }

--- a/examples/sparkfun-promicro/src/bin/promicro-usart.rs
+++ b/examples/sparkfun-promicro/src/bin/promicro-usart.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
 use panic_halt as _;
 
 use embedded_hal_v0::serial::Read;
@@ -12,13 +11,13 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
     let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").void_unwrap();
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).void_unwrap();
+        let b = nb::block!(serial.read()).unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).void_unwrap();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
     }
 }

--- a/mcu/atmega-hal/src/usart.rs
+++ b/mcu/atmega-hal/src/usart.rs
@@ -157,7 +157,7 @@ impl crate::usart::UsartOps<
         self.ucsrb.reset();
     }
 
-    fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), avr_hal_generic::void::Void> {
+    fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
         if self.ucsra.read().udre().bit_is_clear() {
             Err(avr_hal_generic::nb::Error::WouldBlock)
         } else {
@@ -165,7 +165,7 @@ impl crate::usart::UsartOps<
         }
     }
 
-    fn raw_write(&mut self, byte: u8) -> avr_hal_generic::nb::Result<(), avr_hal_generic::void::Void> {
+    fn raw_write(&mut self, byte: u8) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
         // Call flush to make sure the data-register is empty
         self.raw_flush()?;
 
@@ -173,7 +173,7 @@ impl crate::usart::UsartOps<
         Ok(())
     }
 
-    fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, avr_hal_generic::void::Void> {
+    fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, core::convert::Infallible> {
         if self.ucsra.read().rxc().bit_is_clear() {
             return Err(avr_hal_generic::nb::Error::WouldBlock);
         }
@@ -230,7 +230,7 @@ impl crate::usart::UsartOps<
         self.ucsr1b.reset();
     }
 
-    fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), avr_hal_generic::void::Void> {
+    fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
         if self.ucsr1a.read().udre1().bit_is_clear() {
             Err(avr_hal_generic::nb::Error::WouldBlock)
         } else {
@@ -238,7 +238,7 @@ impl crate::usart::UsartOps<
         }
     }
 
-    fn raw_write(&mut self, byte: u8) -> avr_hal_generic::nb::Result<(), avr_hal_generic::void::Void> {
+    fn raw_write(&mut self, byte: u8) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
         // Call flush to make sure the data-register is empty
         self.raw_flush()?;
 
@@ -246,7 +246,7 @@ impl crate::usart::UsartOps<
         Ok(())
     }
 
-    fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, avr_hal_generic::void::Void> {
+    fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, core::convert::Infallible> {
         if self.ucsr1a.read().rxc1().bit_is_clear() {
             return Err(avr_hal_generic::nb::Error::WouldBlock);
         }
@@ -304,7 +304,7 @@ impl crate::usart::UsartOps<
         self.ucsr0b.reset();
     }
 
-    fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), avr_hal_generic::void::Void> {
+    fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
         if self.ucsr0a.read().udre0().bit_is_clear() {
             Err(avr_hal_generic::nb::Error::WouldBlock)
         } else {
@@ -312,7 +312,7 @@ impl crate::usart::UsartOps<
         }
     }
 
-    fn raw_write(&mut self, byte: u8) -> avr_hal_generic::nb::Result<(), avr_hal_generic::void::Void> {
+    fn raw_write(&mut self, byte: u8) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
         // Call flush to make sure the data-register is empty
         self.raw_flush()?;
 
@@ -320,7 +320,7 @@ impl crate::usart::UsartOps<
         Ok(())
     }
 
-    fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, avr_hal_generic::void::Void> {
+    fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, core::convert::Infallible> {
         if self.ucsr0a.read().rxc0().bit_is_clear() {
             return Err(avr_hal_generic::nb::Error::WouldBlock);
         }


### PR DESCRIPTION
there's no need for the `void` dependency anymore. accordingly it can be removed. this will also help with implementing `embedded-hal` v1 traits as some of them rely on (or at least have better support for) `core::convert::Infallible`.

this is a breaking change for consumers as they have to e.g. replace `void_unwrap()` calls with `unwrap()`.

the prelude is now no longer needed in most cases (potentally the whole `mod prelude` could be removed in the future as it now adds little benefit?).

note that this PR will conflict with #481; when one gets merged i'll have to rebase the other on top of it (though it will be a fairly trivial rebase). this is due to the fact that both modify the same lines in a few places. merging this one here first might be easier as the other one is smaller.