### PR TITLE
generic: improve bit operations usage

### DIFF
--- a/mcu/atmega-hal/src/port.rs
+++ b/mcu/atmega-hal/src/port.rs
@@ -23,7 +23,7 @@ avr_hal_generic::impl_port_traditional! {
 avr_hal_generic::impl_port_traditional! {
     enum Ports {
         B: crate::pac::PORTB = [0, 1, 2, 3, 4, 5, 6, 7],
-        C: crate::pac::PORTC = [0, 1, 2, 3, 4, 5, 6, 7],
+        C: crate::pac::PORTC = [0, 1, 2, 3, 4, 5, 6],
         D: crate::pac::PORTD = [0, 1, 2, 3, 4, 5, 6, 7],
         E: crate::pac::PORTE = [0, 1, 2, 3],
     }
@@ -36,7 +36,7 @@ avr_hal_generic::impl_port_traditional! {
         C: crate::pac::PORTC = [6, 7],
         D: crate::pac::PORTD = [0, 1, 2, 3, 4, 5, 6, 7],
         E: crate::pac::PORTE = [2, 6],
-        F: crate::pac::PORTF = [0, 1, 2, 3, 4, 5, 6, 7],
+        F: crate::pac::PORTF = [0, 1, 4, 5, 6, 7],
     }
 }
 
@@ -49,7 +49,7 @@ avr_hal_generic::impl_port_traditional! {
         D: crate::pac::PORTD = [0, 1, 2, 3, 4, 5, 6, 7],
         E: crate::pac::PORTE = [0, 1, 2, 3, 4, 5, 6, 7],
         F: crate::pac::PORTF = [0, 1, 2, 3, 4, 5, 6, 7],
-        G: crate::pac::PORTG = [0, 1, 2, 3, 4, 5],
+        G: crate::pac::PORTG = [0, 1, 2, 3, 4],
     }
 }
 


### PR DESCRIPTION
Reading the discussion in the fixed #499 is important to understand this. For the dynamic case, I ended up just changing the typo, since its dynamic nature prevents optimizing further without some real arcane magic. But I also changed the static one to use fields, which look more sound and always generate the optimized bytecode.

All low-level operations with registers in `PinOps` were implemented with raw bit-manipulation, a là C. The method used from the readers/writers of `avr-device` was `.bits()`, which takes/gets a full u8 bitmask, to which changes were made via bitwise operators. This is the most "expected" approach, but digging through the PAC documentation, Rust's static typing and discrimination of ports and pins via types allows us to write code that really reads off as "write to this single bit in the register" as opposed to "write this 1-bit-changed mask to the whole register". Moreover, when compiled down, AVR actually has instructions for single bit operations on IO registers, so Rust turns it into just `(s|c)bi  $IO,$bit`, where $IO and $bit are static/immediate.

Let's look at an example expansion of the generator macro for a known-type `Pin`:

```rust
unsafe fn out_set(&mut self) {
    (*<PORTD>::ptr()).portd.modify(|_, w| {
        w.pd2().set_bit()
    })
}
```

Because 1) we used fields instead of the `.bits` method, 2) we only touched 1 bit and 3) we used `.modify`, therefore saying "only change what I explicitly request", the compiler knows this can be safely turned into `sbi  0x2B,0x2`. `out_clear` is the same, the instruction just changes to `cbi`. Toggle would need to be an XOR, but due to the feature that writing 1 to pind toggles the corresponding bit in portd, it can be exactly like above, replacing portd with pind as the self for `.modify`. To make it consistent, I changed the read implementation to also use these field accessors. In the known-pin case, it's:

```rust
unsafe fn out_get(&mut self) -> bool {
    (*<PORTD>::ptr()).portd.read().pd2().bit() // Returns bool, no need to use != 0.
}
```

This generates a read with `in r24,0x2B`, then some manipulation to make the value either 0b00000000 or 0b00000001 as Rust mandates for bool. I tested two different pins, the manipulations it generates depend on the position of the 1 in the byte, so maybe there's some room for improvement here.

For the unknown-pin case, I tried many approaches, but short of somehow storing the static methods and deferring to those (which I couldn't implement), the `.bits`-style beats all of them. So I kept it there, with some minor reformatting.