### PR TITLE
Prepare for release-plz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,13 @@ jobs:
       - name: Test ravedude
         run: |
           cargo test --manifest-path ravedude/Cargo.toml
+
+  crates_io_release:
+     name: "release-plz"
+     runs-on: ubuntu-latest
+     steps:
+       - name: Run release-plz
+         uses: MarcoIeni/release-plz-action@main
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/arduino-hal/Cargo.toml
+++ b/arduino-hal/Cargo.toml
@@ -41,9 +41,11 @@ embedded-hal = "1.0"
 ufmt = "0.2.0"
 
 [dependencies.avr-hal-generic]
+version = "0.1.0"
 path = "../avr-hal-generic/"
 
 [dependencies.atmega-hal]
+version = "0.1.0"
 path = "../mcu/atmega-hal/"
 optional = true
 
@@ -54,6 +56,7 @@ optional = true
 features = ["disable-device-selection-error"]
 
 [dependencies.attiny-hal]
+version = "0.1.0"
 path = "../mcu/attiny-hal/"
 optional = true
 

--- a/mcu/atmega-hal/Cargo.toml
+++ b/mcu/atmega-hal/Cargo.toml
@@ -37,7 +37,7 @@ disable-device-selection-error = []
 docsrs = ["atmega328p"]
 
 [dependencies]
-avr-hal-generic = { path = "../../avr-hal-generic/" }
+avr-hal-generic = { version="0.1.0", path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
 version = "0.7"

--- a/mcu/attiny-hal/Cargo.toml
+++ b/mcu/attiny-hal/Cargo.toml
@@ -28,7 +28,7 @@ disable-device-selection-error = []
 docsrs = ["attiny85"]
 
 [dependencies]
-avr-hal-generic = { path = "../../avr-hal-generic/" }
+avr-hal-generic = { version = "0.1.0", path = "../../avr-hal-generic/" }
 
 [dependencies.avr-device]
 version = "0.7"


### PR DESCRIPTION
Hello @Rahix, @tonnes111 and other avr-hal interested folks.

After [this comment from @tonnes111](https://github.com/embassy-rs/embassy/pull/3696/files#r1900239902), I wanted to contribute with setting up a reliable crates.io release automation for this repository, it has worked wonders at my dayjob:

https://github.com/umccr/htsget-rs

Hope it helps for you too! Next steps would be to locally run `cargo install release-plz`, outside the `avr-hal` repository (to avoid clashes with edition2024) and then run `release-plz init` inside `avr-hal`'s root, like so:

```
avr-hal % release-plz init
👋 This process will guide you in setting up release-plz in your GitHub repository, using `gh` (the GitHub CLI) to store the necessary tokens in your repository secrets.
👉 Paste your cargo registry token to store it in the GitHub actions repository secrets.
💡 You can create a crates.io token on https://crates.io/settings/tokens/new, specifying the following scopes: "publish-new" and "publish-update".
? Paste your secret: *******
```

There's plenty of guidance on the official page: https://release-plz.dev/