### PR TITLE
Apply rustfmt

### DIFF
--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -13,7 +13,10 @@
 #![cfg_attr(feature = "arduino-nano", doc = "**Arduino Nano**.")]
 #![cfg_attr(feature = "arduino-uno", doc = "**Arduino Uno**.")]
 #![cfg_attr(feature = "sparkfun-promicro", doc = "**SparkFun ProMicro**.")]
-#![cfg_attr(feature = "sparkfun-promini-5v", doc = "**SparkFun ProMini 5V (16MHz)**.")]
+#![cfg_attr(
+    feature = "sparkfun-promini-5v",
+    doc = "**SparkFun ProMini 5V (16MHz)**."
+)]
 #![cfg_attr(feature = "trinket-pro", doc = "**Trinket Pro**.")]
 #![cfg_attr(feature = "trinket", doc = "**Trinket**.")]
 #![cfg_attr(feature = "nano168", doc = "**Nano clone (ATmega168)**.")]
@@ -259,7 +262,11 @@ macro_rules! default_serial {
         )
     };
 }
-#[cfg(any(feature = "arduino-nano", feature = "nano168", feature = "sparkfun-promini-5v"))]
+#[cfg(any(
+    feature = "arduino-nano",
+    feature = "nano168",
+    feature = "sparkfun-promini-5v"
+))]
 #[macro_export]
 macro_rules! default_serial {
     ($p:expr, $pins:expr, $baud:expr) => {

--- a/arduino-hal/src/port/mod.rs
+++ b/arduino-hal/src/port/mod.rs
@@ -27,9 +27,19 @@ pub use leonardo::*;
 mod mega;
 #[cfg(any(feature = "arduino-mega2560", feature = "arduino-mega1280"))]
 pub use mega::*;
-#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168", feature = "sparkfun-promini-5v"))]
+#[cfg(any(
+    feature = "arduino-nano",
+    feature = "arduino-uno",
+    feature = "nano168",
+    feature = "sparkfun-promini-5v"
+))]
 mod uno;
-#[cfg(any(feature = "arduino-nano", feature = "arduino-uno", feature = "nano168", feature = "sparkfun-promini-5v"))]
+#[cfg(any(
+    feature = "arduino-nano",
+    feature = "arduino-uno",
+    feature = "nano168",
+    feature = "sparkfun-promini-5v"
+))]
 pub use uno::*;
 #[cfg(feature = "sparkfun-promicro")]
 mod promicro;

--- a/avr-hal-generic/src/adc.rs
+++ b/avr-hal-generic/src/adc.rs
@@ -329,4 +329,3 @@ macro_rules! impl_adc {
         )*)?
     };
 }
-

--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -1,8 +1,8 @@
 //! Delay implementations
 
 use core::marker;
-use embedded_hal_v0::blocking::delay as delay_v0;
 use embedded_hal::delay::DelayNs;
+use embedded_hal_v0::blocking::delay as delay_v0;
 
 #[cfg(all(target_arch = "avr", avr_hal_asm_macro))]
 use core::arch::asm;
