### PR TITLE
examples: Pin proc-macro2 in all examples

### DIFF
--- a/examples/arduino-diecimila/Cargo.toml
+++ b/examples/arduino-diecimila/Cargo.toml
@@ -18,3 +18,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["arduino-diecimila"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/arduino-leonardo/Cargo.toml
+++ b/examples/arduino-leonardo/Cargo.toml
@@ -18,3 +18,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["arduino-leonardo"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/arduino-mega1280/Cargo.toml
+++ b/examples/arduino-mega1280/Cargo.toml
@@ -18,3 +18,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["arduino-mega1280"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/arduino-mega2560/Cargo.toml
+++ b/examples/arduino-mega2560/Cargo.toml
@@ -18,3 +18,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["arduino-mega2560"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/arduino-nano/Cargo.toml
+++ b/examples/arduino-nano/Cargo.toml
@@ -21,3 +21,9 @@ features = ["arduino-nano"]
 
 [dependencies.avr-device]
 version = "0.5.1"
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/arduino-uno/Cargo.toml
+++ b/examples/arduino-uno/Cargo.toml
@@ -28,3 +28,9 @@ version = "0.5.4"
 [dependencies.either]
 version = "1.6.1"
 default-features = false
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/atmega2560/Cargo.toml
+++ b/examples/atmega2560/Cargo.toml
@@ -19,3 +19,9 @@ package = "embedded-hal"
 [dependencies.atmega-hal]
 path = "../../mcu/atmega-hal/"
 features = ["atmega2560"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/nano168/Cargo.toml
+++ b/examples/nano168/Cargo.toml
@@ -22,3 +22,9 @@ features = ["nano168"]
 
 [dependencies.avr-device]
 version = "0.5.4"
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/sparkfun-promicro/Cargo.toml
+++ b/examples/sparkfun-promicro/Cargo.toml
@@ -18,3 +18,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["sparkfun-promicro"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/sparkfun-promini-3v3/Cargo.toml
+++ b/examples/sparkfun-promini-3v3/Cargo.toml
@@ -18,3 +18,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["sparkfun-promini-3v3"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/sparkfun-promini-5v/Cargo.toml
+++ b/examples/sparkfun-promini-5v/Cargo.toml
@@ -18,3 +18,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["sparkfun-promini-5v"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/trinket-pro/Cargo.toml
+++ b/examples/trinket-pro/Cargo.toml
@@ -16,3 +16,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["trinket-pro"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"

--- a/examples/trinket/Cargo.toml
+++ b/examples/trinket/Cargo.toml
@@ -16,3 +16,9 @@ package = "embedded-hal"
 [dependencies.arduino-hal]
 path = "../../arduino-hal/"
 features = ["trinket"]
+
+# The latest releases of `proc-macro2` do not support the rust toolchain that
+# we use.  Thus, we must fix this dependency to an older version where our
+# toolchain is still supported.  See https://github.com/Rahix/avr-hal/issues/537
+[build-dependencies.proc-macro2]
+version = "=1.0.79"


### PR DESCRIPTION
The latest releases of `proc-macro2` do not support the rust toolchain that we use (#537).  Thus, we must fix this dependency to an older version where our toolchain is still supported.