### PR TITLE
impl wdt modes

### DIFF
--- a/mcu/atmega-hal/src/wdt.rs
+++ b/mcu/atmega-hal/src/wdt.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-pub use avr_hal_generic::wdt::{Timeout, WdtOps};
+pub use avr_hal_generic::wdt::{Timeout, WdtMode, WdtOps};
 
 pub type Wdt = avr_hal_generic::wdt::Wdt<crate::Atmega, crate::pac::WDT>;
 

--- a/mcu/attiny-hal/src/wdt.rs
+++ b/mcu/attiny-hal/src/wdt.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-pub use avr_hal_generic::wdt::{Timeout, WdtOps};
+pub use avr_hal_generic::wdt::{Timeout, WdtMode, WdtOps};
 
 pub type Wdt = avr_hal_generic::wdt::Wdt<crate::Attiny, crate::pac::WDT>;
 


### PR DESCRIPTION
This adds the ability to set the mode for the watchdog.  
Previously the wdt mode was enforced to softreset the board.  
Now we can also set it to trigger the `WDT` interrupt by calling `watchdog.set_mode()`.  

This PR closes #552 

Please let me know if there is anything i need to change!