@@ -237,9 +237,9 @@ impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz1> {
 
         // compensate for the time taken by the preceeding and next commands (about 22 cycles)
         us -= 22; // = 2 cycles
-        // the following loop takes 4 microseconds (4 cycles)
-        // per iteration, so execute it us/4 times
-        // us is at least 4, divided by 4 gives us 1 (no zero delay bug)
+                  // the following loop takes 4 microseconds (4 cycles)
+                  // per iteration, so execute it us/4 times
+                  // us is at least 4, divided by 4 gives us 1 (no zero delay bug)
         us >>= 2; // us div 4, = 4 cycles
 
         busy_loop(us);
@@ -249,8 +249,8 @@ impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz1> {
 // ------------------------------------------------------------------------ }}}
 
 impl<SPEED> delay_v0::DelayUs<u8> for Delay<SPEED>
-    where
-        Delay<SPEED>: delay_v0::DelayUs<u16>,
+where
+    Delay<SPEED>: delay_v0::DelayUs<u16>,
 {
     fn delay_us(&mut self, us: u8) {
         delay_v0::DelayUs::<u16>::delay_us(self, us as u16);
@@ -258,8 +258,8 @@ impl<SPEED> delay_v0::DelayUs<u8> for Delay<SPEED>
 }
 
 impl<SPEED> delay_v0::DelayUs<u32> for Delay<SPEED>
-    where
-        Delay<SPEED>: delay_v0::DelayUs<u16>,
+where
+    Delay<SPEED>: delay_v0::DelayUs<u16>,
 {
     fn delay_us(&mut self, us: u32) {
         // TODO: Somehow fix the overhead induced by this loop
@@ -278,8 +278,8 @@ impl<SPEED> delay_v0::DelayUs<u32> for Delay<SPEED>
 }
 
 impl<SPEED> delay_v0::DelayMs<u16> for Delay<SPEED>
-    where
-        Delay<SPEED>: delay_v0::DelayUs<u32>,
+where
+    Delay<SPEED>: delay_v0::DelayUs<u32>,
 {
     fn delay_ms(&mut self, ms: u16) {
         delay_v0::DelayUs::<u32>::delay_us(self, ms as u32 * 1000);
@@ -287,8 +287,8 @@ impl<SPEED> delay_v0::DelayMs<u16> for Delay<SPEED>
 }
 
 impl<SPEED> delay_v0::DelayMs<u8> for Delay<SPEED>
-    where
-        Delay<SPEED>: delay_v0::DelayMs<u16>,
+where
+    Delay<SPEED>: delay_v0::DelayMs<u16>,
 {
     fn delay_ms(&mut self, ms: u8) {
         delay_v0::DelayMs::<u16>::delay_ms(self, ms as u16);
@@ -296,8 +296,9 @@ impl<SPEED> delay_v0::DelayMs<u8> for Delay<SPEED>
 }
 
 impl<SPEED> DelayNs for Delay<SPEED>
-    where
-        Delay<SPEED>: delay_v0::DelayUs<u16>, {
+where
+    Delay<SPEED>: delay_v0::DelayUs<u16>,
+{
     fn delay_ns(&mut self, ns: u32) {
         // quick-win to get an initial implementation.
         // note that the trait does not guarantee nanosecond-accuracy.

--- a/avr-hal-generic/src/eeprom.rs
+++ b/avr-hal-generic/src/eeprom.rs
@@ -264,7 +264,6 @@ macro_rules! impl_eeprom_atmega_old {
         impl $crate::eeprom::EepromOps<$HAL> for $EEPROM {
             const CAPACITY: u16 = $capacity;
 
-
             fn raw_read_byte(&self, address: u16) -> u8 {
                 unsafe {
                     atmega_helper::set_address(&self, address);
@@ -279,14 +278,9 @@ macro_rules! impl_eeprom_atmega_old {
                 }
 
                 //Start EEPROM read operation
-                self.eedr.write(|w| unsafe {
-                    w.bits(data)
-                });
+                self.eedr.write(|w| unsafe { w.bits(data) });
 
-                self.eecr.write(|w|
-                    w
-                        .eemwe().set_bit()
-                        .eewe().clear_bit());
+                self.eecr.write(|w| w.eemwe().set_bit().eewe().clear_bit());
 
                 self.eecr.write(|w| w.eewe().set_bit());
             }

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -335,7 +335,9 @@ impl<PIN: PinOps> OutputPinV0 for Pin<mode::Output, PIN> {
     }
 }
 
-impl<PIN: PinOps> ErrorType for Pin<mode::Output, PIN> { type Error = core::convert::Infallible; }
+impl<PIN: PinOps> ErrorType for Pin<mode::Output, PIN> {
+    type Error = core::convert::Infallible;
+}
 
 impl<PIN: PinOps> OutputPin for Pin<mode::Output, PIN> {
     fn set_low(&mut self) -> Result<(), Self::Error> {
@@ -440,7 +442,9 @@ impl<PIN: PinOps> InputPinV0 for Pin<mode::OpenDrain, PIN> {
     }
 }
 
-impl<PIN: PinOps> ErrorType for Pin<mode::OpenDrain, PIN> { type Error = core::convert::Infallible; }
+impl<PIN: PinOps> ErrorType for Pin<mode::OpenDrain, PIN> {
+    type Error = core::convert::Infallible;
+}
 
 impl<PIN: PinOps> InputPin for Pin<mode::OpenDrain, PIN> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
@@ -465,7 +469,9 @@ impl<PIN: PinOps, IMODE: mode::InputMode> InputPinV0 for Pin<mode::Input<IMODE>,
     }
 }
 
-impl<PIN: PinOps, IMODE: mode::InputMode> ErrorType for Pin<mode::Input<IMODE>, PIN> { type Error = core::convert::Infallible; }
+impl<PIN: PinOps, IMODE: mode::InputMode> ErrorType for Pin<mode::Input<IMODE>, PIN> {
+    type Error = core::convert::Infallible;
+}
 
 impl<PIN: PinOps, IMODE: mode::InputMode> InputPin for Pin<mode::Input<IMODE>, PIN> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {

--- a/avr-hal-generic/src/simple_pwm.rs
+++ b/avr-hal-generic/src/simple_pwm.rs
@@ -97,9 +97,11 @@ impl pwm::Error for PwmError {
     }
 }
 
-impl<TC, PIN: PwmPinOps<TC>> ErrorType for Pin<mode::PwmOutput<TC>, PIN> { type Error = PwmError; }
+impl<TC, PIN: PwmPinOps<TC>> ErrorType for Pin<mode::PwmOutput<TC>, PIN> {
+    type Error = PwmError;
+}
 
-impl<TC, PIN: PwmPinOps<TC, Duty=u8>> SetDutyCycle for Pin<mode::PwmOutput<TC>, PIN> {
+impl<TC, PIN: PwmPinOps<TC, Duty = u8>> SetDutyCycle for Pin<mode::PwmOutput<TC>, PIN> {
     fn max_duty_cycle(&self) -> u16 {
         self.get_max_duty() as u16
     }

--- a/avr-hal-generic/src/spi.rs
+++ b/avr-hal-generic/src/spi.rs
@@ -1,7 +1,7 @@
 //! SPI Implementation
 use crate::port;
 use core::marker::PhantomData;
-use embedded_hal::spi::{self,SpiBus};
+use embedded_hal::spi::{self, SpiBus};
 
 /// Oscillator Clock Frequency division options.
 ///
@@ -75,7 +75,7 @@ pub trait SpiOps<H, SCLK, MOSI, MISO, CS> {
     fn raw_release(&mut self);
 
     /// Check the interrupt flag to see if the write has completed
-    /// 
+    ///
     /// Returns `true` if the bus is idle
     fn raw_check_iflag(&self) -> bool;
     /// Read a byte from the data register
@@ -116,7 +116,9 @@ impl<CSPIN: port::PinOps> embedded_hal_v0::digital::v2::StatefulOutputPin for Ch
     }
 }
 
-impl<CSPIN: port::PinOps> embedded_hal_v0::digital::v2::ToggleableOutputPin for ChipSelectPin<CSPIN> {
+impl<CSPIN: port::PinOps> embedded_hal_v0::digital::v2::ToggleableOutputPin
+    for ChipSelectPin<CSPIN>
+{
     type Error = core::convert::Infallible;
     fn toggle(&mut self) -> Result<(), Self::Error> {
         self.0.toggle();
@@ -150,14 +152,12 @@ impl<CSPIN: port::PinOps> embedded_hal::digital::StatefulOutputPin for ChipSelec
     }
 }
 
-
-
 /// Behavior for a SPI interface.
 ///
 /// Stores the SPI peripheral for register access.  In addition, it takes
 /// ownership of the MOSI and MISO pins to ensure they are in the correct mode.
 /// Instantiate with the `new` method.
-/// 
+///
 /// This can be used both with the embedded-hal 0.2 [`spi::FullDuplex`] trait, and
 /// with the embedded-hal 1.0 [`spi::SpiBus`] trait.
 ///
@@ -345,10 +345,10 @@ where
         SpiBus::flush(self)?;
 
         for b in read.iter_mut() {
-            // We send 0x00 on MOSI during "pure" reading 
+            // We send 0x00 on MOSI during "pure" reading
             *b = self.p.raw_transaction(0x00);
         }
-        
+
         Ok(())
     }
 
@@ -379,6 +379,7 @@ where
 
         Ok(())
     }
+
     fn transfer_in_place(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
         // Must flush() first, if asynchronous operations happened before this.
         // To be removed if in the future we "only" implement embedded_hal 1.0
@@ -390,7 +391,6 @@ where
 
         Ok(())
     }
-    
 }
 
 /// Default Transfer trait implementation. Only 8-bit word size is supported for now.
@@ -429,7 +429,6 @@ macro_rules! impl_spi {
         cs: $cspin:ty,
     ) => {
         impl $crate::spi::SpiOps<$HAL, $sclkpin, $mosipin, $misopin, $cspin> for $SPI {
-            
             fn raw_setup(&mut self, settings: &Settings) {
                 use $crate::hal::spi;
 
@@ -489,7 +488,6 @@ macro_rules! impl_spi {
                 self.spdr.read().bits()
             }
 
-            
             fn raw_write(&mut self, byte: u8) {
                 self.spdr.write(|w| unsafe { w.bits(byte) });
             }

--- a/avr-hal-generic/src/usart.rs
+++ b/avr-hal-generic/src/usart.rs
@@ -2,9 +2,9 @@
 //!
 //! Check the documentation of [`Usart`] for details.
 
+use crate::prelude::*;
 use core::cmp::Ordering;
 use core::marker;
-use crate::prelude::*;
 
 use crate::port;
 
@@ -151,7 +151,7 @@ pub enum Event {
     RxComplete,
 
     /// A compete byte was sent.
-    /// 
+    ///
     /// Corresponds to the `USART_TX` or `USART#_TX` interrupt.  Please refer to the datasheet for
     /// your MCU for details.
     TxComplete,

--- a/avr-hal-generic/src/wdt.rs
+++ b/avr-hal-generic/src/wdt.rs
@@ -112,7 +112,8 @@ macro_rules! impl_wdt {
                     // Reset the watchdog timer.
                     self.raw_feed();
                     // Enable watchdog configuration mode.
-                    self.$wdtcsr.modify(|_, w| w.wdce().set_bit().wde().set_bit());
+                    self.$wdtcsr
+                        .modify(|_, w| w.wdce().set_bit().wde().set_bit());
                     // Enable watchdog and set interval.
                     self.$wdtcsr.write(|w| {
                         let $to = timeout;
@@ -142,11 +143,12 @@ macro_rules! impl_wdt {
                     // Reset the watchdog timer.
                     self.raw_feed();
                     // Enable watchdog configuration mode.
-                    self.$wdtcsr.modify(|_, w| w.wdce().set_bit().wde().set_bit());
+                    self.$wdtcsr
+                        .modify(|_, w| w.wdce().set_bit().wde().set_bit());
                     // Disable watchdog.
                     self.$wdtcsr.reset();
                 })
             }
         }
-    }
+    };
 }

--- a/mcu/atmega-hal/src/adc.rs
+++ b/mcu/atmega-hal/src/adc.rs
@@ -256,7 +256,6 @@ avr_hal_generic::impl_adc! {
     },
 }
 
-
 #[cfg(any(feature = "atmega2560", feature = "atmega1280"))]
 avr_hal_generic::impl_adc! {
     hal: crate::Atmega,

--- a/mcu/atmega-hal/src/eeprom.rs
+++ b/mcu/atmega-hal/src/eeprom.rs
@@ -55,9 +55,7 @@ avr_hal_generic::impl_eeprom_atmega! {
     },
 }
 
-#[cfg(any(
-    feature = "atmega8"
-))]
+#[cfg(any(feature = "atmega8"))]
 avr_hal_generic::impl_eeprom_atmega_old! {
     hal: crate::Atmega,
     peripheral: crate::pac::EEPROM,
@@ -68,9 +66,7 @@ avr_hal_generic::impl_eeprom_atmega_old! {
     },
 }
 
-#[cfg(any(
-    feature = "atmega32a"
-))]
+#[cfg(any(feature = "atmega32a"))]
 avr_hal_generic::impl_eeprom_atmega_old! {
     hal: crate::Atmega,
     peripheral: crate::pac::EEPROM,
@@ -81,9 +77,7 @@ avr_hal_generic::impl_eeprom_atmega_old! {
     },
 }
 
-#[cfg(any(
-    feature = "atmega128a",
-))]
+#[cfg(any(feature = "atmega128a",))]
 avr_hal_generic::impl_eeprom_atmega_old! {
     hal: crate::Atmega,
     peripheral: crate::pac::EEPROM,
@@ -93,4 +87,3 @@ avr_hal_generic::impl_eeprom_atmega_old! {
         peripheral.eear.write(|w| w.bits(address));
     },
 }
