### PR TITLE
Add atmega-hal examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
           - type: board
             name: nano168
             examples: true
+          - type: board
+            # Not really a board, but also an examples crate
+            name: atmega2560
+            examples: true
           - type: mcu
             name: atmega1280
             spec: atmega1280

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "examples/arduino-mega1280",
     "examples/arduino-nano",
     "examples/arduino-uno",
+    "examples/atmega2560",
     "examples/nano168",
     "examples/sparkfun-promicro",
     "examples/sparkfun-promini-5v",

--- a/examples/atmega2560/.cargo/config.toml
+++ b/examples/atmega2560/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "../../avr-specs/avr-atmega2560.json"
+
+[target.'cfg(target_arch = "avr")']
+runner = "ravedude -cb 57600 mega2560"
+
+[unstable]
+build-std = ["core"]

--- a/examples/atmega2560/Cargo.toml
+++ b/examples/atmega2560/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "arduino-mega2560-examples"
+name = "atmega2560-examples"
 version = "0.0.0"
-authors = ["Rahix <rahix@rahix.de>"]
+authors = ["Rahix <rahix@rahix.de>", "Armandas Jarušauskas <jarusauskas@gmail.com>"]
 edition = "2021"
 publish = false
 
@@ -10,11 +10,12 @@ panic-halt = "0.2.0"
 ufmt = "0.2.0"
 nb = "1.1.0"
 embedded-hal = "1.0"
+avr-device = { version = "0.5.4", features = ["rt"] }
 
 [dependencies.embedded-hal-v0]
 version = "0.2.3"
 package = "embedded-hal"
 
-[dependencies.arduino-hal]
-path = "../../arduino-hal/"
-features = ["arduino-mega2560"]
+[dependencies.atmega-hal]
+path = "../../atmega-hal/"
+features = ["atmega2560"]

