### PR TITLE
Make attiny_hal::pins! and atmega_hal::pins! feature-agnostic

### DIFF
--- a/avr-hal-generic/src/port.rs
+++ b/avr-hal-generic/src/port.rs
@@ -586,7 +586,7 @@ macro_rules! impl_port_traditional {
 
             impl Pins {
                 pub fn new(
-                    $(_: $port,)+
+                    $(_: &$port,)+
                 ) -> Self {
                     Self {
                         $($([<p $name:lower $pin>]: $crate::port::Pin::new(

--- a/mcu/atmega-hal/src/lib.rs
+++ b/mcu/atmega-hal/src/lib.rs
@@ -147,68 +147,10 @@ pub use eeprom::Eeprom;
 
 pub struct Atmega;
 
-#[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
+#[cfg(feature = "device-selected")]
 #[macro_export]
 macro_rules! pins {
     ($p:expr) => {
-        $crate::Pins::new($p.PORTB, $p.PORTC, $p.PORTD)
-    };
-}
-#[cfg(any(feature = "atmega164pa"))]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD)
-    };
-}
-#[cfg(feature = "atmega328pb")]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTB, $p.PORTC, $p.PORTD, $p.PORTE)
-    };
-}
-#[cfg(feature = "atmega32u4")]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTB, $p.PORTC, $p.PORTD, $p.PORTE, $p.PORTF)
-    };
-}
-
-#[cfg(any(feature = "atmega128a"))]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new(
-            $p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD, $p.PORTE, $p.PORTF, $p.PORTG,
-        )
-    };
-}
-
-#[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new(
-            $p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD, $p.PORTE, $p.PORTF, $p.PORTG, $p.PORTH,
-            $p.PORTJ, $p.PORTK, $p.PORTL,
-        )
-    };
-}
-
-#[cfg(any(feature = "atmega1284p", feature = "atmega32a"))]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD)
-    };
-}
-
-#[cfg(any(feature = "atmega8"))]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTB, $p.PORTC, $p.PORTD)
+        $crate::port::pins(&$p)
     };
 }

--- a/mcu/atmega-hal/src/port.rs
+++ b/mcu/atmega-hal/src/port.rs
@@ -27,6 +27,11 @@ avr_hal_generic::impl_port_traditional! {
         D: crate::pac::PORTD = [0, 1, 2, 3, 4, 5, 6, 7],
     }
 }
+#[cfg(any(feature = "atmega48p", feature = "atmega168", feature = "atmega328p"))]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD);
+}
+
 
 #[cfg(any(feature = "atmega164pa"))]
 avr_hal_generic::impl_port_traditional! {
@@ -37,6 +42,11 @@ avr_hal_generic::impl_port_traditional! {
         D: crate::pac::PORTD = [0, 1, 2, 3, 4, 5, 6 ,7],
     }
 }
+#[cfg(any(feature = "atmega164pa"))]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTA, &peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD);
+}
+
 
 #[cfg(feature = "atmega328pb")]
 avr_hal_generic::impl_port_traditional! {
@@ -47,6 +57,11 @@ avr_hal_generic::impl_port_traditional! {
         E: crate::pac::PORTE = [0, 1, 2, 3],
     }
 }
+#[cfg(feature = "atmega328pb")]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD, &peripherals.PORTE);
+}
+
 
 #[cfg(feature = "atmega32u4")]
 avr_hal_generic::impl_port_traditional! {
@@ -58,6 +73,11 @@ avr_hal_generic::impl_port_traditional! {
         F: crate::pac::PORTF = [0, 1, 4, 5, 6, 7],
     }
 }
+#[cfg(feature = "atmega32u4")]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD, &peripherals.PORTE, &peripherals.PORTF);
+}
+
 
 #[cfg(any(feature = "atmega128a"))]
 avr_hal_generic::impl_port_traditional! {
@@ -71,6 +91,11 @@ avr_hal_generic::impl_port_traditional! {
         G: crate::pac::PORTG = [0, 1, 2, 3, 4],
     }
 }
+#[cfg(any(feature = "atmega128a"))]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTA, &peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD, &peripherals.PORTE, &peripherals.PORTF, &peripherals.PORTG);
+}
+
 
 #[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
 avr_hal_generic::impl_port_traditional! {
@@ -88,6 +113,11 @@ avr_hal_generic::impl_port_traditional! {
         L: crate::pac::PORTL = [0, 1, 2, 3, 4, 5, 6, 7],
     }
 }
