### PR TITLE
Fix eeprom write and erase

### DIFF
--- a/avr-hal-generic/src/eeprom.rs
+++ b/avr-hal-generic/src/eeprom.rs
@@ -190,14 +190,14 @@ macro_rules! impl_eeprom_common {
                                 let $periph_ewmode_var = &self;
                                 $set_erasewrite_mode
                             }
-                            self.eecr.write(|w| w.eepe().set_bit()); // Start Erase+Write operation.
+                            self.eecr.modify(|_, w| w.eepe().set_bit()); // Start Erase+Write operation.
                         } else {
                             // Now we know that all bits should be erased.
                             {
                                 let $periph_emode_var = &self;
                                 $set_erase_mode
                             }
-                            self.eecr.write(|w| w.eepe().set_bit()); // Start Erase-only operation.
+                            self.eecr.modify(|_, w| w.eepe().set_bit()); // Start Erase-only operation.
                         }
                     }
                     //Now we know that _no_ bits need to be erased to '1'.
@@ -210,7 +210,7 @@ macro_rules! impl_eeprom_common {
                                 let $periph_wmode_var = &self;
                                 $set_write_mode
                             }
-                            self.eecr.write(|w| w.eepe().set_bit()); // Start Write-only operation.
+                            self.eecr.modify(|_, w| w.eepe().set_bit()); // Start Write-only operation.
                         }
                     }
                 }
@@ -229,7 +229,7 @@ macro_rules! impl_eeprom_common {
                         $set_erase_mode
                     }
                     // Start Erase-only operation.
-                    self.eecr.write(|w| w.eepe().set_bit());
+                    self.eecr.modify(|_, w| w.eepe().set_bit());
                 }
             }
         }

--- a/avr-hal-generic/src/eeprom.rs
+++ b/avr-hal-generic/src/eeprom.rs
@@ -63,9 +63,7 @@ where
     #[inline]
     pub fn erase_byte(&mut self, offset: u16) {
         assert!(offset < Self::CAPACITY);
-        // Write 0xff here because the erase function is borked.
-        // See also: https://github.com/Rahix/avr-hal/issues/406
-        self.p.raw_write_byte(offset, 0xff)
+        self.p.raw_erase_byte(offset)
     }
 
     pub fn read(&self, offset: u16, buf: &mut [u8]) -> Result<(), OutOfBoundsError> {
@@ -181,12 +179,26 @@ macro_rules! impl_eeprom_common {
 
                     // Check if any bits are changed to '1' in the new value.
                     if (diff_mask & data) != 0 {
-                        self.eedr.write(|w| w.bits(data)); // Set EEPROM data register.
-                        {
-                            let $periph_ewmode_var = &self;
-                            $set_erasewrite_mode
+                        // Now we know that _some_ bits need to be erased to '1'.
+
+                        // Check if any bits in the new value are '0'.
+                        if data != 0xff {
+                            // Now we know that some bits need to be programmed to '0' also.
+                            self.eedr.write(|w| w.bits(data)); // Set EEPROM data register.
+
+                            {
+                                let $periph_ewmode_var = &self;
+                                $set_erasewrite_mode
+                            }
+                            self.eecr.write(|w| w.eepe().set_bit()); // Start Erase+Write operation.
+                        } else {
+                            // Now we know that all bits should be erased.
+                            {
+                                let $periph_emode_var = &self;
+                                $set_erase_mode
+                            }
+                            self.eecr.write(|w| w.eepe().set_bit()); // Start Erase-only operation.
                         }
-                        self.eecr.write(|w| w.eepe().set_bit()); // Start Erase+Write operation.
                     }
                     //Now we know that _no_ bits need to be erased to '1'.
                     else {


### PR DESCRIPTION
Hey, i authored the Atmega164PA support at work with my colleague (see https://github.com/Rahix/avr-hal/pull/452).
I took some spare time to look into the EEPROM issue once again (https://github.com/Rahix/avr-hal/issues/406):

The various datasheets for the atmega* chips essentially state the following procedure :
1. Wait for the EEPE bit to become zero.
2. Write a logical one to the EEMPE bit while writing a zero to EEPE in EECR.
3. Within four clock cycles after setting EEMPE, write a logical one to EEPE.

While we do step 1 and 2 correctly, for step 3, we use `self.eecr.write(|w| w.eepe().set_bit());` which sets the EEPE bit, but also sets the rest of the register to zero.
This seems to cause some slightly different behavior on different boards, e.g. on my Arduino Uno (Atmega328p) on which i tested this, only a 0xff write fails, while on the atmega164pa an erase also fails.

Using `self.eecr.modify(|_, w| w.eepe().set_bit());` fixes the issue, because it preserves the rest of the register.

Please let me know what you think :).