### PR TITLE
[ravedude] add output modes, newline after n bytes or after char

### DIFF
--- a/ravedude/README.md
+++ b/ravedude/README.md
@@ -132,6 +132,22 @@ port = "/dev/ttyACM0"
 # ravedude should open a serial console after flashing
 open-console = true
 
+# console output mode. Can be ascii, hex, dec or bin
+output-mode = "ascii"
+
+# Print a newline after this byte
+# not used with output_mode ascii
+# hex (0x) and bin (0b) notations are supported.
+# matching chars/bytes are NOT removed
+# to add newlines after \n (in non-ascii mode), use \n, 0x0a or 0b00001010
+# newline-on = '\n'
+
+# Print a newline after n bytes
+# not used with output_mode ascii
+# defaults to 16 for hex and dec and 8 for bin
+# if dividable by 4, bytes will be grouped to 4
+# newline-after = 16
+
 # baudrate for the serial console (this is **not** the avrdude flashing baudrate)
 serial-baudrate = 57600
 

--- a/ravedude/src/config.rs
+++ b/ravedude/src/config.rs
@@ -48,6 +48,9 @@ impl RavedudeConfig {
                 port: args.port.clone(),
                 reset_delay: args.reset_delay,
                 board: args.legacy_board_name().clone(),
+                output_mode: args.output_mode,
+                newline_after: None,
+                newline_on: None,
             },
             board_config: Default::default(),
         })
@@ -63,6 +66,9 @@ pub struct RavedudeGeneralConfig {
     pub port: Option<std::path::PathBuf>,
     pub reset_delay: Option<u64>,
     pub board: Option<String>,
+    pub output_mode: Option<OutputMode>,
+    pub newline_on: Option<char>,
+    pub newline_after: Option<u8>,
 }
 
 impl RavedudeGeneralConfig {
@@ -82,6 +88,9 @@ impl RavedudeGeneralConfig {
         }
         if let Some(reset_delay) = args.reset_delay {
             self.reset_delay = Some(reset_delay);
+        }
+        if let Some(output_mode) = args.output_mode {
+            self.output_mode = Some(output_mode);
         }
         Ok(())
     }
@@ -180,4 +189,12 @@ impl BoardConfig {
             None => None,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub enum OutputMode {
+    Ascii,
+    Hex,
+    Dec,
+    Bin,
 }

--- a/ravedude/src/config.rs
+++ b/ravedude/src/config.rs
@@ -67,7 +67,7 @@ pub struct RavedudeGeneralConfig {
     pub reset_delay: Option<u64>,
     pub board: Option<String>,
     pub output_mode: Option<OutputMode>,
-    pub newline_on: Option<char>,
+    pub newline_on: Option<String>,
     pub newline_after: Option<u8>,
 }
 

--- a/ravedude/src/config.rs
+++ b/ravedude/src/config.rs
@@ -221,6 +221,7 @@ impl BoardConfig {
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, PartialEq)]
+#[serde(rename_all = "kebab-case")]
 pub enum OutputMode {
     #[default]
     Ascii,

--- a/ravedude/src/config.rs
+++ b/ravedude/src/config.rs
@@ -49,7 +49,7 @@ impl RavedudeConfig {
                 port: args.port.clone(),
                 reset_delay: args.reset_delay,
                 board: args.legacy_board_name().clone(),
-                output_mode: args.output_mode.unwrap_or(OutputMode::default()),
+                output_mode: args.output_mode.unwrap_or_default(),
                 newline_after: None,
                 newline_on: None,
             },
@@ -67,7 +67,7 @@ impl RavedudeGeneralConfig {
                 )
             }
 