--- a/examples/atmega2560/Cargo.toml
+++ b/examples/atmega2560/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "arduino-mega2560-examples"
+version = "0.0.0"
+authors = ["Rahix <rahix@rahix.de>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+panic-halt = "0.2.0"
+ufmt = "0.2.0"
+nb = "1.1.0"
+embedded-hal = "1.0"
+
+[dependencies.embedded-hal-v0]
+version = "0.2.3"
+package = "embedded-hal"
+
+[dependencies.arduino-hal]
+path = "../../arduino-hal/"
+features = ["arduino-mega2560"]

--- a/examples/atmega2560/Cargo.toml
+++ b/examples/atmega2560/Cargo.toml
@@ -17,5 +17,5 @@ version = "0.2.3"
 package = "embedded-hal"
 
 [dependencies.atmega-hal]
-path = "../../atmega-hal/"
+path = "../../mcu/atmega-hal/"
 features = ["atmega2560"]

--- a/examples/atmega2560/README.md
+++ b/examples/atmega2560/README.md
@@ -1,0 +1,5 @@
+# ATmega2560 Examples
+
+This directory includes examples of using plain `atmega-hal`, rather than the `hal` targeted at Arduino boards.
+
+The examples can be run and have been tested on the Arduino Mega2560 board.

--- a/examples/atmega2560/src/bin/atmega2560-adc.rs
+++ b/examples/atmega2560/src/bin/atmega2560-adc.rs
@@ -1,53 +1,66 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
+use atmega_hal::adc::channel;
+use atmega_hal::clock;
+use atmega_hal::delay::Delay;
+use atmega_hal::usart::{Baudrate, Usart};
+use embedded_hal::delay::DelayNs;
 use panic_halt as _;
 
-use arduino_hal::adc;
+type Adc = atmega_hal::adc::Adc<clock::MHz16>;
 
-#[arduino_hal::entry]
+#[avr_device::entry]
 fn main() -> ! {
-    let dp = arduino_hal::Peripherals::take().unwrap();
-    let pins = arduino_hal::pins!(dp);
-    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+    let dp = atmega_hal::Peripherals::take().unwrap();
+    let pins = atmega_hal::pins!(dp);
 
-    let mut adc = arduino_hal::Adc::new(dp.ADC, Default::default());
+    let mut delay = Delay::<clock::MHz16>::new();
+
+    // set up serial interface for text output
+    let mut serial = Usart::new(
+        dp.USART0,
+        pins.pe0,
+        pins.pe1.into_output(),
+        Baudrate::<clock::MHz16>::new(57600),
+    );
+
+    let mut adc = Adc::new(dp.ADC, Default::default());
 
     let (vbg, gnd) = (
-        adc.read_blocking(&adc::channel::Vbg),
-        adc.read_blocking(&adc::channel::Gnd),
+        adc.read_blocking(&channel::Vbg),
+        adc.read_blocking(&channel::Gnd),
     );
-    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
-    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap();
 
     // To store multiple channels in an array, we use the `into_channel()` method.
-    let channels: [adc::Channel; 16] = [
-        pins.a0.into_analog_input(&mut adc).into_channel(),
-        pins.a1.into_analog_input(&mut adc).into_channel(),
-        pins.a2.into_analog_input(&mut adc).into_channel(),
-        pins.a3.into_analog_input(&mut adc).into_channel(),
-        pins.a4.into_analog_input(&mut adc).into_channel(),
-        pins.a5.into_analog_input(&mut adc).into_channel(),
-        pins.a6.into_analog_input(&mut adc).into_channel(),
-        pins.a7.into_analog_input(&mut adc).into_channel(),
-        pins.a8.into_analog_input(&mut adc).into_channel(),
-        pins.a9.into_analog_input(&mut adc).into_channel(),
-        pins.a10.into_analog_input(&mut adc).into_channel(),
-        pins.a11.into_analog_input(&mut adc).into_channel(),
-        pins.a12.into_analog_input(&mut adc).into_channel(),
-        pins.a13.into_analog_input(&mut adc).into_channel(),
-        pins.a14.into_analog_input(&mut adc).into_channel(),
-        pins.a15.into_analog_input(&mut adc).into_channel(),
+    let channels: [atmega_hal::adc::Channel; 16] = [
+        pins.pf0.into_analog_input(&mut adc).into_channel(),
+        pins.pf1.into_analog_input(&mut adc).into_channel(),
+        pins.pf2.into_analog_input(&mut adc).into_channel(),
+        pins.pf3.into_analog_input(&mut adc).into_channel(),
+        pins.pf4.into_analog_input(&mut adc).into_channel(),
+        pins.pf5.into_analog_input(&mut adc).into_channel(),
+        pins.pf6.into_analog_input(&mut adc).into_channel(),
+        pins.pf7.into_analog_input(&mut adc).into_channel(),
+        pins.pk0.into_analog_input(&mut adc).into_channel(),
+        pins.pk1.into_analog_input(&mut adc).into_channel(),
+        pins.pk2.into_analog_input(&mut adc).into_channel(),
+        pins.pk3.into_analog_input(&mut adc).into_channel(),
+        pins.pk4.into_analog_input(&mut adc).into_channel(),
+        pins.pk5.into_analog_input(&mut adc).into_channel(),
+        pins.pk6.into_analog_input(&mut adc).into_channel(),
+        pins.pk7.into_analog_input(&mut adc).into_channel(),
     ];
 
     loop {
         for (i, ch) in channels.iter().enumerate() {
             let v = adc.read_blocking(ch);
-            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap();
         }
 
-        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
-        arduino_hal::delay_ms(1000);
+        ufmt::uwriteln!(&mut serial, "").unwrap();
+        delay.delay_ms(1000);
     }
 }

--- a/examples/atmega2560/src/bin/atmega2560-adc.rs
+++ b/examples/atmega2560/src/bin/atmega2560-adc.rs
@@ -2,27 +2,29 @@
 #![no_main]
 
 use atmega_hal::adc::channel;
-use atmega_hal::clock;
 use atmega_hal::delay::Delay;
 use atmega_hal::usart::{Baudrate, Usart};
 use embedded_hal::delay::DelayNs;
 use panic_halt as _;
 
-type Adc = atmega_hal::adc::Adc<clock::MHz16>;
+// Define core clock in the root crate
+type CoreClock = atmega_hal::clock::MHz16;
+// Use it as follows in the rest of the project
+type Adc = atmega_hal::adc::Adc<crate::CoreClock>;
 
 #[avr_device::entry]
 fn main() -> ! {
     let dp = atmega_hal::Peripherals::take().unwrap();
     let pins = atmega_hal::pins!(dp);
 
-    let mut delay = Delay::<clock::MHz16>::new();
+    let mut delay = Delay::<crate::CoreClock>::new();
 
     // set up serial interface for text output
     let mut serial = Usart::new(
         dp.USART0,
         pins.pe0,
         pins.pe1.into_output(),
-        Baudrate::<clock::MHz16>::new(57600),
+        Baudrate::<crate::CoreClock>::new(57600),
     );
 
     let mut adc = Adc::new(dp.ADC, Default::default());

--- a/examples/atmega2560/src/bin/atmega2560-adc.rs
+++ b/examples/atmega2560/src/bin/atmega2560-adc.rs
@@ -1,0 +1,53 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+use arduino_hal::adc;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    let mut adc = arduino_hal::Adc::new(dp.ADC, Default::default());
+
+    let (vbg, gnd) = (
+        adc.read_blocking(&adc::channel::Vbg),
+        adc.read_blocking(&adc::channel::Gnd),
+    );
+    ufmt::uwriteln!(&mut serial, "Vbandgap: {}", vbg).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Ground: {}", gnd).unwrap_infallible();
+
+    // To store multiple channels in an array, we use the `into_channel()` method.
+    let channels: [adc::Channel; 16] = [
+        pins.a0.into_analog_input(&mut adc).into_channel(),
+        pins.a1.into_analog_input(&mut adc).into_channel(),
+        pins.a2.into_analog_input(&mut adc).into_channel(),
+        pins.a3.into_analog_input(&mut adc).into_channel(),
+        pins.a4.into_analog_input(&mut adc).into_channel(),
+        pins.a5.into_analog_input(&mut adc).into_channel(),
+        pins.a6.into_analog_input(&mut adc).into_channel(),
+        pins.a7.into_analog_input(&mut adc).into_channel(),
+        pins.a8.into_analog_input(&mut adc).into_channel(),
+        pins.a9.into_analog_input(&mut adc).into_channel(),
+        pins.a10.into_analog_input(&mut adc).into_channel(),
+        pins.a11.into_analog_input(&mut adc).into_channel(),
+        pins.a12.into_analog_input(&mut adc).into_channel(),
+        pins.a13.into_analog_input(&mut adc).into_channel(),
+        pins.a14.into_analog_input(&mut adc).into_channel(),
+        pins.a15.into_analog_input(&mut adc).into_channel(),
+    ];
+
+    loop {
+        for (i, ch) in channels.iter().enumerate() {
+            let v = adc.read_blocking(ch);
+            ufmt::uwrite!(&mut serial, "A{}: {} ", i, v).unwrap_infallible();
+        }
+
+        ufmt::uwriteln!(&mut serial, "").unwrap_infallible();
+        arduino_hal::delay_ms(1000);
+    }
+}

--- a/examples/atmega2560/src/bin/atmega2560-blink.rs
+++ b/examples/atmega2560/src/bin/atmega2560-blink.rs
@@ -1,0 +1,17 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    let mut led = pins.d13.into_output().downgrade();
+
+    loop {
+        led.toggle();
+        arduino_hal::delay_ms(1000);
+    }
+}

--- a/examples/atmega2560/src/bin/atmega2560-blink.rs
+++ b/examples/atmega2560/src/bin/atmega2560-blink.rs
@@ -2,16 +2,20 @@
 #![no_main]
 
 use panic_halt as _;
+use atmega_hal::clock;
+use atmega_hal::delay::Delay;
+use embedded_hal::delay::DelayNs;
 
-#[arduino_hal::entry]
+#[avr_device::entry]
 fn main() -> ! {
-    let dp = arduino_hal::Peripherals::take().unwrap();
-    let pins = arduino_hal::pins!(dp);
+    let dp = atmega_hal::Peripherals::take().unwrap();
+    let pins = atmega_hal::pins!(dp);
+    let mut delay = Delay::<clock::MHz16>::new();
 
-    let mut led = pins.d13.into_output().downgrade();
+    let mut led = pins.pb7.into_output();
 
     loop {
         led.toggle();
-        arduino_hal::delay_ms(1000);
+        delay.delay_ms(1000);
     }
 }

--- a/examples/atmega2560/src/bin/atmega2560-blink.rs
+++ b/examples/atmega2560/src/bin/atmega2560-blink.rs
@@ -2,22 +2,31 @@
 #![no_main]
 
 use panic_halt as _;
-use atmega_hal::delay::Delay;
 use embedded_hal::delay::DelayNs;
 
 // Define core clock. This can be used in the rest of the project.
 type CoreClock = atmega_hal::clock::MHz16;
+type Delay = atmega_hal::delay::Delay<crate::CoreClock>;
+
+// Below are examples of a delay helper functions
+fn delay_ms(ms: u16) {
+    Delay::new().delay_ms(u32::from(ms))
+}
+
+#[allow(dead_code)]
+fn delay_us(us: u32) {
+    Delay::new().delay_us(us)
+}
 
 #[avr_device::entry]
 fn main() -> ! {
     let dp = atmega_hal::Peripherals::take().unwrap();
     let pins = atmega_hal::pins!(dp);
-    let mut delay = Delay::<crate::CoreClock>::new();
 
     let mut led = pins.pb7.into_output();
 
     loop {
         led.toggle();
-        delay.delay_ms(1000);
+        delay_ms(1000);
     }
 }

--- a/examples/atmega2560/src/bin/atmega2560-blink.rs
+++ b/examples/atmega2560/src/bin/atmega2560-blink.rs
@@ -2,15 +2,17 @@
 #![no_main]
 
 use panic_halt as _;
-use atmega_hal::clock;
 use atmega_hal::delay::Delay;
 use embedded_hal::delay::DelayNs;
+
+// Define core clock. This can be used in the rest of the project.
+type CoreClock = atmega_hal::clock::MHz16;
 
 #[avr_device::entry]
 fn main() -> ! {
     let dp = atmega_hal::Peripherals::take().unwrap();
     let pins = atmega_hal::pins!(dp);
-    let mut delay = Delay::<clock::MHz16>::new();
+    let mut delay = Delay::<crate::CoreClock>::new();
 
     let mut led = pins.pb7.into_output();
 

--- a/examples/atmega2560/src/bin/atmega2560-i2cdetect.rs
+++ b/examples/atmega2560/src/bin/atmega2560-i2cdetect.rs
@@ -1,11 +1,13 @@
 #![no_std]
 #![no_main]
 
-use atmega_hal::clock;
 use atmega_hal::usart::{Baudrate, Usart};
 use panic_halt as _;
 
-type I2c = atmega_hal::i2c::I2c<clock::MHz16>;
+// Define core clock in the root crate
+type CoreClock = atmega_hal::clock::MHz16;
+// Use it as follows in the rest of the project
+type I2c = atmega_hal::i2c::I2c<crate::CoreClock>;
 
 #[avr_device::entry]
 fn main() -> ! {
@@ -17,7 +19,7 @@ fn main() -> ! {
         dp.USART0,
         pins.pe0,
         pins.pe1.into_output(),
-        Baudrate::<clock::MHz16>::new(57600),
+        Baudrate::<crate::CoreClock>::new(57600),
     );
 
     let mut i2c = I2c::new(

--- a/examples/atmega2560/src/bin/atmega2560-i2cdetect.rs
+++ b/examples/atmega2560/src/bin/atmega2560-i2cdetect.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    let mut i2c = arduino_hal::I2c::new(
+        dp.TWI,
+        pins.d20.into_pull_up_input(),
+        pins.d21.into_pull_up_input(),
+        50000,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
+    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap_infallible();
+
+    loop {}
+}

--- a/examples/atmega2560/src/bin/atmega2560-i2cdetect.rs
+++ b/examples/atmega2560/src/bin/atmega2560-i2cdetect.rs
@@ -1,26 +1,38 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
+use atmega_hal::clock;
+use atmega_hal::usart::{Baudrate, Usart};
 use panic_halt as _;
 
-#[arduino_hal::entry]
-fn main() -> ! {
-    let dp = arduino_hal::Peripherals::take().unwrap();
-    let pins = arduino_hal::pins!(dp);
-    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+type I2c = atmega_hal::i2c::I2c<clock::MHz16>;
 
-    let mut i2c = arduino_hal::I2c::new(
-        dp.TWI,
-        pins.d20.into_pull_up_input(),
-        pins.d21.into_pull_up_input(),
-        50000,
+#[avr_device::entry]
+fn main() -> ! {
+    let dp = atmega_hal::Peripherals::take().unwrap();
+    let pins = atmega_hal::pins!(dp);
+
+    // set up serial interface for text output
+    let mut serial = Usart::new(
+        dp.USART0,
+        pins.pe0,
+        pins.pe1.into_output(),
+        Baudrate::<clock::MHz16>::new(57600),
     );
 
-    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap_infallible();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Write).unwrap_infallible();
-    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap_infallible();
-    i2c.i2cdetect(&mut serial, arduino_hal::i2c::Direction::Read).unwrap_infallible();
+    let mut i2c = I2c::new(
+        dp.TWI,
+        pins.pd1.into_pull_up_input(),
+        pins.pd0.into_pull_up_input(),
+        50_000,
+    );
+
+    ufmt::uwriteln!(&mut serial, "Write direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, atmega_hal::i2c::Direction::Write)
+        .unwrap();
+    ufmt::uwriteln!(&mut serial, "\r\nRead direction test:\r").unwrap();
+    i2c.i2cdetect(&mut serial, atmega_hal::i2c::Direction::Read)
+        .unwrap();
 
     loop {}
 }

--- a/examples/atmega2560/src/bin/atmega2560-spi-feedback.rs
+++ b/examples/atmega2560/src/bin/atmega2560-spi-feedback.rs
@@ -1,0 +1,50 @@
+//! This example demonstrates how to set up a SPI interface and communicate
+//! over it.  The physical hardware configuation consists of connecting a
+//! jumper directly from pin `~11` to pin `~12`.
+//!
+//! Once this program is written to the board, the serial output can be
+//! accessed with
+//!
+//! ```
+//! sudo screen /dev/ttyACM0 57600
+//! ```
+//!
+//! You should see it output the line `data: 15` repeatedly (aka 0b00001111).
+//! If the output you see is `data: 255`, you may need to check your jumper.
+
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use arduino_hal::spi;
+use embedded_hal_v0::spi::FullDuplex;
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+
+    // set up serial interface for text output
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    // Create SPI interface.
+    let (mut spi, _) = arduino_hal::Spi::new(
+        dp.SPI,
+        pins.d52.into_output(),
+        pins.d51.into_output(),
+        pins.d50.into_pull_up_input(),
+        pins.d53.into_output(),
+        spi::Settings::default(),
+    );
+
+    loop {
+        // Send a byte
+        nb::block!(spi.send(0b00001111)).unwrap_infallible();
+        // Because MISO is connected to MOSI, the read data should be the same
+        let data = nb::block!(spi.read()).unwrap_infallible();
+
+        ufmt::uwriteln!(&mut serial, "data: {}\r", data).unwrap_infallible();
+        arduino_hal::delay_ms(1000);
+    }
+}

--- a/examples/atmega2560/src/bin/atmega2560-spi-feedback.rs
+++ b/examples/atmega2560/src/bin/atmega2560-spi-feedback.rs
@@ -9,7 +9,6 @@
 #![no_std]
 #![no_main]
 
-use atmega_hal::clock;
 use atmega_hal::spi;
 use atmega_hal::usart::{Baudrate, Usart};
 use atmega_hal::delay::Delay;
@@ -17,19 +16,22 @@ use embedded_hal::delay::DelayNs;
 use embedded_hal::spi::SpiBus;
 use panic_halt as _;
 
+// Define core clock. This can be used in the rest of the project.
+type CoreClock = atmega_hal::clock::MHz16;
+
 #[avr_device::entry]
 fn main() -> ! {
     let dp = atmega_hal::Peripherals::take().unwrap();
     let pins = atmega_hal::pins!(dp);
 
-    let mut delay = Delay::<clock::MHz16>::new();
+    let mut delay = Delay::<crate::CoreClock>::new();
 
     // set up serial interface for text output
     let mut serial = Usart::new(
         dp.USART0,
         pins.pe0,
         pins.pe1.into_output(),
-        Baudrate::<clock::MHz16>::new(57600),
+        Baudrate::<crate::CoreClock>::new(57600),
     );
 
     // Create SPI interface.

--- a/examples/atmega2560/src/bin/atmega2560-usart.rs
+++ b/examples/atmega2560/src/bin/atmega2560-usart.rs
@@ -1,24 +1,29 @@
 #![no_std]
 #![no_main]
 
-use arduino_hal::prelude::*;
+use atmega_hal::prelude::*;
+use atmega_hal::clock;
+use atmega_hal::usart::{Baudrate, Usart};
 use panic_halt as _;
 
-use embedded_hal_v0::serial::Read;
-
-#[arduino_hal::entry]
+#[avr_device::entry]
 fn main() -> ! {
-    let dp = arduino_hal::Peripherals::take().unwrap();
-    let pins = arduino_hal::pins!(dp);
-    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+    let dp = atmega_hal::Peripherals::take().unwrap();
+    let pins = atmega_hal::pins!(dp);
+    let mut serial = Usart::new(
+        dp.USART0,
+        pins.pe0,
+        pins.pe1.into_output(),
+        Baudrate::<clock::MHz16>::new(57600),
+    );
 
-    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
+    ufmt::uwriteln!(&mut serial, "Hello from ATmega!\r").unwrap();
 
     loop {
         // Read a byte from the serial connection
-        let b = nb::block!(serial.read()).unwrap_infallible();
+        let b = nb::block!(serial.read()).unwrap();
 
         // Answer
-        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap();
     }
 }

--- a/examples/atmega2560/src/bin/atmega2560-usart.rs
+++ b/examples/atmega2560/src/bin/atmega2560-usart.rs
@@ -2,9 +2,11 @@
 #![no_main]
 
 use atmega_hal::prelude::*;
-use atmega_hal::clock;
 use atmega_hal::usart::{Baudrate, Usart};
 use panic_halt as _;
+
+// Define core clock. This can be used in the rest of the project.
+type CoreClock = atmega_hal::clock::MHz16;
 
 #[avr_device::entry]
 fn main() -> ! {
@@ -14,7 +16,7 @@ fn main() -> ! {
         dp.USART0,
         pins.pe0,
         pins.pe1.into_output(),
-        Baudrate::<clock::MHz16>::new(57600),
+        Baudrate::<crate::CoreClock>::new(57600),
     );
 
     ufmt::uwriteln!(&mut serial, "Hello from ATmega!\r").unwrap();

--- a/examples/atmega2560/src/bin/atmega2560-usart.rs
+++ b/examples/atmega2560/src/bin/atmega2560-usart.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::prelude::*;
+use panic_halt as _;
+
+use embedded_hal_v0::serial::Read;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    ufmt::uwriteln!(&mut serial, "Hello from Arduino!\r").unwrap_infallible();
+
+    loop {
+        // Read a byte from the serial connection
+        let b = nb::block!(serial.read()).unwrap_infallible();
+
+        // Answer
+        ufmt::uwriteln!(&mut serial, "Got {}!\r", b).unwrap_infallible();
+    }
+}


### PR DESCRIPTION
At first I was a bit puzzled about this crate being called `avr-hal`, while everything focuses on `arduino-hal`. As I prefer to use "plain" AVR, I took some time to figure out how to use the HAL and port the examples.

Hopefully, this will help people working on non-Arduino boards.