### PR TITLE
Add atmega168 feature to target ATmega168 chip running with its internal 8MHz oscillator

### DIFF
--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -24,6 +24,7 @@ sparkfun-promicro = ["mcu-atmega", "atmega-hal/atmega32u4", "board-selected"]
 sparkfun-promini-5v = ["mcu-atmega", "atmega-hal/atmega328p", "atmega-hal/enable-extra-adc", "board-selected"]
 trinket = ["mcu-attiny", "attiny-hal/attiny85", "board-selected"]
 nano168 = ["mcu-atmega", "atmega-hal/atmega168", "atmega-hal/enable-extra-adc", "board-selected"]
+atmega168 = ["mcu-atmega", "atmega-hal/atmega168", "board-selected"]
 
 [dependencies]
 cfg-if = "1"

--- a/arduino-hal/src/clock.rs
+++ b/arduino-hal/src/clock.rs
@@ -27,6 +27,6 @@ pub(crate) mod default {
         feature = "nano168",
     ))]
     pub type DefaultClock = avr_hal_generic::clock::MHz16;
-    #[cfg(feature = "trinket")]
+    #[cfg(any(feature = "trinket", feature = "atmega168"))]
     pub type DefaultClock = avr_hal_generic::clock::MHz8;
 }

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -17,6 +17,7 @@
 #![cfg_attr(feature = "trinket-pro", doc = "**Trinket Pro**.")]
 #![cfg_attr(feature = "trinket", doc = "**Trinket**.")]
 #![cfg_attr(feature = "nano168", doc = "**Nano clone (ATmega168)**.")]
+#![cfg_attr(feature = "atmega168", doc = "**ATmega168**.")]
 //! This means that only items which are available for this board are visible.  If you are using a
 //! different board, try building the documentation locally with
 //!
@@ -64,6 +65,7 @@ compile_error!(
     * trinket-pro
     * trinket
     * nano168
+    * atmega168
     "
 );
 
@@ -259,7 +261,7 @@ macro_rules! default_serial {
         )
     };
 }
-#[cfg(any(feature = "arduino-nano", feature = "nano168", feature = "sparkfun-promini-5v"))]
+#[cfg(any(feature = "arduino-nano", feature = "nano168", feature = "sparkfun-promini-5v", feature = "atmega168"))]
 #[macro_export]
 macro_rules! default_serial {
     ($p:expr, $pins:expr, $baud:expr) => {

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -27,9 +27,9 @@ pub use leonardo::*;
 mod mega;
 #[cfg(any(feature = "arduino-mega2560", feature = "arduino-mega1280"))]
 pub use mega::*;
-#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168", feature = "sparkfun-promini-5v"))]
+#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168", feature = "sparkfun-promini-5v", feature = "atmega168"))]
 mod uno;
-#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168", feature = "sparkfun-promini-5v"))]
+#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168", feature = "sparkfun-promini-5v", feature = "atmega168"))]
 pub use uno::*;
 #[cfg(feature = "sparkfun-promicro")]
 mod promicro;

--- a/ravedude/src/board.rs
+++ b/ravedude/src/board.rs
@@ -23,6 +23,7 @@ pub fn get_board(board: &str) -> Option<Box<dyn Board>> {
         "trinket" => Box::new(Trinket),
         "nano168" => Box::new(Nano168),
         "duemilanove" => Box::new(ArduinoDuemilanove),
+        "atmega168" => Box::new(Atmega168),
         _ => return None,
     })
 }
