### PR TITLE
Fixed trinket board def

### DIFF
--- a/ravedude/src/boards.toml
+++ b/ravedude/src/boards.toml
@@ -201,9 +201,9 @@
     
     [trinket.avrdude]
     programmer = "usbtiny"
-    partno = "atmega328p"
+    partno = "attiny85"
     baudrate = -1
-    do-chip-erase = true
+    do-chip-erase = false
 
     # The Trinket does not have USB-Serial, thus no port is known or needed.
 


### PR DESCRIPTION
Not sure how we got here, but the original Trinket was an ATtiny85 board; see https://www.adafruit.com/product/1501. I tested this change on a Trinket I have here, and also found that it does not support chip erase via avrdude.