### PR TITLE
treewide: Apply changes for new svd2rust API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ exclude = [
     "ravedude",
 ]
 resolver = "2"
+
+[patch.crates-io]
+avr-device = { path = "../avr-device" }

--- a/avr-hal-generic/src/adc.rs
+++ b/avr-hal-generic/src/adc.rs
@@ -250,17 +250,17 @@ macro_rules! impl_adc {
 
             #[inline]
             fn raw_read_adc(&self) -> u16 {
-                self.adc.read().bits()
+                self.adc().read().bits()
             }
 
             #[inline]
             fn raw_is_converting(&self) -> bool {
-                self.adcsra.read().adsc().bit_is_set()
+                self.adcsra().read().adsc().bit_is_set()
             }
 
             #[inline]
             fn raw_start_conversion(&mut self) {
-                self.adcsra.modify(|_, w| w.adsc().set_bit());
+                self.adcsra().modify(|_, w| w.adsc().set_bit());
             }
 
             #[inline]
@@ -276,7 +276,7 @@ macro_rules! impl_adc {
                 match channel {
                     $(
                         x if x == $pin_channel => {
-                            $(self.$didr.modify(|_, w| w.$didr_method().set_bit());)?
+                            $(self.$didr().modify(|_, w| w.$didr_method().set_bit());)?
                         }
                     )+
                     _ => unreachable!(),
@@ -288,7 +288,7 @@ macro_rules! impl_adc {
                 match channel {
                     $(
                         x if x == $pin_channel => {
-                            $(self.$didr.modify(|_, w| w.$didr_method().clear_bit());)?
+                            $(self.$didr().modify(|_, w| w.$didr_method().clear_bit());)?
                         }
                     )+
                     _ => unreachable!(),

--- a/avr-hal-generic/src/eeprom.rs
+++ b/avr-hal-generic/src/eeprom.rs
@@ -159,8 +159,8 @@ macro_rules! impl_eeprom_common {
                         $set_address
                     }
 
-                    self.eecr.write(|w| w.eere().set_bit());
-                    self.eedr.read().bits()
+                    self.eecr().write(|w| w.eere().set_bit());
+                    self.eedr().read().bits()
                 }
             }
 
@@ -173,8 +173,8 @@ macro_rules! impl_eeprom_common {
                     }
 
                     //Start EEPROM read operation
-                    self.eecr.write(|w| w.eere().set_bit());
-                    let old_value = self.eedr.read().bits();
+                    self.eecr().write(|w| w.eere().set_bit());
+                    let old_value = self.eedr().read().bits();
                     let diff_mask = old_value ^ data;
 
                     // Check if any bits are changed to '1' in the new value.
@@ -184,20 +184,20 @@ macro_rules! impl_eeprom_common {
                         // Check if any bits in the new value are '0'.
                         if data != 0xff {
                             // Now we know that some bits need to be programmed to '0' also.
-                            self.eedr.write(|w| w.bits(data)); // Set EEPROM data register.
+                            self.eedr().write(|w| w.bits(data)); // Set EEPROM data register.
 
                             {
                                 let $periph_ewmode_var = &self;
                                 $set_erasewrite_mode
                             }
-                            self.eecr.modify(|_, w| w.eepe().set_bit()); // Start Erase+Write operation.
+                            self.eecr().modify(|_, w| w.eepe().set_bit()); // Start Erase+Write operation.
                         } else {
                             // Now we know that all bits should be erased.
                             {
                                 let $periph_emode_var = &self;
                                 $set_erase_mode
                             }
-                            self.eecr.modify(|_, w| w.eepe().set_bit()); // Start Erase-only operation.
+                            self.eecr().modify(|_, w| w.eepe().set_bit()); // Start Erase-only operation.
                         }
                     }
                     //Now we know that _no_ bits need to be erased to '1'.
@@ -205,12 +205,12 @@ macro_rules! impl_eeprom_common {
                         // Check if any bits are changed from '1' in the old value.
                         if diff_mask != 0 {
                             // Now we know that _some_ bits need to the programmed to '0'.
-                            self.eedr.write(|w| w.bits(data)); // Set EEPROM data register.
+                            self.eedr().write(|w| w.bits(data)); // Set EEPROM data register.
                             {
                                 let $periph_wmode_var = &self;
                                 $set_write_mode
                             }
-                            self.eecr.modify(|_, w| w.eepe().set_bit()); // Start Write-only operation.
+                            self.eecr().modify(|_, w| w.eepe().set_bit()); // Start Write-only operation.
                         }
                     }
                 }
@@ -229,7 +229,7 @@ macro_rules! impl_eeprom_common {
                         $set_erase_mode
                     }
                     // Start Erase-only operation.
-                    self.eecr.modify(|_, w| w.eepe().set_bit());
+                    self.eecr().modify(|_, w| w.eepe().set_bit());
                 }
             }
         }