@@ -170,16 +171,14 @@ impl Board for ArduinoLeonardo {
     fn needs_reset(&self) -> Option<&str> {
         let a = self.guess_port();
         match a {
-            Some(Ok(name)) => {
-                match serialport::new(name.to_str().unwrap(), 1200).open() {
-                    Ok(_) => {
-                        std::thread::sleep(core::time::Duration::from_secs(1));
-                        None
-                    },
-                    Err(_) => Some("Reset the board by pressing the reset button once.")
+            Some(Ok(name)) => match serialport::new(name.to_str().unwrap(), 1200).open() {
+                Ok(_) => {
+                    std::thread::sleep(core::time::Duration::from_secs(1));
+                    None
                 }
+                Err(_) => Some("Reset the board by pressing the reset button once."),
             },
-            _ => Some("Reset the board by pressing the reset button once.")
+            _ => Some("Reset the board by pressing the reset button once."),
         }
     }
 
@@ -202,7 +201,6 @@ impl Board for ArduinoLeonardo {
     }
 }
 
-
 struct ArduinoMega1280;
 
 impl Board for ArduinoMega1280 {
@@ -224,11 +222,10 @@ impl Board for ArduinoMega1280 {
     }
 
     fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
-       // This board uses a generic serial interface id 0403:6001 which is too common for auto detection.
-       Some(Err(anyhow::anyhow!("Unable to guess port.")))
+        // This board uses a generic serial interface id 0403:6001 which is too common for auto detection.
+        Some(Err(anyhow::anyhow!("Unable to guess port.")))
     }
 }
-
 
 struct ArduinoMega2560;
 
@@ -417,7 +414,6 @@ impl Board for Nano168 {
     }
 }
 
-
 struct ArduinoDuemilanove;
 
 impl Board for ArduinoDuemilanove {
@@ -435,6 +431,31 @@ impl Board for ArduinoDuemilanove {
             partno: "atmega328p",
             baudrate: Some(57600),
             do_chip_erase: true,
+        }
+    }
+
+    fn guess_port(&self) -> Option<anyhow::Result<std::path::PathBuf>> {
+        Some(Err(anyhow::anyhow!("Not able to guess port")))
+    }
+}
+
+struct Atmega168;
+
+impl Board for Atmega168 {
+    fn display_name(&self) -> &str {
+        "ATmega168"
+    }
+
+    fn needs_reset(&self) -> Option<&str> {
+        None
+    }
+
+    fn avrdude_options(&self) -> avrdude::AvrdudeOptions {
+        avrdude::AvrdudeOptions {
+            programmer: "arduino",
+            partno: "atmega168",
+            baudrate: Some(19200),
+            do_chip_erase: false,
         }
     }
 

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::Context as _;
 use colored::Colorize as _;
 use structopt::clap::AppSettings;
 
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 mod avrdude;
 mod board;
@@ -66,6 +66,7 @@ struct Args {
     /// * trinket
     /// * nano168
     /// * duemilanove
+    /// * atmega168
     #[structopt(name = "BOARD", verbatim_doc_comment)]
     board: String,
 
@@ -94,15 +95,15 @@ fn ravedude() -> anyhow::Result<()> {
 
     task_message!("Board", "{}", board.display_name());
 
-    if let Some(wait_time) = args.reset_delay{
+    if let Some(wait_time) = args.reset_delay {
         if wait_time > 0 {
             println!("Waiting {} ms before proceeding", wait_time);
             let wait_time = Duration::from_millis(wait_time);
             thread::sleep(wait_time);
-        }else{
+        } else {
             println!("Assuming board has been reset");
         }
-    }else{
+    } else {
         if let Some(msg) = board.needs_reset() {
             warning!("this board cannot reset itself.");
             eprintln!("");
@@ -157,11 +158,7 @@ fn ravedude() -> anyhow::Result<()> {
         let port = port.context("console can only be opened for devices with USB-to-Serial")?;
 
         task_message!("Console", "{} at {} baud", port.display(), baudrate);
-        task_message!(
-            "",
-            "{}",
-            "CTRL+C to exit.".dimmed()
-        );
+        task_message!("", "{}", "CTRL+C to exit.".dimmed());
         // Empty line for visual consistency
         eprintln!();
         console::open(&port, baudrate)?;


### PR DESCRIPTION
I'm working on a project based on an ATmega168 chip without an external oscillator and therefore using its own internal 8MHz oscillator.
These changes introduce a new feature to be able to target this chip.

However, the changes made in the PR for adding an internal-clock feature (https://github.com/Rahix/avr-hal/pull/443) may be a better way to achieve what I want. With this I could use both the 'nano168' and 'internal-clock' features to get the same result.