### PR TITLE
ravedude: Don't emit non-ascii bytes on Windows

### DIFF
--- a/ravedude/src/console.rs
+++ b/ravedude/src/console.rs
@@ -31,6 +31,16 @@ pub fn open(port: &std::path::Path, baudrate: u32) -> anyhow::Result<()> {
 
         match rx.read(&mut buf) {
             Ok(count) => {
+                #[cfg(target_os = "windows")]
+                {
+                    // On windows, we must ensure that we are not sending anything outside of the
+                    // ASCII range.
+                    for byte in &mut buf[..count] {
+                        if *byte & 0x80 != 0 {
+                            *byte = '?'.try_into().unwrap();
+                        }
+                    }
+                }
                 stdout.write(&buf[..count]).unwrap();
                 stdout.flush().unwrap();
             }


### PR DESCRIPTION
Windows console stdio does not support sending UTF-8 sequences which means that we must ensure that any data received from the serial connection is cleaned to ASCII only before forwarding it to the console.

To make sure that users notice the illegal data getting sent, print `?` symbols instead.

Fixes #515.

@BiasedKiwi, please give this branch a try using

```bash
cargo install --git https://github.com/rahix/avr-hal --rev 3fddc711ad504c4dff4a18952834b8ad13d50446 ravedude
```