### PR TITLE
generic: port: Fix toggle() for dynamic pins

### DIFF
--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -644,7 +644,7 @@ macro_rules! impl_port_traditional {
                 #[inline]
                 unsafe fn out_toggle(&mut self) {
                     match self.port {
-                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<port $name:lower>].write(|w| {
+                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<pin $name:lower>].write(|w| {
                             w.bits(self.mask)
                         }),)+
                     }


### PR DESCRIPTION
During commit 063f845a0940 ("generic: simplify port macro via `paste!`"), an accidental change was introduced where out_toggle() for dynamic pins wrote to the `PORT` register instead of the `PIN` register. This meant that toggle() for dynamic pins no longer worked.

Fix this regression by making out_toggle() write to `PIN` again.

Fixes #499.