-			return Ok(NewlineMode::Off);
+            return Ok(NewlineMode::Off);
         }
 
         Ok(match (self.newline_on.as_ref(), self.newline_after) {

--- a/ravedude/src/console.rs
+++ b/ravedude/src/console.rs
@@ -1,8 +1,35 @@
-use anyhow::Context as _;
 use std::io::Read as _;
 use std::io::Write as _;
 
-pub fn open(port: &std::path::Path, baudrate: u32) -> anyhow::Result<()> {
+use anyhow::Context as _;
+use colored::Colorize as _;
+
+use crate::config::OutputMode;
+use crate::config::OutputMode::*;
+use crate::task_message;
+
+pub fn open(
+    port: &std::path::PathBuf,
+    baudrate: u32,
+    output_mode: Option<OutputMode>,
+    newline_on: Option<char>,
+    newline_after: Option<u8>,
+) -> anyhow::Result<()> {
+    task_message!("Console", "{} at {} baud", port.display(), baudrate);
+    task_message!(
+        "Output",
+        "{}",
+        match output_mode {
+            Some(Ascii) | None => "ascii",
+            Some(Hex) => "hexadecimal",
+            Some(Dec) => "decimal",
+            Some(Bin) => "binary",
+        }
+    );
+    task_message!("", "{}", "CTRL+C to exit.".dimmed());
+    // Empty line for visual consistency
+    eprintln!();
+
     let mut rx = serialport::new(port.to_string_lossy(), baudrate)
         .timeout(std::time::Duration::from_secs(2))
         .open_native()
@@ -14,11 +41,28 @@ pub fn open(port: &std::path::Path, baudrate: u32) -> anyhow::Result<()> {
 
     // Set a CTRL+C handler to terminate cleanly instead of with an error.
     ctrlc::set_handler(move || {
-        eprintln!("");
+        eprintln!();
         eprintln!("Exiting.");
         std::process::exit(0);
     })
     .context("failed setting a CTRL+C handler")?;
+
+    let newline_after = match newline_after {
+        Some(n) => n,
+        None => match output_mode {
+            Some(Hex) | Some(Dec) => 16,
+            Some(Bin) => 8,
+            _ => 0,
+        },
+    };
+
+    let (spaces, space_after) = if newline_on.is_none() && newline_after % 4 == 0 {
+        (true, 4)
+    } else {
+        (false, 0)
+    };
+
+    let mut byte_count = 0;
 
     // Spawn a thread for the receiving end because stdio is not portably non-blocking...
     std::thread::spawn(move || loop {
@@ -41,7 +85,38 @@ pub fn open(port: &std::path::Path, baudrate: u32) -> anyhow::Result<()> {
                         }
                     }
                 }
-                stdout.write(&buf[..count]).unwrap();
+                match output_mode {
+                    Some(Ascii) | None => {
+                        stdout.write_all(&buf).unwrap();
+                    }
+                    _ => {
+                        for byte in &buf[..count] {
+                            byte_count += 1;
+                            match output_mode {
+                                Some(Ascii) | None => unreachable!(),
+                                Some(Hex) => {
+                                    write!(stdout, "{:02x} ", byte).unwrap();
+                                }
+                                Some(Dec) => {
+                                    write!(stdout, "{:03} ", byte).unwrap();
+                                }
+                                Some(Bin) => {
+                                    write!(stdout, "{:08b} ", byte).unwrap();
+                                }
+                            }
+                            // don’t execute in ascii mode, ascii is unreachable here
+                            if spaces && byte_count % space_after == 0 {
+                                write!(stdout, " ").unwrap();
+                            }
+                            if newline_on.is_none() && byte_count % newline_after == 0 {
+                                writeln!(stdout).unwrap();
+                            }
+                            if newline_on.is_some() && *byte as char == newline_on.unwrap() {
+                                writeln!(stdout).unwrap();
+                            }
+                        }
+                    }
+                }
                 stdout.flush().unwrap();
             }
             Err(e) => {

--- a/ravedude/src/console.rs
+++ b/ravedude/src/console.rs
@@ -2,12 +2,10 @@ use std::io::Read as _;
 use std::io::Write as _;
 
 use anyhow::Context as _;
-use colored::Colorize as _;
 
 use crate::config::NewlineMode;
 use crate::config::OutputMode;
 use crate::config::OutputMode::*;
-use crate::task_message;
 
 pub fn open(
     port: &std::path::PathBuf,
@@ -16,11 +14,6 @@ pub fn open(
     newline_mode: NewlineMode,
     space_after: Option<u8>,
 ) -> anyhow::Result<()> {
-    task_message!("Console", "{} at {} baud", port.display(), baudrate);
-    task_message!("", "{}", "CTRL+C to exit.".dimmed());
-    // Empty line for visual consistency
-    eprintln!();
-
     let mut rx = serialport::new(port.to_string_lossy(), baudrate)
         .timeout(std::time::Duration::from_secs(2))
         .open_native()

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -264,12 +264,6 @@ fn ravedude() -> anyhow::Result<()> {
         anyhow::bail!("no named board given and no board options provided");
     };
 
-    if ravedude_config.general_options.newline_on.is_some()
-        && ravedude_config.general_options.newline_after.is_some()
-    {
-        anyhow::bail!("newline_on and newline_after cannot be used at the same time");
-    }
-
     let board_avrdude_options = board
         .avrdude
         .take()

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -348,8 +348,7 @@ fn ravedude() -> anyhow::Result<()> {
             })?;
 
         let port = port.context("console can only be opened for devices with USB-to-Serial")?;
-		let newline_mode = ravedude_config.general_options.newline_mode()?;
-
+        let newline_mode = ravedude_config.general_options.newline_mode()?;
 
         task_message!("Console", "{} at {} baud", port.display(), baudrate);
         task_message!("", "{}", "CTRL+C to exit.".dimmed());
@@ -358,9 +357,9 @@ fn ravedude() -> anyhow::Result<()> {
         console::open(
             &port,
             baudrate.get(),
-			ravedude_config.general_options.output_mode,
-			newline_mode,
-			newline_mode.space_after()
+            ravedude_config.general_options.output_mode,
+            newline_mode,
+            newline_mode.space_after(),
         )?;
     } else if args.bin.is_none() && port.is_some() {
         warning!("you probably meant to add -c/--open-console?");

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -91,7 +91,7 @@
 //! ```
 //!
 //! For reference, take a look at [`boards.toml`](https://github.com/Rahix/avr-hal/blob/main/ravedude/src/boards.toml).
-use anyhow::{bail, Context as _};
+use anyhow::Context as _;
 use colored::Colorize as _;
 use config::OutputMode;
 
@@ -130,7 +130,7 @@ fn parse_newline_on(s: &str) -> Result<u8, anyhow::Error> {
     // if it starts with 0x then parse the hex byte
     if &s[0..2] == "0x" {
         if s.len() != 4 {
-            bail!("hex byte must have 2 digits");
+            anyhow::bail!("hex byte must have 2 digits");
         }
         return u8::from_str_radix(&s[2..4], 16).context("invalid hex byte");
     }
@@ -138,12 +138,12 @@ fn parse_newline_on(s: &str) -> Result<u8, anyhow::Error> {
     // if it starts with 0b then parse the binary byte
     if &s[0..2] == "0b" {
         if s.len() != 10 {
-            bail!("binary byte must have 8 digits");
+            anyhow::bail!("binary byte must have 8 digits");
         }
         return u8::from_str_radix(&s[2..10], 2).context("invalid binary byte");
     }
 
-    bail!("must be a single character or a byte in hex or binary notation");
+    anyhow::bail!("must be a single character or a byte in hex or binary notation");
 }
 
 #[test]
@@ -280,7 +280,7 @@ fn ravedude() -> anyhow::Result<()> {
 
     let mut ravedude_config = match (manifest_path.as_deref(), args.legacy_board_name()) {
         (Some(_), Some(board_name)) => {
-            bail!("can't pass board as command-line argument when Ravedude.toml is present; set `board = {:?}` under [general] in Ravedude.toml", board_name);
+            anyhow::bail!("can't pass board as command-line argument when Ravedude.toml is present; set `board = {:?}` under [general] in Ravedude.toml", board_name);
         }
         (Some(path), None) => board::get_board_from_manifest(path)?,
         (None, Some(board_name)) => {
@@ -295,7 +295,7 @@ fn ravedude() -> anyhow::Result<()> {
             board::get_board_from_name(&board_name)?
         }
         (None, None) => {
-            bail!("couldn't find Ravedude.toml in project");
+            anyhow::bail!("couldn't find Ravedude.toml in project");
         }
     };
 
@@ -312,13 +312,13 @@ fn ravedude() -> anyhow::Result<()> {
     avrdude::Avrdude::require_min_ver(MIN_VERSION_AVRDUDE)?;
 
     let Some(mut board) = ravedude_config.board_config else {
-        bail!("no named board given and no board options provided");
+        anyhow::bail!("no named board given and no board options provided");
     };
 
     if ravedude_config.general_options.newline_on.is_some()
         && ravedude_config.general_options.newline_after.is_some()
     {
-        bail!("newline_on and newline_after cannot be used at the same time");
+        anyhow::bail!("newline_on and newline_after cannot be used at the same time");
     }
 
     let board_avrdude_options = board

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -409,7 +409,11 @@ fn ravedude() -> anyhow::Result<()> {
         let port = port.context("console can only be opened for devices with USB-to-Serial")?;
 
         let output_mode = ravedude_config.general_options.output_mode;
-        let newline_on = ravedude_config.general_options.newline_on;
+        let newline_on = if let Some(newline_on) = ravedude_config.general_options.newline_on {
+            Some(parse_newline_on(newline_on.as_str()))
+        } else {
+            None
+        };
         let newline_after = ravedude_config.general_options.newline_after;
 
         task_message!("Console", "{} at {} baud", port.display(), baudrate);
@@ -420,7 +424,7 @@ fn ravedude() -> anyhow::Result<()> {
             &port,
             baudrate.get(),
             output_mode,
-            newline_on,
+            parse_newline_on(newline_on),
             newline_after,
         )?;
     } else if args.bin.is_none() && port.is_some() {


### PR DESCRIPTION
From `--help`:
```
    -o <output-mode>
            Output mode. Can be ascii, hex, dec or bin

        --newline-on <newline-on>
            Print a newline after this byte
            not used with output_mode ascii
            hex (0x) and bin (0b) notations are supported.
            matching chars/bytes are NOT removed
            to add newlines after \n (in non-ascii mode), use \n, 0x0a or 0b00001010
        --newline-after <newline-after>
            Print a newline after n bytes
            not used with output_mode ascii
            defaults to 16 for hex and dec and 8 for bin
            if dividable by 4, bytes will be grouped to 4
```

This helps when working with non-ascii output.

Other solutions:

- use another serial console: too much context switching for me, having the serial console in watch mode is way better.
- use ravedude and pipe into hexdump or xxd: they only handle streamed data line by line, meaning the data is not printed immediately. They also can’t add newlines.
