### PR TITLE
Add ravedude support for Mighty Core ATMEGA1284P boards

### DIFF
--- a/ravedude/src/boards.toml
+++ b/ravedude/src/boards.toml
@@ -238,3 +238,19 @@
     [duemilanove.usb-info]
     # No IDs here because the Nano 168 uses a generic USB-Serial chip.
     error = "Not able to guess port"
+
+[mighty-core-atmega1284p]
+    name = "Might Core Development Board for ATMEGA1284P"
+
+    [mighty-core-atmega1284p.reset]
+    automatic = true
+
+    [mighty-core-atmega1284p.avrdude]
+    programmer = "arduino"
+    partno = "atmega1284p"
+    baudrate = -1
+    do-chip-erase = true
+
+    [mighty-core-atmega1284p.usb-info]
+    error = "Not able to guess port"
+

--- a/ravedude/src/boards.toml
+++ b/ravedude/src/boards.toml
@@ -239,17 +239,17 @@
     # No IDs here because the Nano 168 uses a generic USB-Serial chip.
     error = "Not able to guess port"
 
-[atmega-dip40-atmega1284p]
+[mighty-core-atmega1284p]
     name = "Mighty Core DIP40 Dev Board for ATMEGA1284P"
 
-    [atmega-dip40-atmega1284p.reset]
+    [mighty-core-atmega1284p.reset]
     automatic = true
 
-    [atmega-dip40-atmega1284p.avrdude]
+    [mighty-core-atmega1284p.avrdude]
     programmer = "arduino"
     partno = "atmega1284p"
     baudrate = -1
     do-chip-erase = true
 
-    [atmega-dip40-atmega1284p.usb-info]
+    [mighty-core-atmega1284p.usb-info]
     error = "Not able to guess port"

--- a/ravedude/src/boards.toml
+++ b/ravedude/src/boards.toml
@@ -239,18 +239,17 @@
     # No IDs here because the Nano 168 uses a generic USB-Serial chip.
     error = "Not able to guess port"
 
-[mighty-core-atmega1284p]
-    name = "Mighty Core Development Board for ATMEGA1284P"
+[atmega-dip40-atmega1284p]
+    name = "Mighty Core DIP40 Dev Board for ATMEGA1284P"
 
-    [mighty-core-atmega1284p.reset]
+    [atmega-dip40-atmega1284p.reset]
     automatic = true
 
-    [mighty-core-atmega1284p.avrdude]
+    [atmega-dip40-atmega1284p.avrdude]
     programmer = "arduino"
     partno = "atmega1284p"
     baudrate = -1
     do-chip-erase = true
 
-    [mighty-core-atmega1284p.usb-info]
+    [atmega-dip40-atmega1284p.usb-info]
     error = "Not able to guess port"
-

--- a/ravedude/src/boards.toml
+++ b/ravedude/src/boards.toml
@@ -240,7 +240,7 @@
     error = "Not able to guess port"
 
 [mighty-core-atmega1284p]
-    name = "Might Core Development Board for ATMEGA1284P"
+    name = "Mighty Core Development Board for ATMEGA1284P"
 
     [mighty-core-atmega1284p.reset]
     automatic = true


### PR DESCRIPTION
This adds support for the [Arduino DIP-40 Development Board](https://www.tindie.com/products/MCUdude/dip-40-arduino-compatible-development-board/) with a ATMEGA1284P using the Mighty Core Arduino core and bootloader, or really any board using a ATEMEGA1284P with the [Mighty Core Arduino core](https://github.com/MCUdude/MightyCore) installed.

 Tested and verified to work with a ATEMEGA1284P. Theoretically variants of this can be made for other ATMEGA DIP40 MCUs, but I am not in a position to test that.