-

--- a/mcu/atmega-hal/src/i2c.rs
+++ b/mcu/atmega-hal/src/i2c.rs
@@ -2,7 +2,12 @@
 use crate::port;
 pub use avr_hal_generic::i2c::*;
 
-#[cfg(any(feature = "atmega128a", feature = "atmega1280", feature = "atmega2560", feature = "atmega32u4"))]
+#[cfg(any(
+    feature = "atmega128a",
+    feature = "atmega1280",
+    feature = "atmega2560",
+    feature = "atmega32u4"
+))]
 pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
     crate::Atmega,
     crate::pac::TWI,
@@ -10,7 +15,12 @@ pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
     port::Pin<port::mode::Input, port::PD0>,
     CLOCK,
 >;
-#[cfg(any(feature = "atmega128a", feature = "atmega1280", feature = "atmega2560", feature = "atmega32u4"))]
+#[cfg(any(
+    feature = "atmega128a",
+    feature = "atmega1280",
+    feature = "atmega2560",
+    feature = "atmega32u4"
+))]
 avr_hal_generic::impl_i2c_twi! {
     hal: crate::Atmega,
     peripheral: crate::pac::TWI,
@@ -34,7 +44,12 @@ avr_hal_generic::impl_i2c_twi! {
     scl: port::PC0,
 }
 
-#[cfg(any(feature = "atmega328p", feature = "atmega168", feature = "atmega48p", feature = "atmega8"))]
+#[cfg(any(
+    feature = "atmega328p",
+    feature = "atmega168",
+    feature = "atmega48p",
+    feature = "atmega8"
+))]
 pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
     crate::Atmega,
     crate::pac::TWI,
