### PR TITLE
arduino-hal: Add panic-halt feature

### DIFF
--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["no-std", "embedded", "hardware-support"]
 [features]
 default = ["rt"]
 rt = ["avr-device/rt"]
+panic-halt = ["dep:panic-halt"]
 
 critical-section-impl = ["avr-device/critical-section-impl"]
 
@@ -56,6 +57,10 @@ optional = true
 # this allows us to show our error instead of the one from `atmega-hal` (which
 # is much less helpful in this situation).
 features = ["disable-device-selection-error"]
+
+[dependencies.panic-halt]
+version = "0.2.0"
+optional = true
 
 [dependencies.attiny-hal]
 path = "../mcu/attiny-hal/"

--- a/arduino-hal/src/lib.rs
+++ b/arduino-hal/src/lib.rs
@@ -129,6 +129,9 @@ pub mod port;
 #[cfg(feature = "board-selected")]
 pub use port::Pins;
 
+#[cfg(feature = "panic-halt")]
+use panic_halt as _;
+
 /// Analog to Digital converter.
 #[cfg(feature = "mcu-atmega")]
 pub mod adc {


### PR DESCRIPTION
For most beginners, the panic handler will be a simple one. Like the one from the [panic-halt](https://github.com/korken89/panic-halt) crate. It's usage has already been established in most exmaples. 

Thus, it would be less boilerplate for beginner projects, if the panic-halt handler would just be a feature. Similar to how the [uefi-rs](https://github.com/rust-osdev/uefi-rs) crate handles this. 