### PR TITLE
Enabled and fixed SPI for attiny mcu

### DIFF
--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -88,6 +88,11 @@ pub mod eeprom;
 #[cfg(feature = "device-selected")]
 pub use eeprom::Eeprom;
 
+#[cfg(feature = "device-selected")]
+pub mod spi;
+#[cfg(feature = "device-selected")]
+pub use spi::Spi;
+
 pub struct Attiny;
 
 #[cfg(feature = "attiny84")]

--- a/mcu/attiny-hal/src/spi.rs
+++ b/mcu/attiny-hal/src/spi.rs
@@ -4,7 +4,7 @@ pub use avr_hal_generic::spi::*;
 
 #[cfg(feature = "attiny88")]
 pub type Spi = avr_hal_generic::spi::Spi<
-    crate::Atmega,
+    crate::Attiny,
     crate::pac::SPI,
     port::PB5,
     port::PB3,
@@ -13,7 +13,7 @@ pub type Spi = avr_hal_generic::spi::Spi<
 >;
 #[cfg(feature = "attiny88")]
 avr_hal_generic::impl_spi! {
-    hal: crate::Atmega,
+    hal: crate::Attiny,
     peripheral: crate::pac::SPI,
     sclk: port::PB5,
     mosi: port::PB3,
@@ -23,7 +23,7 @@ avr_hal_generic::impl_spi! {
 
 #[cfg(feature = "attiny167")]
 pub type Spi = avr_hal_generic::spi::Spi<
-        crate::Atmega,
+    crate::Attiny,
     crate::pac::SPI,
     port::PA5,
     port::PA4,
@@ -32,7 +32,7 @@ pub type Spi = avr_hal_generic::spi::Spi<
     >;
 #[cfg(feature = "attiny167")]
 avr_hal_generic::impl_spi! {
-    hal: crate::Atmega,
+    hal: crate::Attiny,
     peripheral: crate::pac::SPI,
     sclk: port::PA5,
     mosi: port::PA4,


### PR DESCRIPTION
SPI was not exposed for attiny mcu by `lib.rs` so I've added it. Also I've corrected the `spi.rs` to use `Attiny` instead `Atmega`. This was tested using board with atttiny88 and neopixels connected using SPI driver and seems to work fine