@@ -42,7 +57,12 @@ pub type I2c<CLOCK> = avr_hal_generic::i2c::I2c<
     port::Pin<port::mode::Input, port::PC5>,
     CLOCK,
 >;
-#[cfg(any(feature = "atmega328p", feature = "atmega168", feature = "atmega48p", feature = "atmega8"))]
+#[cfg(any(
+    feature = "atmega328p",
+    feature = "atmega168",
+    feature = "atmega48p",
+    feature = "atmega8"
+))]
 avr_hal_generic::impl_i2c_twi! {
     hal: crate::Atmega,
     peripheral: crate::pac::TWI,

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -50,6 +50,12 @@ compile_error!(
 /// Reexport of `atmega1280` from `avr-device`
 #[cfg(feature = "atmega1280")]
 pub use avr_device::atmega1280 as pac;
+/// Reexport of `atmega1284p` from `avr-device`
+#[cfg(feature = "atmega1284p")]
+pub use avr_device::atmega1284p as pac;
+/// Reexport of `atmega128a` from `avr-device`
+#[cfg(feature = "atmega128a")]
+pub use avr_device::atmega128a as pac;
 /// Reexport of `atmega164pa` from `avr-device`
 #[cfg(feature = "atmega164pa")]
 pub use avr_device::atmega164pa as pac;
@@ -74,12 +80,6 @@ pub use avr_device::atmega32u4 as pac;
 /// Reexport of `atmega48p` from `avr-device`
 #[cfg(feature = "atmega48p")]
 pub use avr_device::atmega48p as pac;
-/// Reexport of `atmega128a` from `avr-device`
-#[cfg(feature = "atmega128a")]
-pub use avr_device::atmega128a as pac;
-/// Reexport of `atmega1284p` from `avr-device`
-#[cfg(feature = "atmega1284p")]
-pub use avr_device::atmega1284p as pac;
 /// Reexport of `atmega8` from `avr-device`
 #[cfg(feature = "atmega8")]
 pub use avr_device::atmega8 as pac;
@@ -132,7 +132,6 @@ pub use wdt::Wdt;
 pub mod eeprom;
 #[cfg(feature = "device-selected")]
 pub use eeprom::Eeprom;
-
 
 pub struct Atmega;
 
@@ -190,9 +189,7 @@ macro_rules! pins {
 #[macro_export]
 macro_rules! pins {
     ($p:expr) => {
-        $crate::Pins::new(
-            $p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD,
-        )
+        $crate::Pins::new($p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD)
     };
 }
 
@@ -200,8 +197,6 @@ macro_rules! pins {
 #[macro_export]
 macro_rules! pins {
     ($p:expr) => {
-        $crate::Pins::new(
-            $p.PORTB, $p.PORTC, $p.PORTD,
-        )
+        $crate::Pins::new($p.PORTB, $p.PORTC, $p.PORTD)
     };
 }

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -1,4 +1,4 @@
-pub use avr_hal_generic::simple_pwm::{IntoPwmPin, PwmPinOps, Prescaler};
+pub use avr_hal_generic::simple_pwm::{IntoPwmPin, Prescaler, PwmPinOps};
 
 #[allow(unused_imports)]
 use crate::port::*;
@@ -994,9 +994,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(any(
-    feature = "atmega8",
-))]
+#[cfg(any(feature = "atmega8",))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC1` for PWM (pins `PB1`, `PB2`)
     ///
@@ -1048,9 +1046,7 @@ avr_hal_generic::impl_simple_pwm! {
     }
 }
 
-#[cfg(any(
-    feature = "atmega8",
-))]
+#[cfg(any(feature = "atmega8",))]
 avr_hal_generic::impl_simple_pwm! {
     /// Use `TC2` for PWM (pins `PB3`, `PD3`)
     ///

--- a/mcu/attiny-hal/src/adc.rs
+++ b/mcu/attiny-hal/src/adc.rs
@@ -12,20 +12,14 @@ pub use avr_hal_generic::adc::{AdcChannel, AdcOps, ClockDivider};
 #[repr(u8)]
 pub enum ReferenceVoltage {
     /// Voltage applied to AREF pin.
-    #[cfg(any(
-        feature = "attiny85",
-        feature = "attiny167",
-    ))]
+    #[cfg(any(feature = "attiny85", feature = "attiny167",))]
     Aref,
     /// Default reference voltage (default).
     AVcc,
     /// Internal 1.1V reference.
     Internal1_1,
     /// Internal 2.56V reference.
