### PR TITLE
Add an into_digital method to analog input pins

### DIFF
--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -207,11 +207,12 @@ impl<PIN: PinOps, MODE: mode::Io> Pin<MODE, PIN> {
         ADC: crate::adc::AdcOps<H>,
         CLOCK: crate::clock::Clock,
     {
-        let new = Pin {
+        let mut new = Pin {
             pin: self.pin,
             _mode: PhantomData,
         };
         adc.enable_pin(&new);
+        unsafe { new.pin.make_input(false) };
         new
     }
 }
@@ -536,7 +537,7 @@ impl<PIN: PinOps> Pin<mode::Analog, PIN> {
     /// input. You can get to other digital modes by calling one of the usual `into_...` methods
     /// on the return value of this function.
     pub fn into_digital<H, ADC, CLOCK>(
-        mut self,
+        self,
         adc: &mut crate::adc::Adc<H, ADC, CLOCK>,
     ) -> Pin<mode::Input<mode::Floating>, PIN>
     where
@@ -544,7 +545,6 @@ impl<PIN: PinOps> Pin<mode::Analog, PIN> {
         ADC: crate::adc::AdcOps<H>,
         CLOCK: crate::clock::Clock,
     {
-        unsafe { self.pin.make_input(false) };
         adc.disable_pin(&self);
         Pin {
             pin: self.pin,

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -529,6 +529,28 @@ impl<PIN: PinOps> Pin<mode::Analog, PIN> {
     {
         crate::adc::Channel::new(self)
     }
+
+    /// Convert this pin to a floating digital input pin.
+    ///
+    /// The pin is re-enabled in the digital input buffer and is no longer usable as an analog
+    /// input. You can get to other digital modes by calling one of the usual `into_...` methods
+    /// on the return value of this function.
+    pub fn into_digital<H, ADC, CLOCK>(
+        mut self,
+        adc: &mut crate::adc::Adc<H, ADC, CLOCK>,
+    ) -> Pin<mode::Input<mode::Floating>, PIN>
+    where
+        Pin<mode::Analog, PIN>: crate::adc::AdcChannel<H, ADC>,
+        ADC: crate::adc::AdcOps<H>,
+        CLOCK: crate::clock::Clock,
+    {
+        unsafe { self.pin.make_input(false) };
+        adc.disable_pin(&self);
+        Pin {
+            pin: self.pin,
+            _mode: PhantomData,
+        }
+    }
 }
 
 #[macro_export]


### PR DESCRIPTION
Adds a way to get a pin back into digital mode after using it as an analog input re: our conversation in #490.

```rust
let dp = arduino_hal::Peripherals::take().unwrap();
let pins = arduino_hal::pins!(dp);
let mut adc = arduino_hal::Adc::new(dp.ADC, Default::default());
let a5 = pins.a5.into_analog_input(&mut adc);

let floating_voltage = a5.analog_read(&mut adc);

let mut my_button = a5.into_digital(&mut adc).into_pull_up_input();

if my_button.is_low() {
    // ...
}
```

Confirmed working on ATmega328p Arduino Nano.

It's a little awkward that you have to pass in `&adc` to set the pin back to digital mode. For that mater, it's a little awkward that you have to do `pin.into_analog_input(&mut adc).analog_read(&mut adc);` to read from it. But I didn't see another way to do it without affecting runtime performance and/or getting into borrow checker hell. Let me know if you have another idea.