### PR TITLE
arduino-hal: provide renamed types matching fields

### DIFF
--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -781,13 +781,18 @@ macro_rules! renamed_pins {
             type McuPins = $mcu_pins:ty;
         }
     ) => {
-        $(#[$pins_attr])*
-        pub struct Pins {
-            $($(#[$pin_attr])*
-            pub $pin_name: $pin_wrapper<
-                $crate::port::mode::Input<$crate::port::mode::Floating>,
-                $pin_type,
-            >,)+
+        $crate::paste::paste! {
+            $(#[$pins_attr])*
+            pub struct Pins {
+                    $(pub $pin_name: $pin_wrapper<
+                        $crate::port::mode::Input<$crate::port::mode::Floating>,
+                        [<$pin_name:upper>],
+                    >,)+
+            }
+        }
+
+        $crate::paste::paste! {
+            $($(#[$pin_attr])* pub type [<$pin_name:upper>] = $pin_type;)+
         }
 
         impl Pins {


### PR DESCRIPTION
A very simple improvement to fix #558 and fix #555.

The approach is a basic application of renaming with `paste!`, but I choose to generate slightly different code than suggested:

```rust
pub struct Pins {
    // Notice the lack of documentation here, I thought it became redundant...
    pub a0: PinA0<
        mode::Input<mode::Floating>,
    >,
    // ...
}

// ...since I moved it to the type aliases themselves.

/// `A0`
///
/// * ADC0 (ADC input channel 0)
/// * PCINT8 (pin change interrupt 8)
pub type A0 = atmega_hal::port::PC0;
// ...

// It seemed more consistent to use the pin name in uppercase for the
// raw type and "Pin<pin name in uppercase>" for the wrapped version.

/// Safely wrapped version of:
/// `A0`
///
/// * ADC0 (ADC input channel 0)
/// * PCINT8 (pin change interrupt 8)
pub type PinA0<MODE> = Pin<MODE, atmega_hal::port::PC0>
```

In rust-analyzer the type aliases are resolved to the underlying type, so in this implementation the documentation popups still show the MCU names. We could fix this by using a newtype with `Deref`, but that seems like overkill.