-    #[cfg(any(
-        feature = "attiny85",
-        feature = "attiny167",
-    ))]
+    #[cfg(any(feature = "attiny85", feature = "attiny167",))]
     Internal2_56,
 }
 
@@ -83,7 +77,6 @@ fn apply_clock(peripheral: &crate::pac::ADC, settings: AdcSettings) {
     });
 }
 
-
 #[cfg(feature = "attiny85")]
 avr_hal_generic::impl_adc! {
     hal: crate::Attiny,
@@ -114,7 +107,6 @@ avr_hal_generic::impl_adc! {
         channel::Temperature: crate::pac::adc::admux::MUX_A::TEMPSENS,
     },
 }
-
 
 #[cfg(feature = "attiny88")]
 avr_hal_generic::impl_adc! {
@@ -148,7 +140,6 @@ avr_hal_generic::impl_adc! {
         channel::Temperature: crate::pac::adc::admux::MUX_A::TEMPSENS,
     },
 }
-
 
 #[cfg(feature = "attiny167")]
 avr_hal_generic::impl_adc! {

--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -86,7 +86,6 @@ pub mod eeprom;
 #[cfg(feature = "device-selected")]
 pub use eeprom::Eeprom;
 
-
 pub struct Attiny;
 
 #[cfg(feature = "attiny84")]

--- a/mcu/attiny-hal/src/simple_pwm.rs
+++ b/mcu/attiny-hal/src/simple_pwm.rs
@@ -1,6 +1,6 @@
-pub use avr_hal_generic::simple_pwm::{PwmPinOps, Prescaler};
+pub use avr_hal_generic::simple_pwm::{Prescaler, PwmPinOps};
 
-#[cfg(any(feature = "attiny85",feature = "attiny84",feature="attiny88"))]
+#[cfg(any(feature = "attiny85", feature = "attiny84", feature = "attiny88"))]
 use crate::port::*;
 
 #[cfg(feature = "attiny84")]


### PR DESCRIPTION
Since we don't enforce formatting in CI at this time, things have become a bit chaotic.  Let's sync with rustfmt where it matters.  At some point, adding a CI check might make sense.