+#[cfg(any(feature = "atmega1280", feature = "atmega2560"))]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTA, &peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD, &peripherals.PORTE, &peripherals.PORTF, &peripherals.PORTG, &peripherals.PORTH, &peripherals.PORTJ, &peripherals.PORTK, &peripherals.PORTL);
+}
+
 
 #[cfg(any(feature = "atmega1284p", feature = "atmega32a"))]
 avr_hal_generic::impl_port_traditional! {
@@ -98,6 +128,11 @@ avr_hal_generic::impl_port_traditional! {
         D: crate::pac::PORTD = [0, 1, 2, 3, 4, 5, 6, 7],
     }
 }
+#[cfg(any(feature = "atmega1284p", feature = "atmega32a"))]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTA, &peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD);
+}
+
 
 #[cfg(any(feature = "atmega8"))]
 avr_hal_generic::impl_port_traditional! {
@@ -107,3 +142,8 @@ avr_hal_generic::impl_port_traditional! {
         D: crate::pac::PORTD = [0, 1, 2, 3, 4, 5, 6, 7],
     }
 }
+#[cfg(any(feature = "atmega8"))]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD);
+}
+

--- a/mcu/attiny-hal/src/lib.rs
+++ b/mcu/attiny-hal/src/lib.rs
@@ -95,38 +95,10 @@ pub use spi::Spi;
 
 pub struct Attiny;
 
-#[cfg(feature = "attiny84")]
+#[cfg(feature = "device-selected")]
 #[macro_export]
 macro_rules! pins {
     ($p:expr) => {
-        $crate::Pins::new($p.PORTA, $p.PORTB)
-    };
-}
-#[cfg(feature = "attiny85")]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTB)
-    };
-}
-#[cfg(feature = "attiny88")]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTA, $p.PORTB, $p.PORTC, $p.PORTD)
-    };
-}
-#[cfg(feature = "attiny167")]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTA, $p.PORTB)
-    };
-}
-#[cfg(feature = "attiny2313")]
-#[macro_export]
-macro_rules! pins {
-    ($p:expr) => {
-        $crate::Pins::new($p.PORTA, $p.PORTB, $p.PORTD)
+        $crate::port::pins(&$p)
     };
 }

--- a/mcu/attiny-hal/src/port.rs
+++ b/mcu/attiny-hal/src/port.rs
@@ -28,12 +28,22 @@ avr_hal_generic::impl_port_traditional! {
     }
 }
 
+#[cfg(feature = "attiny2313")]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTA, &peripherals.PORTB, &peripherals.PORTD);
+}
+
 #[cfg(feature = "attiny167")]
 avr_hal_generic::impl_port_traditional! {
     enum Ports {
         A: crate::pac::PORTA = [0, 1, 2, 3, 4, 5, 6, 7],
         B: crate::pac::PORTB = [0, 1, 2, 3, 4, 5, 6, 7],
     }
+}
+
+#[cfg(feature = "attiny167")]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTA, &peripherals.PORTB);
 }
 
 #[cfg(feature = "attiny84")]
@@ -44,11 +54,21 @@ avr_hal_generic::impl_port_traditional! {
     }
 }
 
+#[cfg(feature = "attiny84")]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTA, &peripherals.PORTB);
+}
+
 #[cfg(feature = "attiny85")]
 avr_hal_generic::impl_port_traditional! {
     enum Ports {
         B: crate::pac::PORTB = [0, 1, 2, 3, 4, 5],
     }
+}
+
+#[cfg(feature = "attiny85")]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTB);
 }
 
 #[cfg(feature = "attiny88")]
@@ -59,4 +79,9 @@ avr_hal_generic::impl_port_traditional! {
         C: crate::pac::PORTC = [0, 1, 2, 3, 4, 5, 6, 7],
         D: crate::pac::PORTD = [0, 1, 2, 3, 4, 5, 6, 7],
     }
+}
+
+#[cfg(feature = "attiny88")]
+pub fn pins(peripherals: &crate::pac::Peripherals) -> Pins {
+    return Pins::new(&peripherals.PORTA, &peripherals.PORTB, &peripherals.PORTC, &peripherals.PORTD);
 }


### PR DESCRIPTION
This removes the feature-specific (and therefore MCU-specific) `pins!` macro and replaces it with a feature-agnostic `pins!` macro + an MCU-specific wrapper function. 

This is initial work to enable a refractor that will switch all crates in `arduino-hal` to use additive features, as is the recommended best practice. See https://github.com/Rahix/avr-hal/issues/602 for more context. 

Testing: 

* Verified that `cargo build -p arduino-hal --features <board>` succeeds for all boards
* Verified that `cargo build --bins` succeeds for every `example/*`

Using stacked PRs — see https://github.com/innermatrix/avr-hal/pull/1#issuecomment-2489875246 for a preview of the follow-on work in progress. 