### PR TITLE
Add examples to attiny-hal documentation

### DIFF
--- a/mcu/attiny-hal/src/adc.rs
+++ b/mcu/attiny-hal/src/adc.rs
@@ -1,5 +1,29 @@
 #![allow(non_camel_case_types)]
 //! Analog-to-Digital Converter
+//!
+//! # Example
+//!
+//! For full source code, please refer to the ATmega ADC example:
+//! [`atmega2560-adc.rs`](https://github.com/Rahix/avr-hal/blob/main/examples/atmega2560/src/bin/atmega2560-adc.rs)
+//!
+//! ```
+//! let dp = attiny_hal::Peripherals::take().unwrap();
+//! let pins = attiny_hal::pins!(dp);
+//!
+//! let mut adc = Adc::new(dp.ADC, Default::default());
+//!
+//! let channels: [attiny_hal::adc::Channel; 4] = [
+//!     pins.pa0.into_analog_input(&mut adc).into_channel(),
+//!     pins.pa1.into_analog_input(&mut adc).into_channel(),
+//!     pins.pa2.into_analog_input(&mut adc).into_channel(),
+//!     pins.pa3.into_analog_input(&mut adc).into_channel(),
+//! ];
+//!
+//! for (index, channel) in channels.iter().enumerate() {
+//!     let value = adc.read_blocking(channel);
+//!     ufmt::uwrite!(&mut serial, "CH{}: {} ", index, value).unwrap();
+//! }
+//! ```
 
 use crate::port;
 pub use avr_hal_generic::adc::{AdcChannel, AdcOps, ClockDivider};

--- a/mcu/attiny-hal/src/eeprom.rs
+++ b/mcu/attiny-hal/src/eeprom.rs
@@ -1,3 +1,23 @@
+//! EEPROM
+//!
+//! # Example
+//!
+//! For full source code, please refer to the ATmega EEPROM example:
+//! [`atmega2560-eeprom.rs`](https://github.com/Rahix/avr-hal/blob/main/examples/atmega2560/src/bin/atmega2560-eeprom.rs)
+//!
+//! ```
+//! const BOOT_COUNT_OFFSET: u16 = 0;
+//!
+//! let dp = attiny_hal::Peripherals::take().unwrap();
+//! let mut eeprom = Eeprom::new(dp.EEPROM);
+//!
+//! let mut boot_count = eeprom.read_byte(BOOT_COUNT_OFFSET);
+//! boot_count = boot_count.wrapping_add(1);
+//! eeprom.write_byte(BOOT_COUNT_OFFSET, boot_count);
+//!
+//! ufmt::uwriteln!(&mut serial, "Boot count: {}", boot_count).unwrap();
+//! ```
+
 pub use avr_hal_generic::eeprom::{EepromOps, OutOfBoundsError};
 
 pub type Eeprom = avr_hal_generic::eeprom::Eeprom<crate::Attiny, crate::pac::EEPROM>;

--- a/mcu/attiny-hal/src/port.rs
+++ b/mcu/attiny-hal/src/port.rs
@@ -1,3 +1,22 @@
+//! Port
+//!
+//! # Example
+//!
+//! For full source code, please refer to the ATmega port example:
+//! [`atmega2560-blink.rs`](https://github.com/Rahix/avr-hal/blob/main/examples/atmega2560/src/bin/atmega2560-blink.rs)
+//!
+//! ```
+//! let dp = attiny_hal::Peripherals::take().unwrap();
+//! let pins = attiny_hal::pins!(dp);
+//!
+//! let mut led = pins.pb2.into_output();
+//!
+//! loop {
+//!     led.toggle();
+//!     delay_ms(1000);
+//! }
+//! ```
+
 pub use avr_hal_generic::port::{mode, PinMode, PinOps};
 
 #[cfg(feature = "attiny2313")]

--- a/mcu/attiny-hal/src/spi.rs
+++ b/mcu/attiny-hal/src/spi.rs
@@ -1,3 +1,34 @@
+//! SPI
+//!
+//! # Example
+//!
+//! For full source code, please refer to the ATmega SPI example:
+//! [`atmega2560-spi-feedback.rs`](https://github.com/Rahix/avr-hal/blob/main/examples/atmega2560/src/bin/atmega2560-spi-feedback.rs)
+//!
+//! ```
+//! let dp = attiny_hal::Peripherals::take().unwrap();
+//! let pins = attiny_hal::pins!(dp);
+//!
+//! let (mut spi, mut cs) = spi::Spi::new(
+//!     dp.SPI,
+//!     pins.pa4.into_output(),
+//!     pins.pa6.into_output(),
+//!     pins.pa5.into_pull_up_input(),
+//!     pins.pa3.into_output(),
+//!     spi::Settings::default(),
+//! );
+//!
+//! let data_out = b"Hello World!";
+//! let mut data_in = [0u8; 12];
+//!
+//! cs.set_low().unwrap();
+//! spi.transfer(&mut data_in, data_out).unwrap();
+//! cs.set_high().unwrap();
+//!
+//! ufmt::uwriteln!(&mut serial, "data: {:?}", data_in).unwrap();
+//! ```
+
+
 #[allow(unused_imports)]
 use crate::port;
 pub use avr_hal_generic::spi::*;


### PR DESCRIPTION
Part of https://github.com/Rahix/avr-hal/issues/590

This one is a bit more tricky, as there are no plain `attiny-hal` examples and I don't have access to an ATtiny board.

For now, I  copied the examples from `atmega-hal` and modified them for `attiny-hal`, referencing ATtiny84 datasheet for pinouts. As a compromise, I link to ATmega examples.

Do you think this is acceptable?