@@ -249,7 +249,7 @@ macro_rules! impl_eeprom_atmega_old {
             #[inline]
             pub unsafe fn wait_read(regs: &$EEPROM) {
                 //Wait for completion of previous write.
-                while regs.eecr.read().eewe().bit_is_set() {}
+                while regs.eecr().read().eewe().bit_is_set() {}
             }
 
             #[inline]
@@ -268,8 +268,8 @@ macro_rules! impl_eeprom_atmega_old {
                 unsafe {
                     atmega_helper::set_address(&self, address);
                 }
-                self.eecr.write(|w| w.eere().set_bit());
-                self.eedr.read().bits()
+                self.eecr().write(|w| w.eere().set_bit());
+                self.eedr().read().bits()
             }
 
             fn raw_write_byte(&mut self, address: u16, data: u8) {
@@ -278,11 +278,11 @@ macro_rules! impl_eeprom_atmega_old {
                 }
 
                 //Start EEPROM read operation
-                self.eedr.write(|w| unsafe { w.bits(data) });
+                self.eedr().write(|w| unsafe { w.bits(data) });
 
-                self.eecr.write(|w| w.eemwe().set_bit().eewe().clear_bit());
+                self.eecr().write(|w| w.eemwe().set_bit().eewe().clear_bit());
 
-                self.eecr.write(|w| w.eewe().set_bit());
+                self.eecr().write(|w| w.eewe().set_bit());
             }
 
             fn raw_erase_byte(&mut self, address: u16) {
@@ -305,7 +305,7 @@ macro_rules! impl_eeprom_atmega {
             #[inline]
             pub unsafe fn wait_read(regs: &$EEPROM) {
                 //Wait for completion of previous write.
-                while regs.eecr.read().eepe().bit_is_set() {}
+                while regs.eecr().read().eepe().bit_is_set() {}
             }
             #[inline]
             pub unsafe fn set_address(regs: &$EEPROM, address: $addrwidth) {
@@ -316,21 +316,21 @@ macro_rules! impl_eeprom_atmega {
             }
             #[inline]
             pub unsafe fn set_erasewrite_mode(regs: &$EEPROM) {
-                regs.eecr.write(|w| {
+                regs.eecr().write(|w| {
                     // Set Master Write Enable bit, and and Erase+Write mode mode..
                     w.eempe().set_bit().eepm().val_0x00()
                 })
             }
             #[inline]
             pub unsafe fn set_erase_mode(regs: &$EEPROM) {
-                regs.eecr.write(|w| {
+                regs.eecr().write(|w| {
                     // Set Master Write Enable bit, and Erase-only mode..
                     w.eempe().set_bit().eepm().val_0x01()
                 });
             }
             #[inline]
             pub unsafe fn set_write_mode(regs: &$EEPROM) {
-                regs.eecr.write(|w| {
+                regs.eecr().write(|w| {
                     // Set Master Write Enable bit, and Write-only mode..
                     w.eempe().set_bit().eepm().val_0x02()
                 });
@@ -362,7 +362,7 @@ macro_rules! impl_eeprom_attiny {
         mod attiny_helper {
             #[inline]
             pub unsafe fn wait_read(regs: &$EEPROM) {
-                while regs.eecr.read().eepe().bit_is_set() {}
+                while regs.eecr().read().eepe().bit_is_set() {}
             }
             #[inline]
             pub unsafe fn set_address(regs: &$EEPROM, address: $addrwidth) {
@@ -373,21 +373,21 @@ macro_rules! impl_eeprom_attiny {
             }
             #[inline]
             pub unsafe fn set_erasewrite_mode(regs: &$EEPROM) {
-                regs.eecr.write(|w| {
+                regs.eecr().write(|w| {
                     // Set Master Write Enable bit...and and Erase+Write mode mode..
                     w.eempe().set_bit().eepm().atomic()
                 });
             }
             #[inline]
             pub unsafe fn set_erase_mode(regs: &$EEPROM) {
-                regs.eecr.write(|w| {
+                regs.eecr().write(|w| {
                     // Set Master Write Enable bit, and Erase-only mode..
                     w.eempe().set_bit().eepm().erase()
                 });
             }
             #[inline]
             pub unsafe fn set_write_mode(regs: &$EEPROM) {
-                regs.eecr.write(|w| {
+                regs.eecr().write(|w| {
                     // Set Master Write Enable bit, and Write-only mode..
                     w.eempe().set_bit().eepm().write()
                 });

--- a/avr-hal-generic/src/i2c.rs
+++ b/avr-hal-generic/src/i2c.rs
@@ -466,22 +466,22 @@ macro_rules! impl_i2c_twi {
             fn raw_setup<CLOCK: $crate::clock::Clock>(&mut self, speed: u32) {
                 // Calculate TWBR register value
                 let twbr = ((CLOCK::FREQ / speed) - 16) / 2;
-                self.twbr.write(|w| unsafe { w.bits(twbr as u8) });
+                self.twbr().write(|w| unsafe { w.bits(twbr as u8) });
 
                 // Disable prescaler
-                self.twsr.write(|w| w.twps().prescaler_1());
+                self.twsr().write(|w| w.twps().prescaler_1());
             }
 
             #[inline]
             fn raw_start(&mut self, address: u8, direction: Direction) -> Result<(), Error> {
                 // Write start condition
-                self.twcr
+                self.twcr()
                     .write(|w| w.twen().set_bit().twint().set_bit().twsta().set_bit());
                 // wait()
-                while self.twcr.read().twint().bit_is_clear() {}
+                while self.twcr().read().twint().bit_is_clear() {}
 
                 // Validate status
-                match self.twsr.read().tws().bits() {
+                match self.twsr().read().tws().bits() {
                     $crate::i2c::twi_status::TW_START | $crate::i2c::twi_status::TW_REP_START => (),
                     $crate::i2c::twi_status::TW_MT_ARB_LOST
                     | $crate::i2c::twi_status::TW_MR_ARB_LOST => {
@@ -502,13 +502,13 @@ macro_rules! impl_i2c_twi {
                     0
                 };
                 let rawaddr = (address << 1) | dirbit;
-                self.twdr.write(|w| unsafe { w.bits(rawaddr) });
+                self.twdr().write(|w| unsafe { w.bits(rawaddr) });
                 // transact()
-                self.twcr.write(|w| w.twen().set_bit().twint().set_bit());
-                while self.twcr.read().twint().bit_is_clear() {}
+                self.twcr().write(|w| w.twen().set_bit().twint().set_bit());
+                while self.twcr().read().twint().bit_is_clear() {}
 
                 // Check if the slave responded
-                match self.twsr.read().tws().bits() {
+                match self.twsr().read().tws().bits() {
                     $crate::i2c::twi_status::TW_MT_SLA_ACK
                     | $crate::i2c::twi_status::TW_MR_SLA_ACK => (),
                     $crate::i2c::twi_status::TW_MT_SLA_NACK
@@ -535,12 +535,12 @@ macro_rules! impl_i2c_twi {
             #[inline]
             fn raw_write(&mut self, bytes: &[u8]) -> Result<(), Error> {
                 for byte in bytes {
-                    self.twdr.write(|w| unsafe { w.bits(*byte) });
+                    self.twdr().write(|w| unsafe { w.bits(*byte) });
                     // transact()
-                    self.twcr.write(|w| w.twen().set_bit().twint().set_bit());
-                    while self.twcr.read().twint().bit_is_clear() {}
+                    self.twcr().write(|w| w.twen().set_bit().twint().set_bit());
+                    while self.twcr().read().twint().bit_is_clear() {}
 
-                    match self.twsr.read().tws().bits() {
+                    match self.twsr().read().tws().bits() {
                         $crate::i2c::twi_status::TW_MT_DATA_ACK => (),
                         $crate::i2c::twi_status::TW_MT_DATA_NACK => {
                             self.raw_stop()?;
@@ -565,17 +565,17 @@ macro_rules! impl_i2c_twi {
                 let last = buffer.len() - 1;
                 for (i, byte) in buffer.iter_mut().enumerate() {
                     if i != last {
-                        self.twcr
+                        self.twcr()
                             .write(|w| w.twint().set_bit().twen().set_bit().twea().set_bit());
                         // wait()
-                        while self.twcr.read().twint().bit_is_clear() {}
+                        while self.twcr().read().twint().bit_is_clear() {}
                     } else {
-                        self.twcr.write(|w| w.twint().set_bit().twen().set_bit());
+                        self.twcr().write(|w| w.twint().set_bit().twen().set_bit());
                         // wait()
-                        while self.twcr.read().twint().bit_is_clear() {}
+                        while self.twcr().read().twint().bit_is_clear() {}
                     }
 
-                    match self.twsr.read().tws().bits() {
+                    match self.twsr().read().tws().bits() {
                         $crate::i2c::twi_status::TW_MR_DATA_ACK
                         | $crate::i2c::twi_status::TW_MR_DATA_NACK => (),
                         $crate::i2c::twi_status::TW_MR_ARB_LOST => {
@@ -589,14 +589,14 @@ macro_rules! impl_i2c_twi {
                         }
                     }
 
-                    *byte = self.twdr.read().bits();
+                    *byte = self.twdr().read().bits();
                 }
                 Ok(())
             }
 
             #[inline]
             fn raw_stop(&mut self) -> Result<(), Error> {
-                self.twcr
+                self.twcr()
                     .write(|w| w.twen().set_bit().twint().set_bit().twsto().set_bit());
                 Ok(())
             }

--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -632,7 +632,7 @@ macro_rules! impl_port_traditional {
                 #[inline]
                 unsafe fn out_set(&mut self) {
                     match self.port {
-                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<port $name:lower>].modify(|r, w| {
+                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<port $name:lower>]().modify(|r, w| {
                             w.bits(r.bits() | self.mask)
                         }),)+
                     }
@@ -641,7 +641,7 @@ macro_rules! impl_port_traditional {
                 #[inline]
                 unsafe fn out_clear(&mut self) {
                     match self.port {
-                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<port $name:lower>].modify(|r, w| {
+                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<port $name:lower>]().modify(|r, w| {
                             w.bits(r.bits() & !self.mask)
                         }),)+
                     }
@@ -650,7 +650,7 @@ macro_rules! impl_port_traditional {
                 #[inline]
                 unsafe fn out_toggle(&mut self) {
                     match self.port {
-                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<pin $name:lower>].write(|w| {
+                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<pin $name:lower>]().write(|w| {
                             w.bits(self.mask)
                         }),)+
                     }
@@ -660,7 +660,7 @@ macro_rules! impl_port_traditional {
                 unsafe fn out_get(&self) -> bool {
                     match self.port {
                         $(DynamicPort::[<PORT $name>] => {
-                            (*<$port>::ptr()).[<port $name:lower>].read().bits() & self.mask != 0
+                            (*<$port>::ptr()).[<port $name:lower>]().read().bits() & self.mask != 0
                         })+
                     }
                 }
@@ -669,7 +669,7 @@ macro_rules! impl_port_traditional {
                 unsafe fn in_get(&self) -> bool {
                     match self.port {
                         $(DynamicPort::[<PORT $name>] => {
-                            (*<$port>::ptr()).[<pin $name:lower>].read().bits() & self.mask != 0
+                            (*<$port>::ptr()).[<pin $name:lower>]().read().bits() & self.mask != 0
                         })+
                     }
                 }
@@ -677,7 +677,7 @@ macro_rules! impl_port_traditional {
                 #[inline]
                 unsafe fn make_output(&mut self) {
                     match self.port {
-                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<ddr $name:lower>].modify(|r, w| {
+                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<ddr $name:lower>]().modify(|r, w| {
                             w.bits(r.bits() | self.mask)
                         }),)+
                     }
@@ -686,7 +686,7 @@ macro_rules! impl_port_traditional {
                 #[inline]
                 unsafe fn make_input(&mut self, pull_up: bool) {
                     match self.port {
-                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<ddr $name:lower>].modify(|r, w| {
+                        $(DynamicPort::[<PORT $name>] => (*<$port>::ptr()).[<ddr $name:lower>]().modify(|r, w| {
                             w.bits(r.bits() & !self.mask)
                         }),)+
                     }
@@ -715,45 +715,45 @@ macro_rules! impl_port_traditional {
 
                     #[inline]
                     unsafe fn out_set(&mut self) {
-                        (*<$port>::ptr()).[<port $name:lower>].modify(|_, w| {
+                        (*<$port>::ptr()).[<port $name:lower>]().modify(|_, w| {
                             w.[<p $name:lower $pin>]().set_bit()
                         })
                     }
 
                     #[inline]
                     unsafe fn out_clear(&mut self) {
-                        (*<$port>::ptr()).[<port $name:lower>].modify(|_, w| {
+                        (*<$port>::ptr()).[<port $name:lower>]().modify(|_, w| {
                             w.[<p $name:lower $pin>]().clear_bit()
                         })
                     }
 
                     #[inline]
                     unsafe fn out_toggle(&mut self) {
-                        (*<$port>::ptr()).[<pin $name:lower>].write(|w| {
+                        (*<$port>::ptr()).[<pin $name:lower>]().write(|w| {
                             w.[<p $name:lower $pin>]().set_bit()
                         })
                     }
 
                     #[inline]
                     unsafe fn out_get(&self) -> bool {
-                        (*<$port>::ptr()).[<port $name:lower>].read().[<p $name:lower $pin>]().bit()
+                        (*<$port>::ptr()).[<port $name:lower>]().read().[<p $name:lower $pin>]().bit()
                     }
 
                     #[inline]
                     unsafe fn in_get(&self) -> bool {
-                        (*<$port>::ptr()).[<pin $name:lower>].read().[<p $name:lower $pin>]().bit()
+                        (*<$port>::ptr()).[<pin $name:lower>]().read().[<p $name:lower $pin>]().bit()
                     }
 
                     #[inline]
                     unsafe fn make_output(&mut self) {
-                        (*<$port>::ptr()).[<ddr $name:lower>].modify(|_, w| {
+                        (*<$port>::ptr()).[<ddr $name:lower>]().modify(|_, w| {
                             w.[<p $name:lower $pin>]().set_bit()
                         })
                     }
 
                     #[inline]
                     unsafe fn make_input(&mut self, pull_up: bool) {
-                        (*<$port>::ptr()).[<ddr $name:lower>].modify(|_, w| {
+                        (*<$port>::ptr()).[<ddr $name:lower>]().modify(|_, w| {
                             w.[<p $name:lower $pin>]().clear_bit()
                         });
                         if pull_up {

--- a/avr-hal-generic/src/simple_pwm.rs
+++ b/avr-hal-generic/src/simple_pwm.rs
@@ -175,7 +175,7 @@ macro_rules! impl_simple_pwm {
                 }
 
                 fn get_duty(&self) -> Self::Duty {
-                    unsafe { (&*<$TIMER>::ptr()) }.$ocr.read().bits() as Self::Duty
+                    unsafe { (&*<$TIMER>::ptr()) }.$ocr().read().bits() as Self::Duty
                 }
 
                 fn get_max_duty(&self) -> Self::Duty {
@@ -185,7 +185,7 @@ macro_rules! impl_simple_pwm {
                 fn set_duty(&mut self, duty: Self::Duty) {
                     // SAFETY: This register is exclusively used here so there are no concurrency
                     // issues.
-                    unsafe { (&*<$TIMER>::ptr()).$ocr.write(|w| w.bits(duty.into())); };
+                    unsafe { (&*<$TIMER>::ptr()).$ocr().write(|w| w.bits(duty.into())); };
                 }
             }
         )+

--- a/avr-hal-generic/src/spi.rs
+++ b/avr-hal-generic/src/spi.rs
@@ -454,7 +454,7 @@ macro_rules! impl_spi {
                 use $crate::hal::spi;
 
                 // set up control register
-                self.spcr.write(|w| {
+                self.spcr().write(|w| {
                     // enable SPI
                     w.spe().set_bit();
                     // Set to primary mode
@@ -486,7 +486,7 @@ macro_rules! impl_spi {
                     }
                 });
                 // set up 2x clock rate status bit
-                self.spsr.write(|w| match settings.clock {
+                self.spsr().write(|w| match settings.clock {
                     SerialClockRate::OscfOver2 => w.spi2x().set_bit(),
                     SerialClockRate::OscfOver4 => w.spi2x().clear_bit(),
                     SerialClockRate::OscfOver8 => w.spi2x().set_bit(),
@@ -498,19 +498,19 @@ macro_rules! impl_spi {
             }
 
             fn raw_release(&mut self) {
-                self.spcr.write(|w| w.spe().clear_bit());
+                self.spcr().write(|w| w.spe().clear_bit());
             }
 
             fn raw_check_iflag(&self) -> bool {
-                self.spsr.read().spif().bit_is_set()
+                self.spsr().read().spif().bit_is_set()
             }
 
             fn raw_read(&self) -> u8 {
-                self.spdr.read().bits()
+                self.spdr().read().bits()
             }
 
             fn raw_write(&mut self, byte: u8) {
-                self.spdr.write(|w| unsafe { w.bits(byte) });
+                self.spdr().write(|w| unsafe { w.bits(byte) });
             }
 
             fn raw_transaction(&mut self, byte: u8) -> u8 {

--- a/avr-hal-generic/src/usart.rs
+++ b/avr-hal-generic/src/usart.rs
@@ -484,18 +484,18 @@ macro_rules! impl_usart_traditional {
                 $crate::port::Pin<$crate::port::mode::Output, $txpin>,
             > for $USART {
                 fn raw_init<CLOCK>(&mut self, baudrate: $crate::usart::Baudrate<CLOCK>) {
-                    self.[<ubrr $n>].write(|w| unsafe { w.bits(baudrate.ubrr) });
-                    self.[<ucsr $n a>].write(|w| w.[<u2x $n>]().bit(baudrate.u2x));
+                    self.[<ubrr $n>]().write(|w| unsafe { w.bits(baudrate.ubrr) });
+                    self.[<ucsr $n a>]().write(|w| w.[<u2x $n>]().bit(baudrate.u2x));
 
                     // Enable receiver and transmitter but leave interrupts disabled.
-                    self.[<ucsr $n b>].write(|w| w
+                    self.[<ucsr $n b>]().write(|w| w
                         .[<txen $n>]().set_bit()
                         .[<rxen $n>]().set_bit()
                     );
 
                     // Set frame format to 8n1 for now.  At some point, this should be made
                     // configurable, similar to what is done in other HALs.
-                    self.[<ucsr $n c>].write(|w| w
+                    self.[<ucsr $n c>]().write(|w| w
                         .[<umsel $n>]().usart_async()
                         .[<ucsz $n>]().chr8()
                         .[<usbs $n>]().stop1()
@@ -506,11 +506,11 @@ macro_rules! impl_usart_traditional {
                 fn raw_deinit(&mut self) {
                     // Wait for any ongoing transfer to finish.
                     $crate::nb::block!(self.raw_flush()).ok();
-                    self.[<ucsr $n b>].reset();
+                    self.[<ucsr $n b>]().reset();
                 }
 
                 fn raw_flush(&mut self) -> $crate::nb::Result<(), core::convert::Infallible> {
-                    if self.[<ucsr $n a>].read().[<udre $n>]().bit_is_clear() {
+                    if self.[<ucsr $n a>]().read().[<udre $n>]().bit_is_clear() {
                         Err($crate::nb::Error::WouldBlock)
                     } else {
                         Ok(())
@@ -521,26 +521,26 @@ macro_rules! impl_usart_traditional {
                     // Call flush to make sure the data-register is empty
                     self.raw_flush()?;
 
-                    self.[<udr $n>].write(|w| unsafe { w.bits(byte) });
+                    self.[<udr $n>]().write(|w| unsafe { w.bits(byte) });
                     Ok(())
                 }
 
                 fn raw_read(&mut self) -> $crate::nb::Result<u8, core::convert::Infallible> {
-                    if self.[<ucsr $n a>].read().[<rxc $n>]().bit_is_clear() {
+                    if self.[<ucsr $n a>]().read().[<rxc $n>]().bit_is_clear() {
                         return Err($crate::nb::Error::WouldBlock);
                     }
 
-                    Ok(self.[<udr $n>].read().bits())
+                    Ok(self.[<udr $n>]().read().bits())
                 }
 
                 fn raw_interrupt(&mut self, event: $crate::usart::Event, state: bool) {
                     match event {
                         $crate::usart::Event::RxComplete =>
-                            self.[<ucsr $n b>].modify(|_, w| w.[<rxcie $n>]().bit(state)),
+                            self.[<ucsr $n b>]().modify(|_, w| w.[<rxcie $n>]().bit(state)),
                         $crate::usart::Event::TxComplete =>
-                            self.[<ucsr $n b>].modify(|_, w| w.[<txcie $n>]().bit(state)),
+                            self.[<ucsr $n b>]().modify(|_, w| w.[<txcie $n>]().bit(state)),
                         $crate::usart::Event::DataRegisterEmpty =>
-                            self.[<ucsr $n b>].modify(|_, w| w.[<udrie $n>]().bit(state)),
+                            self.[<ucsr $n b>]().modify(|_, w| w.[<udrie $n>]().bit(state)),
                     }
                 }
             }

--- a/avr-hal-generic/src/wdt.rs
+++ b/avr-hal-generic/src/wdt.rs
@@ -112,10 +112,10 @@ macro_rules! impl_wdt {
                     // Reset the watchdog timer.
                     self.raw_feed();
                     // Enable watchdog configuration mode.
-                    self.$wdtcsr
+                    self.$wdtcsr()
                         .modify(|_, w| w.wdce().set_bit().wde().set_bit());
                     // Enable watchdog and set interval.
-                    self.$wdtcsr.write(|w| {
+                    self.$wdtcsr().write(|w| {
                         let $to = timeout;
                         let $w = w;
                         ($to_match).wde().set_bit().wdce().clear_bit()
@@ -143,10 +143,10 @@ macro_rules! impl_wdt {
                     // Reset the watchdog timer.
                     self.raw_feed();
                     // Enable watchdog configuration mode.
-                    self.$wdtcsr
+                    self.$wdtcsr()
                         .modify(|_, w| w.wdce().set_bit().wde().set_bit());
                     // Disable watchdog.
-                    self.$wdtcsr.reset();
+                    self.$wdtcsr().reset();
                 })
             }
         }

--- a/examples/arduino-uno/src/bin/uno-ext-interrupt.rs
+++ b/examples/arduino-uno/src/bin/uno-ext-interrupt.rs
@@ -47,9 +47,9 @@ fn main() -> ! {
 
     // thanks to tsemczyszyn and Rahix: https://github.com/Rahix/avr-hal/issues/240
     // Configure INT0 for falling edge. 0x03 would be rising edge.
-    dp.EXINT.eicra.modify(|_, w| w.isc0().bits(0x02));
+    dp.EXINT.eicra().modify(|_, w| w.isc0().set(0x02));
     // Enable the INT0 interrupt source.
-    dp.EXINT.eimsk.modify(|_, w| w.int0().set_bit());
+    dp.EXINT.eimsk().modify(|_, w| w.int0().set_bit());
 
     let mut leds: [Pin<mode::Output>; 4] = [
         pins.d3.into_output().downgrade(),

--- a/examples/arduino-uno/src/bin/uno-infrared.rs
+++ b/examples/arduino-uno/src/bin/uno-infrared.rs
@@ -62,10 +62,10 @@ fn main() -> ! {
     irdroino_led2.set_low();
 
     // Enable group 2 (PORTD)
-    dp.EXINT.pcicr.write(|w| unsafe { w.bits(0b100) });
+    dp.EXINT.pcicr().write(|w| unsafe { w.bits(0b100) });
 
     // Enable pin change interrupts on PCINT18 which is pin PD2 (= d2)
-    dp.EXINT.pcmsk2.write(|w| w.bits(0b100));
+    dp.EXINT.pcmsk2().write(|w| w.set(0b100));
 
     let ir = Receiver::with_pin(Clock::FREQ, pins.d2);
 
@@ -141,12 +141,12 @@ impl Clock {
 
     pub fn start(&self, tc0: arduino_hal::pac::TC0) {
         // Configure the timer for the above interval (in CTC mode)
-        tc0.tccr0a.write(|w| w.wgm0().ctc());
-        tc0.ocr0a.write(|w| w.bits(Self::TOP));
-        tc0.tccr0b.write(|w| w.cs0().variant(Self::PRESCALER));
+        tc0.tccr0a().write(|w| w.wgm0().ctc());
+        tc0.ocr0a().write(|w| w.set(Self::TOP));
+        tc0.tccr0b().write(|w| w.cs0().variant(Self::PRESCALER));
 
         // Enable interrupt
-        tc0.timsk0.write(|w| w.ocie0a().set_bit());
+        tc0.timsk0().write(|w| w.ocie0a().set_bit());
     }
 
     pub fn now(&self) -> u32 {

--- a/examples/arduino-uno/src/bin/uno-manual-servo.rs
+++ b/examples/arduino-uno/src/bin/uno-manual-servo.rs
@@ -30,17 +30,17 @@ fn main() -> ! {
     // - Each count increases the duty-cycle by 4us.
     // - Use OC1A which is connected to D9 of the Arduino Uno.
     let tc1 = dp.TC1;
-    tc1.icr1.write(|w| w.bits(4999));
-    tc1.tccr1a
-        .write(|w| w.wgm1().bits(0b10).com1a().match_clear());
-    tc1.tccr1b
-        .write(|w| w.wgm1().bits(0b11).cs1().prescale_64());
+    tc1.icr1().write(|w| w.set(4999));
+    tc1.tccr1a()
+        .write(|w| w.wgm1().set(0b10).com1a().match_clear());
+    tc1.tccr1b()
+        .write(|w| w.wgm1().set(0b11).cs1().prescale_64());
 
     loop {
         // 100 counts => 0.4ms
         // 700 counts => 2.8ms
         for duty in 100..=700 {
-            tc1.ocr1a.write(|w| w.bits(duty));
+            tc1.ocr1a().write(|w| w.set(duty));
             arduino_hal::delay_ms(20);
         }
     }

--- a/examples/arduino-uno/src/bin/uno-millis.rs
+++ b/examples/arduino-uno/src/bin/uno-millis.rs
@@ -40,16 +40,16 @@ static MILLIS_COUNTER: avr_device::interrupt::Mutex<cell::Cell<u32>> =
 fn millis_init(tc0: arduino_hal::pac::TC0) {
     // Configure the timer for the above interval (in CTC mode)
     // and enable its interrupt.
-    tc0.tccr0a.write(|w| w.wgm0().ctc());
-    tc0.ocr0a.write(|w| w.bits(TIMER_COUNTS as u8));
-    tc0.tccr0b.write(|w| match PRESCALER {
+    tc0.tccr0a().write(|w| w.wgm0().ctc());
+    tc0.ocr0a().write(|w| w.set(TIMER_COUNTS as u8));
+    tc0.tccr0b().write(|w| match PRESCALER {
         8 => w.cs0().prescale_8(),
         64 => w.cs0().prescale_64(),
         256 => w.cs0().prescale_256(),
         1024 => w.cs0().prescale_1024(),
         _ => panic!(),
     });
-    tc0.timsk0.write(|w| w.ocie0a().set_bit());
+    tc0.timsk0().write(|w| w.ocie0a().set_bit());
 
     // Reset the global millisecond counter
     avr_device::interrupt::free(|cs| {

--- a/examples/arduino-uno/src/bin/uno-pin-change-interrupt.rs
+++ b/examples/arduino-uno/src/bin/uno-pin-change-interrupt.rs
@@ -49,10 +49,10 @@ fn main() -> ! {
     ];
 
     // Enable the PCINT2 pin change interrupt
-    dp.EXINT.pcicr.write(|w| unsafe { w.bits(0b100) });
+    dp.EXINT.pcicr().write(|w| unsafe { w.bits(0b100) });
 
     // Enable pin change interrupts on PCINT18 which is pin PD2 (= d2)
-    dp.EXINT.pcmsk2.write(|w| w.bits(0b100));
+    dp.EXINT.pcmsk2().write(|w| w.set(0b100));
 
     //From this point on an interrupt can happen
     unsafe { avr_device::interrupt::enable() };

--- a/examples/arduino-uno/src/bin/uno-timer.rs
+++ b/examples/arduino-uno/src/bin/uno-timer.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
     ufmt::uwriteln!(
         &mut serial,
         "configured timer output compare register = {}",
-        tmr1.ocr1a.read().bits()
+        tmr1.ocr1a().read().bits()
     )
     .unwrap_infallible();
 
@@ -107,16 +107,16 @@ pub fn rig_timer<W: uWrite<Error = ::core::convert::Infallible>>(tmr1: &TC1, ser
     )
     .unwrap_infallible();
 
-    tmr1.tccr1a.write(|w| w.wgm1().bits(0b00));
-    tmr1.tccr1b.write(|w| {
+    tmr1.tccr1a().write(|w| w.wgm1().set(0b00));
+    tmr1.tccr1b().write(|w| {
         w.cs1()
             //.prescale_256()
             .variant(CLOCK_SOURCE)
             .wgm1()
-            .bits(0b01)
+            .set(0b01)
     });
-    tmr1.ocr1a.write(|w| w.bits(ticks));
-    tmr1.timsk1.write(|w| w.ocie1a().set_bit()); //enable this specific interrupt
+    tmr1.ocr1a().write(|w| w.set(ticks));
+    tmr1.timsk1().write(|w| w.ocie1a().set_bit()); //enable this specific interrupt
 }
 
 #[avr_device::interrupt(atmega328p)]

--- a/examples/arduino-uno/src/bin/uno-watchdog.rs
+++ b/examples/arduino-uno/src/bin/uno-watchdog.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
         arduino_hal::delay_ms(100);
     }
 
-    let mut watchdog = wdt::Wdt::new(dp.WDT, &dp.CPU.mcusr);
+    let mut watchdog = wdt::Wdt::new(dp.WDT, &dp.CPU.mcusr());
     watchdog.start(wdt::Timeout::Ms2000).unwrap();
 
     loop {

--- a/examples/nano168/src/bin/nano168-millis.rs
+++ b/examples/nano168/src/bin/nano168-millis.rs
@@ -38,16 +38,16 @@ static MILLIS_COUNTER: avr_device::interrupt::Mutex<cell::Cell<u32>> =
 fn millis_init(tc0: arduino_hal::pac::TC0) {
     // Configure the timer for the above interval (in CTC mode)
     // and enable its interrupt.
-    tc0.tccr0a.write(|w| w.wgm0().ctc());
-    tc0.ocr0a.write(|w| w.bits(TIMER_COUNTS as u8));
-    tc0.tccr0b.write(|w| match PRESCALER {
+    tc0.tccr0a().write(|w| w.wgm0().ctc());
+    tc0.ocr0a().write(|w| w.set(TIMER_COUNTS as u8));
+    tc0.tccr0b().write(|w| match PRESCALER {
         8 => w.cs0().prescale_8(),
         64 => w.cs0().prescale_64(),
         256 => w.cs0().prescale_256(),
         1024 => w.cs0().prescale_1024(),
         _ => panic!(),
     });
-    tc0.timsk0.write(|w| w.ocie0a().set_bit());
+    tc0.timsk0().write(|w| w.ocie0a().set_bit());
 
     // Reset the global millisecond counter
     avr_device::interrupt::free(|cs| {

--- a/examples/nano168/src/bin/nano168-watchdog.rs
+++ b/examples/nano168/src/bin/nano168-watchdog.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     }
     ufmt::uwriteln!(&mut serial, "\nEnabling watchdog...").unwrap_infallible();
 
-    let mut watchdog = wdt::Wdt::new(dp.WDT, &dp.CPU.mcusr);
+    let mut watchdog = wdt::Wdt::new(dp.WDT, &dp.CPU.mcusr());
     watchdog.start(wdt::Timeout::Ms4000).unwrap();
 
     ufmt::uwriteln!(&mut serial, "\nWatchdog on watch...").unwrap_infallible();

--- a/mcu/atmega-hal/src/adc.rs
+++ b/mcu/atmega-hal/src/adc.rs
@@ -32,7 +32,7 @@ pub struct AdcSettings {
 }
 
 fn apply_settings(peripheral: &crate::pac::ADC, settings: AdcSettings) {
-    peripheral.adcsra.write(|w| {
+    peripheral.adcsra().write(|w| {
         w.aden().set_bit();
         match settings.clock_divider {
             ClockDivider::Factor2 => w.adps().prescaler_2(),
@@ -44,7 +44,7 @@ fn apply_settings(peripheral: &crate::pac::ADC, settings: AdcSettings) {
             ClockDivider::Factor128 => w.adps().prescaler_128(),
         }
     });
-    peripheral.admux.write(|w| match settings.ref_voltage {
+    peripheral.admux().write(|w| match settings.ref_voltage {
         ReferenceVoltage::Aref => w.refs().aref(),
         ReferenceVoltage::AVcc => w.refs().avcc(),
         ReferenceVoltage::Internal => w.refs().internal(),
@@ -150,7 +150,7 @@ avr_hal_generic::impl_adc! {
     apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PC0: (crate::pac::adc::admux::MUX_A::ADC0, didr0::adc0d),
@@ -180,7 +180,7 @@ avr_hal_generic::impl_adc! {
     apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PA0: (crate::pac::adc::admux::MUX_A::ADC0),
@@ -206,8 +206,8 @@ avr_hal_generic::impl_adc! {
     apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
     channel_id: u8,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().bits(id & 0x1f));
-        peripheral.adcsrb.modify(|_, w| w.mux5().bit(id & 0x20 != 0));
+        peripheral.admux().modify(|_, w| w.mux().set(id & 0x1f));
+        peripheral.adcsrb().modify(|_, w| w.mux5().bit(id & 0x20 != 0));
     },
     pins: {
         port::PF0: (0b000000, didr0::adc0d),
@@ -238,7 +238,7 @@ avr_hal_generic::impl_adc! {
     apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PF0: (crate::pac::adc::admux::MUX_A::ADC0),
@@ -264,8 +264,8 @@ avr_hal_generic::impl_adc! {
     apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
     channel_id: u8,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().bits(id & 0x1f));
-        peripheral.adcsrb.modify(|_, w| w.mux5().bit(id & 0x20 != 0));
+        peripheral.admux().modify(|_, w| w.mux().set(id & 0x1f));
+        peripheral.adcsrb().modify(|_, w| w.mux5().bit(id & 0x20 != 0));
     },
     pins: {
         port::PF0: (0b000000, didr0::adc0d),
@@ -299,7 +299,7 @@ avr_hal_generic::impl_adc! {
     apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PA0: (crate::pac::adc::admux::MUX_A::ADC0, didr0::adc0d),
@@ -327,7 +327,7 @@ avr_hal_generic::impl_adc! {
     apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PC0: (crate::pac::adc::admux::MUX_A::ADC0),
@@ -355,7 +355,7 @@ avr_hal_generic::impl_adc! {
     apply_settings: |peripheral, settings| { apply_settings(peripheral, settings) },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PA0: (crate::pac::adc::admux::MUX_A::ADC0, didr0::adc0d),

--- a/mcu/atmega-hal/src/eeprom.rs
+++ b/mcu/atmega-hal/src/eeprom.rs
@@ -10,7 +10,7 @@ avr_hal_generic::impl_eeprom_atmega! {
     capacity: 256,
     addr_width: u8,
     set_address: |peripheral, address| {
-        peripheral.eearl.write(|w| w.bits(address));
+        peripheral.eearl().write(|w| w.bits(address));
     },
 }
 
@@ -21,7 +21,7 @@ avr_hal_generic::impl_eeprom_atmega! {
     capacity: 512,
     addr_width: u16,
     set_address: |peripheral, address| {
-        peripheral.eear.write(|w| w.bits(address));
+        peripheral.eear().write(|w| w.bits(address));
     },
 }
 
@@ -36,7 +36,7 @@ avr_hal_generic::impl_eeprom_atmega! {
     capacity: 1024,
     addr_width: u16,
     set_address: |peripheral, address| {
-        peripheral.eear.write(|w| w.bits(address));
+        peripheral.eear().write(|w| w.bits(address));
     },
 }
 
@@ -51,7 +51,7 @@ avr_hal_generic::impl_eeprom_atmega! {
     capacity: 4096,
     addr_width: u16,
     set_address: |peripheral, address| {
-        peripheral.eear.write(|w| w.bits(address));
+        peripheral.eear().write(|w| w.bits(address));
     },
 }
 
@@ -62,7 +62,7 @@ avr_hal_generic::impl_eeprom_atmega_old! {
     capacity: 512,
     addr_width: u16,
     set_address: |peripheral, address| {
-        peripheral.eear.write(|w| w.bits(address));
+        peripheral.eear().write(|w| w.bits(address));
     },
 }
 
@@ -73,7 +73,7 @@ avr_hal_generic::impl_eeprom_atmega_old! {
     capacity: 1024,
     addr_width: u16,
     set_address: |peripheral, address| {
-        peripheral.eear.write(|w| w.bits(address));
+        peripheral.eear().write(|w| w.bits(address));
     },
 }
 
@@ -84,6 +84,6 @@ avr_hal_generic::impl_eeprom_atmega_old! {
     capacity: 4096,
     addr_width: u16,
     set_address: |peripheral, address| {
-        peripheral.eear.write(|w| w.bits(address));
+        peripheral.eear().write(|w| w.bits(address));
     },
 }

--- a/mcu/atmega-hal/src/simple_pwm.rs
+++ b/mcu/atmega-hal/src/simple_pwm.rs
@@ -25,8 +25,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer0Pwm {
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
-            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
-            tim.tccr0b.modify(|_r, w| match prescaler {
+            tim.tccr0a().modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs0().direct(),
                 Prescaler::Prescale8 => w.cs0().prescale_8(),
                 Prescaler::Prescale64 => w.cs0().prescale_64(),
@@ -38,18 +38,18 @@ avr_hal_generic::impl_simple_pwm! {
             PD6: {
                 ocr: ocr0a,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0a().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0a().disconnected());
                 },
             },
 
             PD5: {
                 ocr: ocr0b,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0b().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0b().disconnected());
                 },
             },
         },
@@ -78,9 +78,9 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_r, w| {
-                w.wgm1().bits(0b01);
+            tim.tccr1a().modify(|_r, w| w.wgm1().set(0b01));
+            tim.tccr1b().modify(|_r, w| {
+                w.wgm1().set(0b01);
 
                 match prescaler {
                     Prescaler::Direct => w.cs1().direct(),
@@ -95,18 +95,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB1: {
                 ocr: ocr1a,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1a().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1a().disconnected());
                 },
             },
 
             PB2: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1b().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1b().disconnected());
                 },
             },
         },
@@ -135,8 +135,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer2Pwm {
         timer: crate::pac::TC2,
         init: |tim, prescaler| {
-            tim.tccr2a.modify(|_r, w| w.wgm2().pwm_fast());
-            tim.tccr2b.modify(|_r, w| match prescaler {
+            tim.tccr2a().modify(|_r, w| w.wgm2().pwm_fast());
+            tim.tccr2b().modify(|_r, w| match prescaler {
                     Prescaler::Direct => w.cs2().direct(),
                     Prescaler::Prescale8 => w.cs2().prescale_8(),
                     Prescaler::Prescale64 => w.cs2().prescale_64(),
@@ -148,18 +148,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB3: {
                 ocr: ocr2a,
                 into_pwm: |tim| if enable {
-                    tim.tccr2a.modify(|_r, w| w.com2a().match_clear());
+                    tim.tccr2a().modify(|_r, w| w.com2a().match_clear());
                 } else {
-                    tim.tccr2a.modify(|_r, w| w.com2a().disconnected());
+                    tim.tccr2a().modify(|_r, w| w.com2a().disconnected());
                 },
             },
 
             PD3: {
                 ocr: ocr2b,
                 into_pwm: |tim| if enable {
-                    tim.tccr2a.modify(|_r, w| w.com2b().match_clear());
+                    tim.tccr2a().modify(|_r, w| w.com2b().match_clear());
                 } else {
-                    tim.tccr2a.modify(|_r, w| w.com2b().disconnected());
+                    tim.tccr2a().modify(|_r, w| w.com2b().disconnected());
                 },
             },
         },
@@ -172,8 +172,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer3Pwm {
         timer: crate::pac::TC3,
         init: |tim, prescaler| {
-            tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
-            tim.tccr3b.modify(|_r, w| {
+            tim.tccr3a().modify(|_r, w| w.wgm3().set(0b01));
+            tim.tccr3b().modify(|_r, w| {
                 unsafe { w.wgm3().bits(0b01) };
 
                 match prescaler {
@@ -189,18 +189,18 @@ avr_hal_generic::impl_simple_pwm! {
             PD0: {
                 ocr: ocr3a,
                 into_pwm: |tim| if enable {
-                    tim.tccr3a.modify(|_r, w| w.com3a().match_clear());
+                    tim.tccr3a().modify(|_r, w| w.com3a().match_clear());
                 } else {
-                    tim.tccr3a.modify(|_r, w| w.com3a().disconnected());
+                    tim.tccr3a().modify(|_r, w| w.com3a().disconnected());
                 },
             },
 
             PD2: {
                 ocr: ocr3b,
                 into_pwm: |tim| if enable {
-                    tim.tccr3a.modify(|_r, w| w.com3b().match_clear());
+                    tim.tccr3a().modify(|_r, w| w.com3b().match_clear());
                 } else {
-                    tim.tccr3a.modify(|_r, w| w.com3b().disconnected());
+                    tim.tccr3a().modify(|_r, w| w.com3b().disconnected());
                 },
             },
         },
@@ -213,8 +213,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer4Pwm {
         timer: crate::pac::TC4,
         init: |tim, prescaler| {
-            tim.tccr4a.modify(|_r, w| w.wgm4().bits(0b01));
-            tim.tccr4b.modify(|_r, w| {
+            tim.tccr4a().modify(|_r, w| w.wgm4().set(0b01));
+            tim.tccr4b().modify(|_r, w| {
                 unsafe { w.wgm4().bits(0b01) };
 
                 match prescaler {
@@ -230,18 +230,18 @@ avr_hal_generic::impl_simple_pwm! {
             PD1: {
                 ocr: ocr4a,
                 into_pwm: |tim| if enable {
-                    tim.tccr4a.modify(|_r, w| w.com4a().match_clear());
+                    tim.tccr4a().modify(|_r, w| w.com4a().match_clear());
                 } else {
-                    tim.tccr4a.modify(|_r, w| w.com4a().disconnected());
+                    tim.tccr4a().modify(|_r, w| w.com4a().disconnected());
                 },
             },
 
             PD2: {
                 ocr: ocr4b,
                 into_pwm: |tim| if enable {
-                    tim.tccr4a.modify(|_r, w| w.com4b().match_clear());
+                    tim.tccr4a().modify(|_r, w| w.com4b().match_clear());
                 } else {
-                    tim.tccr4a.modify(|_r, w| w.com4b().disconnected());
+                    tim.tccr4a().modify(|_r, w| w.com4b().disconnected());
                 },
             },
         },
@@ -265,8 +265,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer0Pwm {
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
-            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
-            tim.tccr0b.modify(|_r, w| match prescaler {
+            tim.tccr0a().modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs0().direct(),
                 Prescaler::Prescale8 => w.cs0().prescale_8(),
                 Prescaler::Prescale64 => w.cs0().prescale_64(),
@@ -278,18 +278,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB7: {
                 ocr: ocr0a,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0a().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0a().disconnected());
                 },
             },
 
             PG5: {
                 ocr: ocr0b,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0b().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0b().disconnected());
                 },
             },
         },
@@ -314,8 +314,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_r, w| match prescaler {
+            tim.tccr1a().modify(|_r, w| w.wgm1().set(0b01));
+            tim.tccr1b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs1().direct(),
                 Prescaler::Prescale8 => w.cs1().prescale_8(),
                 Prescaler::Prescale64 => w.cs1().prescale_64(),
@@ -327,27 +327,27 @@ avr_hal_generic::impl_simple_pwm! {
             PB5: {
                 ocr: ocr1a,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1a().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1a().disconnected());
                 },
             },
 
             PB6: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1b().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1b().disconnected());
                 },
             },
 
             PB7: {
                 ocr: ocr1c,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1c().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1c().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1c().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1c().disconnected());
                 },
             },
         },
@@ -372,8 +372,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer2Pwm {
         timer: crate::pac::TC2,
         init: |tim, prescaler| {
-            tim.tccr2a.modify(|_r, w| w.wgm2().bits(0b01));
-            tim.tccr2b.modify(|_r, w| {
+            tim.tccr2a().modify(|_r, w| w.wgm2().set(0b01));
+            tim.tccr2b().modify(|_r, w| {
                 w.wgm22().clear_bit();
 
                 match prescaler {
@@ -389,18 +389,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB4: {
                 ocr: ocr2a,
                 into_pwm: |tim| if enable {
-                    tim.tccr2a.modify(|_r, w| w.com2a().match_clear());
+                    tim.tccr2a().modify(|_r, w| w.com2a().match_clear());
                 } else {
-                    tim.tccr2a.modify(|_r, w| w.com2a().disconnected());
+                    tim.tccr2a().modify(|_r, w| w.com2a().disconnected());
                 },
             },
 
             PH6: {
                 ocr: ocr2b,
                 into_pwm: |tim| if enable {
-                    tim.tccr2a.modify(|_r, w| w.com2b().match_clear());
+                    tim.tccr2a().modify(|_r, w| w.com2b().match_clear());
                 } else {
-                    tim.tccr2a.modify(|_r, w| w.com2b().disconnected());
+                    tim.tccr2a().modify(|_r, w| w.com2b().disconnected());
                 },
             },
         },
@@ -425,9 +425,9 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer3Pwm {
         timer: crate::pac::TC3,
         init: |tim, prescaler| {
-            tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
-            tim.tccr3b.modify(|_r, w| {
-                w.wgm3().bits(0b01);
+            tim.tccr3a().modify(|_r, w| w.wgm3().set(0b01));
+            tim.tccr3b().modify(|_r, w| {
+                w.wgm3().set(0b01);
 
                 match prescaler {
                     Prescaler::Direct => w.cs3().direct(),
@@ -442,27 +442,27 @@ avr_hal_generic::impl_simple_pwm! {
             PE3: {
                 ocr: ocr3a,
                 into_pwm: |tim| if enable {
-                    tim.tccr3a.modify(|_r, w| w.com3a().match_clear());
+                    tim.tccr3a().modify(|_r, w| w.com3a().match_clear());
                 } else {
-                    tim.tccr3a.modify(|_r, w| w.com3a().disconnected());
+                    tim.tccr3a().modify(|_r, w| w.com3a().disconnected());
                 },
             },
 
             PE4: {
                 ocr: ocr3b,
                 into_pwm: |tim| if enable {
-                    tim.tccr3a.modify(|_r, w| w.com3b().match_clear());
+                    tim.tccr3a().modify(|_r, w| w.com3b().match_clear());
                 } else {
-                    tim.tccr3a.modify(|_r, w| w.com3b().disconnected());
+                    tim.tccr3a().modify(|_r, w| w.com3b().disconnected());
                 },
             },
 
             PE5: {
                 ocr: ocr3c,
                 into_pwm: |tim| if enable {
-                    tim.tccr3a.modify(|_r, w| w.com3c().match_clear());
+                    tim.tccr3a().modify(|_r, w| w.com3c().match_clear());
                 } else {
-                    tim.tccr3a.modify(|_r, w| w.com3c().disconnected());
+                    tim.tccr3a().modify(|_r, w| w.com3c().disconnected());
                 },
             },
 
@@ -488,9 +488,9 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer4Pwm {
         timer: crate::pac::TC4,
         init: |tim, prescaler| {
-            tim.tccr4a.modify(|_r, w| w.wgm4().bits(0b01));
-            tim.tccr4b.modify(|_r, w| {
-                w.wgm4().bits(0b01);
+            tim.tccr4a().modify(|_r, w| w.wgm4().set(0b01));
+            tim.tccr4b().modify(|_r, w| {
+                w.wgm4().set(0b01);
 
                 match prescaler {
                     Prescaler::Direct => w.cs4().direct(),
@@ -505,27 +505,27 @@ avr_hal_generic::impl_simple_pwm! {
             PH3: {
                 ocr: ocr4a,
                 into_pwm: |tim| if enable {
-                    tim.tccr4a.modify(|_r, w| w.com4a().match_clear());
+                    tim.tccr4a().modify(|_r, w| w.com4a().match_clear());
                 } else {
-                    tim.tccr4a.modify(|_r, w| w.com4a().disconnected());
+                    tim.tccr4a().modify(|_r, w| w.com4a().disconnected());
                 },
             },
 
             PH4: {
                 ocr: ocr4b,
                 into_pwm: |tim| if enable {
-                    tim.tccr4a.modify(|_r, w| w.com4b().match_clear());
+                    tim.tccr4a().modify(|_r, w| w.com4b().match_clear());
                 } else {
-                    tim.tccr4a.modify(|_r, w| w.com4b().disconnected());
+                    tim.tccr4a().modify(|_r, w| w.com4b().disconnected());
                 },
             },
 
             PH5: {
                 ocr: ocr4c,
                 into_pwm: |tim| if enable {
-                    tim.tccr4a.modify(|_r, w| w.com4c().match_clear());
+                    tim.tccr4a().modify(|_r, w| w.com4c().match_clear());
                 } else {
-                    tim.tccr4a.modify(|_r, w| w.com4c().disconnected());
+                    tim.tccr4a().modify(|_r, w| w.com4c().disconnected());
                 },
             },
 
@@ -551,9 +551,9 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer5Pwm {
         timer: crate::pac::TC5,
         init: |tim, prescaler| {
-            tim.tccr5a.modify(|_r, w| w.wgm5().bits(0b01));
-            tim.tccr5b.modify(|_r, w| {
-                w.wgm5().bits(0b01);
+            tim.tccr5a().modify(|_r, w| w.wgm5().set(0b01));
+            tim.tccr5b().modify(|_r, w| {
+                w.wgm5().set(0b01);
 
                 match prescaler {
                     Prescaler::Direct => w.cs5().direct(),
@@ -568,27 +568,27 @@ avr_hal_generic::impl_simple_pwm! {
             PL3: {
                 ocr: ocr5a,
                 into_pwm: |tim| if enable {
-                    tim.tccr5a.modify(|_r, w| w.com5a().match_clear());
+                    tim.tccr5a().modify(|_r, w| w.com5a().match_clear());
                 } else {
-                    tim.tccr5a.modify(|_r, w| w.com5a().disconnected());
+                    tim.tccr5a().modify(|_r, w| w.com5a().disconnected());
                 },
             },
 
             PL4: {
                 ocr: ocr5b,
                 into_pwm: |tim| if enable {
-                    tim.tccr5a.modify(|_r, w| w.com5b().match_clear());
+                    tim.tccr5a().modify(|_r, w| w.com5b().match_clear());
                 } else {
-                    tim.tccr5a.modify(|_r, w| w.com5b().disconnected());
+                    tim.tccr5a().modify(|_r, w| w.com5b().disconnected());
                 },
             },
 
             PL5: {
                 ocr: ocr5c,
                 into_pwm: |tim| if enable {
-                    tim.tccr5a.modify(|_r, w| w.com5c().match_clear());
+                    tim.tccr5a().modify(|_r, w| w.com5c().match_clear());
                 } else {
-                    tim.tccr5a.modify(|_r, w| w.com5c().disconnected());
+                    tim.tccr5a().modify(|_r, w| w.com5c().disconnected());
                 },
             },
 
@@ -613,8 +613,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer0Pwm {
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
-            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
-            tim.tccr0b.modify(|_r, w| match prescaler {
+            tim.tccr0a().modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs0().direct(),
                 Prescaler::Prescale8 => w.cs0().prescale_8(),
                 Prescaler::Prescale64 => w.cs0().prescale_64(),
@@ -626,18 +626,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB7: {
                 ocr: ocr0a,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0a().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0a().disconnected());
                 },
             },
 
             PD0: {
                 ocr: ocr0b,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0b().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0b().disconnected());
                 },
             },
         },
@@ -662,10 +662,10 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_r, w| w.wgm1().bits(0b01));
+            tim.tccr1a().modify(|_r, w| w.wgm1().set(0b01));
+            tim.tccr1b().modify(|_r, w| w.wgm1().set(0b01));
 
-            tim.tccr1b.modify(|_r, w| match prescaler {
+            tim.tccr1b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs1().direct(),
                 Prescaler::Prescale8 => w.cs1().prescale_8(),
                 Prescaler::Prescale64 => w.cs1().prescale_64(),
@@ -677,27 +677,27 @@ avr_hal_generic::impl_simple_pwm! {
             PB5: {
                 ocr: ocr1a,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1a().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1a().disconnected());
                 },
             },
 
             PB6: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1b().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1b().disconnected());
                 },
             },
 
             PB7: {
                 ocr: ocr1c,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1c().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1c().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1c().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1c().disconnected());
                 },
             },
         },
@@ -720,10 +720,10 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer3Pwm {
         timer: crate::pac::TC3,
         init: |tim, prescaler| {
-            tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
-            tim.tccr3b.modify(|_r, w| w.wgm3().bits(0b01));
+            tim.tccr3a().modify(|_r, w| w.wgm3().set(0b01));
+            tim.tccr3b().modify(|_r, w| w.wgm3().set(0b01));
 
-            tim.tccr3b.modify(|_r, w| match prescaler {
+            tim.tccr3b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs3().direct(),
                 Prescaler::Prescale8 => w.cs3().prescale_8(),
                 Prescaler::Prescale64 => w.cs3().prescale_64(),
@@ -735,9 +735,9 @@ avr_hal_generic::impl_simple_pwm! {
             PC6: {
                 ocr: ocr3a,
                 into_pwm: |tim| if enable {
-                    tim.tccr3a.modify(|_r, w| w.com3a().match_clear());
+                    tim.tccr3a().modify(|_r, w| w.com3a().match_clear());
                 } else {
-                    tim.tccr3a.modify(|_r, w| w.com3a().disconnected());
+                    tim.tccr3a().modify(|_r, w| w.com3a().disconnected());
                 },
             },
         },
@@ -762,11 +762,11 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer4Pwm {
         timer: crate::pac::TC4,
         init: |tim, prescaler| {
-            tim.tccr4a.modify(|_r, w| w.pwm4a().set_bit());
-            tim.tccr4a.modify(|_r, w| w.pwm4b().set_bit());
-            tim.tccr4c.modify(|_r, w| w.pwm4d().set_bit());
+            tim.tccr4a().modify(|_r, w| w.pwm4a().set_bit());
+            tim.tccr4a().modify(|_r, w| w.pwm4b().set_bit());
+            tim.tccr4c().modify(|_r, w| w.pwm4d().set_bit());
 
-            tim.tccr4b.modify(|_r, w| match prescaler {
+            tim.tccr4b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs4().direct(),
                 Prescaler::Prescale8 => w.cs4().prescale_8(),
                 Prescaler::Prescale64 => w.cs4().prescale_64(),
@@ -778,27 +778,27 @@ avr_hal_generic::impl_simple_pwm! {
             PB6: {
                 ocr: ocr4b,
                 into_pwm: |tim| if enable {
-                    tim.tccr4a.modify(|_r, w| w.com4b().match_clear());
+                    tim.tccr4a().modify(|_r, w| w.com4b().match_clear());
                 } else {
-                    tim.tccr4a.modify(|_r, w| w.com4b().disconnected());
+                    tim.tccr4a().modify(|_r, w| w.com4b().disconnected());
                 },
             },
 
             PC7: {
                 ocr: ocr4a,
                 into_pwm: |tim| if enable {
-                    tim.tccr4a.modify(|_r, w| w.com4a().match_clear());
+                    tim.tccr4a().modify(|_r, w| w.com4a().match_clear());
                 } else {
-                    tim.tccr4a.modify(|_r, w| w.com4a().disconnected());
+                    tim.tccr4a().modify(|_r, w| w.com4a().disconnected());
                 },
             },
 
             PD7: {
                 ocr: ocr4d,
                 into_pwm: |tim| if enable {
-                    tim.tccr4c.modify(|_r, w| w.com4d().match_clear());
+                    tim.tccr4c().modify(|_r, w| w.com4d().match_clear());
                 } else {
-                    tim.tccr4c.modify(|_r, w| w.com4d().disconnected());
+                    tim.tccr4c().modify(|_r, w| w.com4d().disconnected());
                 },
             },
         },
@@ -822,8 +822,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer0Pwm {
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
-            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
-            tim.tccr0b.modify(|_r, w| match prescaler {
+            tim.tccr0a().modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs0().direct(),
                 Prescaler::Prescale8 => w.cs0().prescale_8(),
                 Prescaler::Prescale64 => w.cs0().prescale_64(),
@@ -835,18 +835,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB3: {
                 ocr: ocr0a,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0a().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0a().disconnected());
                 },
             },
 
             PB4: {
                 ocr: ocr0b,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0b().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0b().disconnected());
                 },
             },
         },
@@ -870,9 +870,9 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_r, w| {
-                w.wgm1().bits(0b01);
+            tim.tccr1a().modify(|_r, w| w.wgm1().set(0b01));
+            tim.tccr1b().modify(|_r, w| {
+                w.wgm1().set(0b01);
 
                 match prescaler {
                     Prescaler::Direct => w.cs1().direct(),
@@ -887,18 +887,18 @@ avr_hal_generic::impl_simple_pwm! {
             PD5: {
                 ocr: ocr1a,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1a().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1a().disconnected());
                 },
             },
 
             PD4: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1b().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1b().disconnected());
                 },
             },
         },
@@ -922,8 +922,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer2Pwm {
         timer: crate::pac::TC2,
         init: |tim, prescaler| {
-            tim.tccr2a.modify(|_r, w| w.wgm2().pwm_fast());
-            tim.tccr2b.modify(|_r, w| match prescaler {
+            tim.tccr2a().modify(|_r, w| w.wgm2().pwm_fast());
+            tim.tccr2b().modify(|_r, w| match prescaler {
                     Prescaler::Direct => w.cs2().direct(),
                     Prescaler::Prescale8 => w.cs2().prescale_8(),
                     Prescaler::Prescale64 => w.cs2().prescale_64(),
@@ -935,18 +935,18 @@ avr_hal_generic::impl_simple_pwm! {
             PD7: {
                 ocr: ocr2a,
                 into_pwm: |tim| if enable {
-                    tim.tccr2a.modify(|_r, w| w.com2a().match_clear());
+                    tim.tccr2a().modify(|_r, w| w.com2a().match_clear());
                 } else {
-                    tim.tccr2a.modify(|_r, w| w.com2a().disconnected());
+                    tim.tccr2a().modify(|_r, w| w.com2a().disconnected());
                 },
             },
 
             PD6: {
                 ocr: ocr2b,
                 into_pwm: |tim| if enable {
-                    tim.tccr2a.modify(|_r, w| w.com2b().match_clear());
+                    tim.tccr2a().modify(|_r, w| w.com2b().match_clear());
                 } else {
-                    tim.tccr2a.modify(|_r, w| w.com2b().disconnected());
+                    tim.tccr2a().modify(|_r, w| w.com2b().disconnected());
                 },
             },
         },
@@ -959,9 +959,9 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer3Pwm {
         timer: crate::pac::TC3,
         init: |tim, prescaler| {
-            tim.tccr3a.modify(|_r, w| w.wgm3().bits(0b01));
-            tim.tccr3b.modify(|_r, w| {
-                w.wgm3().bits(0b01);
+            tim.tccr3a().modify(|_r, w| w.wgm3().set(0b01));
+            tim.tccr3b().modify(|_r, w| {
+                w.wgm3().set(0b01);
 
                 match prescaler {
                     Prescaler::Direct => w.cs3().direct(),
@@ -976,18 +976,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB6: {
                 ocr: ocr3a,
                 into_pwm: |tim| if enable {
-                    tim.tccr3a.modify(|_r, w| w.com3a().match_clear());
+                    tim.tccr3a().modify(|_r, w| w.com3a().match_clear());
                 } else {
-                    tim.tccr3a.modify(|_r, w| w.com3a().disconnected());
+                    tim.tccr3a().modify(|_r, w| w.com3a().disconnected());
                 },
             },
 
             PB7: {
                 ocr: ocr3b,
                 into_pwm: |tim| if enable {
-                    tim.tccr3a.modify(|_r, w| w.com3b().match_clear());
+                    tim.tccr3a().modify(|_r, w| w.com3b().match_clear());
                 } else {
-                    tim.tccr3a.modify(|_r, w| w.com3b().disconnected());
+                    tim.tccr3a().modify(|_r, w| w.com3b().disconnected());
                 },
             },
         },
@@ -1011,9 +1011,9 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_r, w| {
-                w.wgm1().bits(0b01);
+            tim.tccr1a().modify(|_r, w| w.wgm1().set(0b01));
+            tim.tccr1b().modify(|_r, w| {
+                w.wgm1().set(0b01);
 
                 match prescaler {
                     Prescaler::Direct => w.cs1().direct(),
@@ -1028,18 +1028,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB1: {
                 ocr: ocr1a,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1a().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1a().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1a().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1a().disconnected());
                 },
             },
 
             PB2: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1b().match_clear());
+                    tim.tccr1a().modify(|_r, w| w.com1b().match_clear());
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1b().disconnected());
+                    tim.tccr1a().modify(|_r, w| w.com1b().disconnected());
                 },
             },
         },
@@ -1063,8 +1063,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer2Pwm {
         timer: crate::pac::TC2,
         init: |tim, prescaler| {
-            tim.tccr2.modify(|_r, w| w.wgm20().set_bit().wgm21().set_bit());
-            tim.tccr2.modify(|_r, w| match prescaler {
+            tim.tccr2().modify(|_r, w| w.wgm20().set_bit().wgm21().set_bit());
+            tim.tccr2().modify(|_r, w| match prescaler {
                     Prescaler::Direct => w.cs2().direct(),
                     Prescaler::Prescale8 => w.cs2().prescale_8(),
                     Prescaler::Prescale64 => w.cs2().prescale_64(),
@@ -1076,9 +1076,9 @@ avr_hal_generic::impl_simple_pwm! {
             PB3: {
                 ocr: ocr2,
                 into_pwm: |tim| if enable {
-                    tim.tccr2.modify(|_r, w| w.com2().match_clear());
+                    tim.tccr2().modify(|_r, w| w.com2().match_clear());
                 } else {
-                    tim.tccr2.modify(|_r, w| w.com2().disconnected());
+                    tim.tccr2().modify(|_r, w| w.com2().disconnected());
                 },
             },
         },
@@ -1101,10 +1101,10 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer0Pwm {
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
-            tim.tccr0a.modify(|_r, w| w.wgm0().bits(0b11));
-            tim.tccr0a.modify(|_r, w| w.com0a().bits(0b00));
+            tim.tccr0a().modify(|_r, w| w.wgm0().set(0b11));
+            tim.tccr0a().modify(|_r, w| w.com0a().set(0b00));
 
-            tim.tccr0b.modify(|_r, w| match prescaler {
+            tim.tccr0b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs0().running_no_prescaling(),
                 Prescaler::Prescale8 => w.cs0().running_clk_8(),
                 Prescaler::Prescale64 => w.cs0().running_clk_64(),
@@ -1116,9 +1116,9 @@ avr_hal_generic::impl_simple_pwm! {
             PB3: {
                 ocr: ocr0a,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0a().bits(0b11));
+                    tim.tccr0a().modify(|_r, w| w.com0a().set(0b11));
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0a().bits(0b00));
+                    tim.tccr0a().modify(|_r, w| w.com0a().set(0b00));
                 },
             },
         },
@@ -1144,10 +1144,10 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.tccr1a.modify(|_r, w| w.wgm1().bits(0b01));
-            tim.tccr1a.modify(|_r, w| w.com1a().bits(0b00));
-            tim.tccr1a.modify(|_r, w| w.com1b().bits(0b00));
-            tim.tccr1b.modify(|_r, w| match prescaler {
+            tim.tccr1a().modify(|_r, w| w.wgm1().set(0b01));
+            tim.tccr1a().modify(|_r, w| w.com1a().set(0b00));
+            tim.tccr1a().modify(|_r, w| w.com1b().set(0b00));
+            tim.tccr1b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs1().running_no_prescaling(),
                 Prescaler::Prescale8 => w.cs1().running_clk_8(),
                 Prescaler::Prescale64 => w.cs1().running_clk_64(),
@@ -1159,17 +1159,17 @@ avr_hal_generic::impl_simple_pwm! {
             PD4: {
                 ocr: ocr1a,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1a().bits(0b11));
+                    tim.tccr1a().modify(|_r, w| w.com1a().set(0b11));
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1a().bits(0b00));
+                    tim.tccr1a().modify(|_r, w| w.com1a().set(0b00));
                 },
             },
             PD5: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_r, w| w.com1b().bits(0b11));
+                    tim.tccr1a().modify(|_r, w| w.com1b().set(0b11));
                 } else {
-                    tim.tccr1a.modify(|_r, w| w.com1b().bits(0b00));
+                    tim.tccr1a().modify(|_r, w| w.com1b().set(0b00));
                 },
             },
         },

--- a/mcu/atmega-hal/src/usart.rs
+++ b/mcu/atmega-hal/src/usart.rs
@@ -157,13 +157,13 @@ impl
         // msb of ubrrh has to be 0 to set ubrrh register. (see atmega8 datasheet)
         let ubrrh: u8 = ((baudrate.ubrr >> 8) & 0x0F) as u8;
         let ubrrl: u8 = (baudrate.ubrr & 0xFF) as u8;
-        self.ubrrh().write(|w| w.bits(ubrrh));
-        self.ubrrl.write(|w| w.bits(ubrrl));
-        self.ucsra.write(|w| w.u2x().bit(baudrate.u2x));
+        self.ubrrh().write(|w| w.set(ubrrh));
+        self.ubrrl().write(|w| w.set(ubrrl));
+        self.ucsra().write(|w| w.u2x().bit(baudrate.u2x));
 
         // Enable receiver and transmitter but leave interrupts disabled.
         #[rustfmt::skip]
-        self.ucsrb.write(|w| w
+        self.ucsrb().write(|w| w
             .txen().set_bit()
             .rxen().set_bit()
         );
@@ -183,11 +183,11 @@ impl
     fn raw_deinit(&mut self) {
         // Wait for any ongoing transfer to finish.
         avr_hal_generic::nb::block!(self.raw_flush()).ok();
-        self.ucsrb.reset();
+        self.ucsrb().reset();
     }
 
     fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
-        if self.ucsra.read().udre().bit_is_clear() {
+        if self.ucsra().read().udre().bit_is_clear() {
             Err(avr_hal_generic::nb::Error::WouldBlock)
         } else {
             Ok(())
@@ -201,24 +201,24 @@ impl
         // Call flush to make sure the data-register is empty
         self.raw_flush()?;
 
-        self.udr.write(|w| w.bits(byte));
+        self.udr().write(|w| w.set(byte));
         Ok(())
     }
 
     fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, core::convert::Infallible> {
-        if self.ucsra.read().rxc().bit_is_clear() {
+        if self.ucsra().read().rxc().bit_is_clear() {
             return Err(avr_hal_generic::nb::Error::WouldBlock);
         }
 
-        Ok(self.udr.read().bits())
+        Ok(self.udr().read().bits())
     }
 
     fn raw_interrupt(&mut self, event: crate::usart::Event, state: bool) {
         match event {
-            crate::usart::Event::RxComplete => self.ucsrb.modify(|_, w| w.rxcie().bit(state)),
-            crate::usart::Event::TxComplete => self.ucsrb.modify(|_, w| w.txcie().bit(state)),
+            crate::usart::Event::RxComplete => self.ucsrb().modify(|_, w| w.rxcie().bit(state)),
+            crate::usart::Event::TxComplete => self.ucsrb().modify(|_, w| w.txcie().bit(state)),
             crate::usart::Event::DataRegisterEmpty => {
-                self.ucsrb.modify(|_, w| w.udrie().bit(state))
+                self.ucsrb().modify(|_, w| w.udrie().bit(state))
             }
         }
     }
@@ -237,13 +237,13 @@ impl
     fn raw_init<CLOCK>(&mut self, baudrate: crate::usart::Baudrate<CLOCK>) {
         let ubrr1h: u8 = (baudrate.ubrr >> 8) as u8;
         let ubrr1l: u8 = baudrate.ubrr as u8;
-        self.ubrr1h.write(|w| w.bits(ubrr1h));
-        self.ubrr1l.write(|w| w.bits(ubrr1l));
-        self.ucsr1a.write(|w| w.u2x1().bit(baudrate.u2x));
+        self.ubrr1h().write(|w| w.set(ubrr1h));
+        self.ubrr1l().write(|w| w.set(ubrr1l));
+        self.ucsr1a().write(|w| w.u2x1().bit(baudrate.u2x));
 
         // Enable receiver and transmitter but leave interrupts disabled.
         #[rustfmt::skip]
-        self.ucsr1b.write(|w| w
+        self.ucsr1b().write(|w| w
             .txen1().set_bit()
             .rxen1().set_bit()
         );
@@ -251,7 +251,7 @@ impl
         // Set frame format to 8n1 for now.  At some point, this should be made
         // configurable, similar to what is done in other HALs.
         #[rustfmt::skip]
-        self.ucsr1c.write(|w| w
+        self.ucsr1c().write(|w| w
             .umsel1().usart_async()
             .ucsz1().chr8()
             .usbs1().stop1()
@@ -262,11 +262,11 @@ impl
     fn raw_deinit(&mut self) {
         // Wait for any ongoing transfer to finish.
         avr_hal_generic::nb::block!(self.raw_flush()).ok();
-        self.ucsr1b.reset();
+        self.ucsr1b().reset();
     }
 
     fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
-        if self.ucsr1a.read().udre1().bit_is_clear() {
+        if self.ucsr1a().read().udre1().bit_is_clear() {
             Err(avr_hal_generic::nb::Error::WouldBlock)
         } else {
             Ok(())
@@ -280,24 +280,24 @@ impl
         // Call flush to make sure the data-register is empty
         self.raw_flush()?;
 
-        self.udr1.write(|w| w.bits(byte));
+        self.udr1().write(|w| w.set(byte));
         Ok(())
     }
 
     fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, core::convert::Infallible> {
-        if self.ucsr1a.read().rxc1().bit_is_clear() {
+        if self.ucsr1a().read().rxc1().bit_is_clear() {
             return Err(avr_hal_generic::nb::Error::WouldBlock);
         }
 
-        Ok(self.udr1.read().bits())
+        Ok(self.udr1().read().bits())
     }
 
     fn raw_interrupt(&mut self, event: crate::usart::Event, state: bool) {
         match event {
-            crate::usart::Event::RxComplete => self.ucsr1b.modify(|_, w| w.rxcie1().bit(state)),
-            crate::usart::Event::TxComplete => self.ucsr1b.modify(|_, w| w.txcie1().bit(state)),
+            crate::usart::Event::RxComplete => self.ucsr1b().modify(|_, w| w.rxcie1().bit(state)),
+            crate::usart::Event::TxComplete => self.ucsr1b().modify(|_, w| w.txcie1().bit(state)),
             crate::usart::Event::DataRegisterEmpty => {
-                self.ucsr1b.modify(|_, w| w.udrie1().bit(state))
+                self.ucsr1b().modify(|_, w| w.udrie1().bit(state))
             }
         }
     }
@@ -317,17 +317,17 @@ impl
     fn raw_init<CLOCK>(&mut self, baudrate: crate::usart::Baudrate<CLOCK>) {
         let ubrr0h: u8 = (baudrate.ubrr >> 8) as u8;
         let ubrr0l: u8 = baudrate.ubrr as u8;
-        self.ubrr0h.write(|w| w.bits(ubrr0h));
-        self.ubrr0l.write(|w| w.bits(ubrr0l));
-        self.ucsr0a.write(|w| w.u2x0().bit(baudrate.u2x));
+        self.ubrr0h().write(|w| w.set(ubrr0h));
+        self.ubrr0l().write(|w| w.set(ubrr0l));
+        self.ucsr0a().write(|w| w.u2x0().bit(baudrate.u2x));
 
         // Enable receiver and transmitter but leave interrupts disabled.
-        self.ucsr0b.write(|w| w.txen0().set_bit().rxen0().set_bit());
+        self.ucsr0b().write(|w| w.txen0().set_bit().rxen0().set_bit());
 
         // Set frame format to 8n1 for now.  At some point, this should be made
         // configurable, similar to what is done in other HALs.
         #[rustfmt::skip]
-        self.ucsr0c.write(|w| w
+        self.ucsr0c().write(|w| w
             .umsel0().usart_async()
             .ucsz0().chr8()
             .usbs0().stop1()
@@ -338,11 +338,11 @@ impl
     fn raw_deinit(&mut self) {
         // Wait for any ongoing transfer to finish.
         avr_hal_generic::nb::block!(self.raw_flush()).ok();
-        self.ucsr0b.reset();
+        self.ucsr0b().reset();
     }
 
     fn raw_flush(&mut self) -> avr_hal_generic::nb::Result<(), core::convert::Infallible> {
-        if self.ucsr0a.read().udre0().bit_is_clear() {
+        if self.ucsr0a().read().udre0().bit_is_clear() {
             Err(avr_hal_generic::nb::Error::WouldBlock)
         } else {
             Ok(())
@@ -356,24 +356,24 @@ impl
         // Call flush to make sure the data-register is empty
         self.raw_flush()?;
 
-        self.udr0.write(|w| w.bits(byte));
+        self.udr0().write(|w| w.set(byte));
         Ok(())
     }
 
     fn raw_read(&mut self) -> avr_hal_generic::nb::Result<u8, core::convert::Infallible> {
-        if self.ucsr0a.read().rxc0().bit_is_clear() {
+        if self.ucsr0a().read().rxc0().bit_is_clear() {
             return Err(avr_hal_generic::nb::Error::WouldBlock);
         }
 
-        Ok(self.udr0.read().bits())
+        Ok(self.udr0().read().bits())
     }
 
     fn raw_interrupt(&mut self, event: crate::usart::Event, state: bool) {
         match event {
-            crate::usart::Event::RxComplete => self.ucsr0b.modify(|_, w| w.rxcie0().bit(state)),
-            crate::usart::Event::TxComplete => self.ucsr0b.modify(|_, w| w.txcie0().bit(state)),
+            crate::usart::Event::RxComplete => self.ucsr0b().modify(|_, w| w.rxcie0().bit(state)),
+            crate::usart::Event::TxComplete => self.ucsr0b().modify(|_, w| w.txcie0().bit(state)),
             crate::usart::Event::DataRegisterEmpty => {
-                self.ucsr0b.modify(|_, w| w.udrie0().bit(state))
+                self.ucsr0b().modify(|_, w| w.udrie0().bit(state))
             }
         }
     }

--- a/mcu/attiny-hal/src/adc.rs
+++ b/mcu/attiny-hal/src/adc.rs
@@ -63,7 +63,7 @@ pub mod channel {
 }
 
 fn apply_clock(peripheral: &crate::pac::ADC, settings: AdcSettings) {
-    peripheral.adcsra.write(|w| {
+    peripheral.adcsra().write(|w| {
         w.aden().set_bit();
         match settings.clock_divider {
             ClockDivider::Factor2 => w.adps().prescaler_2(),
@@ -84,7 +84,7 @@ avr_hal_generic::impl_adc! {
     settings: AdcSettings,
     apply_settings: |peripheral, settings| {
         apply_clock(peripheral, settings);
-        peripheral.admux.write(|w| match settings.ref_voltage {
+        peripheral.admux().write(|w| match settings.ref_voltage {
             ReferenceVoltage::Aref => w.refs().aref(),
             ReferenceVoltage::AVcc => w.refs().vcc(),
             ReferenceVoltage::Internal1_1 => w.refs().internal().refs2().clear_bit(),
@@ -93,7 +93,7 @@ avr_hal_generic::impl_adc! {
     },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PB5: (crate::pac::adc::admux::MUX_A::ADC0, didr0::adc0d),
@@ -115,14 +115,14 @@ avr_hal_generic::impl_adc! {
     settings: AdcSettings,
     apply_settings: |peripheral, settings| {
         apply_clock(peripheral, settings);
-        peripheral.admux.write(|w| match settings.ref_voltage {
+        peripheral.admux().write(|w| match settings.ref_voltage {
             ReferenceVoltage::AVcc => w.refs0().avcc(),
             ReferenceVoltage::Internal1_1 => w.refs0().internal(),
         });
     },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PC0: (crate::pac::adc::admux::MUX_A::ADC0, didr0::adc0d),
@@ -148,11 +148,11 @@ avr_hal_generic::impl_adc! {
     settings: AdcSettings,
     apply_settings: |peripheral, settings| {
         apply_clock(peripheral, settings);
-        peripheral.amiscr.write(|w| match settings.ref_voltage {
+        peripheral.amiscr().write(|w| match settings.ref_voltage {
             ReferenceVoltage::Aref => w.arefen().set_bit(),
             _ => w.arefen().clear_bit(),
         });
-        peripheral.admux.write(|w| match settings.ref_voltage {
+        peripheral.admux().write(|w| match settings.ref_voltage {
             ReferenceVoltage::Aref => w.refs().avcc(),
             ReferenceVoltage::AVcc => w.refs().avcc(),
             ReferenceVoltage::Internal1_1 => w.refs().internal_11(),
@@ -161,7 +161,7 @@ avr_hal_generic::impl_adc! {
     },
     channel_id: crate::pac::adc::admux::MUX_A,
     set_channel: |peripheral, id| {
-        peripheral.admux.modify(|_, w| w.mux().variant(id));
+        peripheral.admux().modify(|_, w| w.mux().variant(id));
     },
     pins: {
         port::PA0: (crate::pac::adc::admux::MUX_A::ADC0, didr0::adc0d),

--- a/mcu/attiny-hal/src/eeprom.rs
+++ b/mcu/attiny-hal/src/eeprom.rs
@@ -9,7 +9,7 @@ avr_hal_generic::impl_eeprom_attiny! {
     capacity: 128,
     addr_width: u8,
     set_address: |peripheral, address| {
-        peripheral.eear.write(|w| w.bits(address));
+        peripheral.eear().write(|w| w.bits(address));
     },
 }
 
@@ -20,7 +20,7 @@ avr_hal_generic::impl_eeprom_attiny! {
     capacity: 512,
     addr_width: u16,
     set_address: |peripheral, address| {
-        peripheral.eear.write(|w| w.bits(address));
+        peripheral.eear().write(|w| w.bits(address));
     },
 }
 
@@ -31,6 +31,6 @@ avr_hal_generic::impl_eeprom_attiny! {
     capacity: 64,
     addr_width: u8,
     set_address: |peripheral, address| {
-        peripheral.eearl.write(|w| w.bits(address));
+        peripheral.eearl().write(|w| w.bits(address));
     },
 }

--- a/mcu/attiny-hal/src/simple_pwm.rs
+++ b/mcu/attiny-hal/src/simple_pwm.rs
@@ -9,8 +9,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer0Pwm {
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
-            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
-            tim.tccr0b.modify(|_r, w| match prescaler {
+            tim.tccr0a().modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs0().direct(),
                 Prescaler::Prescale8 => w.cs0().prescale_8(),
                 Prescaler::Prescale64 => w.cs0().prescale_64(),
@@ -22,18 +22,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB2: {
                 ocr: ocr0a,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0a().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0a().disconnected());
                 },
             },
 
             PA7: {
                 ocr: ocr0b,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0b().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0b().disconnected());
                 },
             },
         },
@@ -46,10 +46,10 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_, w| w.wgm1().bits(0b01));
+            tim.tccr1a().modify(|_, w| w.wgm1().set(0b01));
+            tim.tccr1b().modify(|_, w| w.wgm1().set(0b01));
 
-            tim.tccr1b.modify(|_r, w| match prescaler {
+            tim.tccr1b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs1().direct(),
                 Prescaler::Prescale8 => w.cs1().prescale_8(),
                 Prescaler::Prescale64 => w.cs1().prescale_64(),
@@ -61,18 +61,18 @@ avr_hal_generic::impl_simple_pwm! {
             PA6: {
                 ocr: ocr1a,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_, w| w.com1a().bits(0b10));
+                    tim.tccr1a().modify(|_, w| w.com1a().set(0b10));
                 } else {
-                    tim.tccr1a.modify(|_, w| w.com1a().disconnected());
+                    tim.tccr1a().modify(|_, w| w.com1a().disconnected());
                 },
             },
 
             PA5: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_, w| w.com1b().bits(0b10));
+                    tim.tccr1a().modify(|_, w| w.com1b().set(0b10));
                 } else {
-                    tim.tccr1a.modify(|_, w| w.com1b().disconnected());
+                    tim.tccr1a().modify(|_, w| w.com1b().disconnected());
                 },
             },
         },
@@ -96,8 +96,8 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer0Pwm {
         timer: crate::pac::TC0,
         init: |tim, prescaler| {
-            tim.tccr0a.modify(|_r, w| w.wgm0().pwm_fast());
-            tim.tccr0b.modify(|_r, w| match prescaler {
+            tim.tccr0a().modify(|_r, w| w.wgm0().pwm_fast());
+            tim.tccr0b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs0().direct(),
                 Prescaler::Prescale8 => w.cs0().prescale_8(),
                 Prescaler::Prescale64 => w.cs0().prescale_64(),
@@ -109,18 +109,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB0: {
                 ocr: ocr0a,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0a().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0a().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0a().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0a().disconnected());
                 },
             },
 
             PB1: {
                 ocr: ocr0b,
                 into_pwm: |tim| if enable {
-                    tim.tccr0a.modify(|_r, w| w.com0b().match_clear());
+                    tim.tccr0a().modify(|_r, w| w.com0b().match_clear());
                 } else {
-                    tim.tccr0a.modify(|_r, w| w.com0b().disconnected());
+                    tim.tccr0a().modify(|_r, w| w.com0b().disconnected());
                 },
             },
         },
@@ -143,9 +143,9 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.gtccr.modify(|_, w| w.pwm1b().bit(true));
+            tim.gtccr().modify(|_, w| w.pwm1b().bit(true));
 
-            tim.tccr1.modify(|_r, w| match prescaler {
+            tim.tccr1().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs1().direct(),
                 Prescaler::Prescale8 => w.cs1().prescale_8(),
                 Prescaler::Prescale64 => w.cs1().prescale_64(),
@@ -157,9 +157,9 @@ avr_hal_generic::impl_simple_pwm! {
             PB4: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.gtccr.modify(|_, w| w.com1b().bits(0b10));
+                    tim.gtccr().modify(|_, w| w.com1b().set(0b10));
                 } else {
-                    tim.gtccr.modify(|_, w| w.com1b().disconnected());
+                    tim.gtccr().modify(|_, w| w.com1b().disconnected());
                 },
             },
         },
@@ -183,10 +183,10 @@ avr_hal_generic::impl_simple_pwm! {
     pub struct Timer1Pwm {
         timer: crate::pac::TC1,
         init: |tim, prescaler| {
-            tim.tccr1a.modify(|_, w| w.wgm1().bits(0b01));
-            tim.tccr1b.modify(|_, w| w.wgm1().bits(0b01));
+            tim.tccr1a().modify(|_, w| w.wgm1().set(0b01));
+            tim.tccr1b().modify(|_, w| w.wgm1().set(0b01));
 
-            tim.tccr1b.modify(|_r, w| match prescaler {
+            tim.tccr1b().modify(|_r, w| match prescaler {
                 Prescaler::Direct => w.cs1().direct(),
                 Prescaler::Prescale8 => w.cs1().prescale_8(),
                 Prescaler::Prescale64 => w.cs1().prescale_64(),
@@ -198,18 +198,18 @@ avr_hal_generic::impl_simple_pwm! {
             PB1: {
                 ocr: ocr1a,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_, w| w.com1a().bits(0b10));
+                    tim.tccr1a().modify(|_, w| w.com1a().set(0b10));
                 } else {
-                    tim.tccr1a.modify(|_, w| w.com1a().disconnected());
+                    tim.tccr1a().modify(|_, w| w.com1a().disconnected());
                 },
             },
 
             PB2: {
                 ocr: ocr1b,
                 into_pwm: |tim| if enable {
-                    tim.tccr1a.modify(|_, w| w.com1b().bits(0b10));
+                    tim.tccr1a().modify(|_, w| w.com1b().set(0b10));
                 } else {
-                    tim.tccr1a.modify(|_, w| w.com1b().disconnected());
+                    tim.tccr1a().modify(|_, w| w.com1b().disconnected());
                 },
             },
         },


### PR DESCRIPTION
As avr-device is upgrading to use svd2rust version 0.33.1 (see https://github.com/Rahix/avr-device/pull/155), there are some significant changes in the generated API.  We have to adapt the HAL code to use the new API whereever relevant.  This PR is a preview of what will change.

The following major changes are necessary:

- Registers are no longer accessed as struct-fields of the peripheral, but rather as methods of the peripheral.
- Safe writing to a field or register is now done using a new `.set()` method instead of `.bits()`.

Fortunately, these changes can be trivially automated from rustc error messages using the following script:

```bash
cargo build --message-format json 2>/dev/null \
  | jq '.message.children[].spans[] | {file: .file_name, line: .line_start, col: (.text[0].highlight_start - 1), insert: .suggested_replacement}' 2>/dev/null \
  | jq -r '"sed -ri '"'"'" + (.line | tostring) + "s/^(.{" + (.col | tostring) + "})/\\1" + .insert + "/'"'"' $(cd ../..; realpath " + .file + ")"' \
  | sort | uniq | bash
```