### PR TITLE
avr-hal-generic: prefer compilation error for unsupported targets

### DIFF
--- a/avr-hal-generic/src/delay.rs
+++ b/avr-hal-generic/src/delay.rs
@@ -57,11 +57,6 @@ fn busy_loop(mut c: u16) {
     }
 }
 
-#[cfg(not(target_arch = "avr"))]
-fn busy_loop(_c: u16) {
-    unimplemented!("Implementation is only available for avr targets!")
-}
-
 // Clock-Specific Delay Implementations ----------------------------------- {{{
 impl delay_v0::DelayUs<u16> for Delay<crate::clock::MHz24> {
     fn delay_us(&mut self, mut us: u16) {


### PR DESCRIPTION
The build.rs logic is only used to detect a relatively old compiler version (Feb 2022). Since a nightly build is required to target AVR it's unlikely anyone is benefiting from this check.  By removing it we reduce dependencies and implementation complexity.