### PR TITLE
Upgrade rust toolchain to nightly-2025-01-01

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   ci:
     name: "${{ matrix.m.type }}: ${{ matrix.m.name }}"
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         m:
           - type: board

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-12-28
+          toolchain: nightly-2025-01-01
           components: rust-src
       - name: Install avr-gcc, binutils, and libc
         run: sudo apt-get install -y avr-libc binutils-avr gcc-avr

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-03-22"
+channel = "nightly-2025-01-01"
 components = [ "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
Time for another toolchain upgrade to fix a number of known compiler bugs.