### PR TITLE
Added the ravedude chip command for bare MCU development

### DIFF
--- a/ravedude/Cargo.lock
+++ b/ravedude/Cargo.lock
@@ -242,6 +242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +320,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "mach"
@@ -380,6 +397,12 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "ppv-lite86"
@@ -461,6 +484,7 @@ dependencies = [
  "ctrlc",
  "either",
  "git-version",
+ "goblin",
  "serde",
  "serialport",
  "tempfile",
@@ -500,6 +524,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/ravedude/Cargo.toml
+++ b/ravedude/Cargo.toml
@@ -21,3 +21,4 @@ serde = { version = "1.0.197", features = ["serde_derive"] }
 toml = "0.8.11"
 either = "1.10.0"
 clap = { version = "4.0.0", features = ["derive", "env"] }
+goblin = "0.9.3"

--- a/ravedude/src/config.rs
+++ b/ravedude/src/config.rs
@@ -34,7 +34,7 @@ where
 }
 
 impl RavedudeConfig {
-    pub fn from_args(args: &crate::Args) -> anyhow::Result<Self> {
+    pub fn from_args(args: &crate::BoardArgs) -> anyhow::Result<Self> {
         Ok(Self {
             general_options: RavedudeGeneralConfig {
                 open_console: args.open_console,
@@ -67,7 +67,7 @@ pub struct RavedudeGeneralConfig {
 
 impl RavedudeGeneralConfig {
     /// Apply command-line overrides to this configuration. Command-line arguments take priority over Ravedude.toml
-    pub fn apply_overrides_from(&mut self, args: &crate::Args) -> anyhow::Result<()> {
+    pub fn apply_overrides_from(&mut self, args: &crate::BoardArgs) -> anyhow::Result<()> {
         if args.open_console {
             self.open_console = true;
         }

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -92,7 +92,9 @@
 //!
 //! For reference, take a look at [`boards.toml`](https://github.com/Rahix/avr-hal/blob/main/ravedude/src/boards.toml).
 use anyhow::Context as _;
+use clap::Parser;
 use colored::Colorize as _;
+use std::num::NonZero;
 
 use std::path::Path;
 use std::thread;
@@ -102,10 +104,21 @@ mod avrdude;
 mod board;
 mod config;
 mod console;
+mod target_detect;
 mod ui;
 
 /// This represents the minimum (Major, Minor) version raverdude requires avrdude to meet.
 const MIN_VERSION_AVRDUDE: (u8, u8) = (6, 3);
+
+// ravedude has two subcommands: the `board` subcommand, which flashes a binary to a board, and a
+// `chip` command, which flashes a binary to a chip. The differ in that
+// * The `chip` command determines the target chip from the elf binary metadata, where as the
+//   `board` command requires that you specify the board by using a TOML config file
+// * The `chip` command allows more of its options to be specified through environment variables,
+//   whereas the board command reads its options from the TOML config and command-line arguments
+
+// A unification between the two is desirable, but I am keeping them separate initially in order to
+// maintain backwards compatibility in `board` while doing new development in `chip`.
 
 /// ravedude is a rust wrapper around avrdude for providing the smoothest possible development
 /// experience with rust on AVR microcontrollers.
@@ -120,6 +133,21 @@ const MIN_VERSION_AVRDUDE: (u8, u8) = (6, 3);
         fallback = "unknown"
     ))]
 struct Args {
+    #[command(subcommand)]
+    subcommand: Subcommand,
+}
+
+#[derive(clap::Parser, Debug)]
+enum Subcommand {
+    Board(BoardArgs),
+    Chip(ChipArgs),
+}
+
+/// High-level flashing command. Use this if you are working on a standalone binary that will be
+/// flashed to a specific off-the shelf board, such as Arduino Uno, Adafruit Trinket, or Arduino Pro
+/// Mini.
+#[derive(clap::Parser, Debug)]
+struct BoardArgs {
     /// Utility flag for dumping a config of a named board to TOML.
     #[clap(long = "dump-config")]
     dump_config: bool,
@@ -160,7 +188,73 @@ struct Args {
     #[clap(name = "LEGACY BINARY", value_parser)]
     bin_legacy: Option<std::path::PathBuf>,
 }
-impl Args {
+
+#[derive(clap::Parser, clap::ValueEnum, Debug, Clone)]
+enum ConsoleMode {
+    /// Do not connect to the chip after flashing the binary
+    None,
+    /// Connect to the chip using a plain serial console
+    Plain,
+}
+
+impl std::fmt::Display for ConsoleMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ConsoleMode::None => write!(f, "none"),
+            ConsoleMode::Plain => write!(f, "plain"),
+        }
+    }
+}
+
+/// Low-level flashing command. Use this if you are flashing to a bare chip or a chip on a custom board.
+#[derive(clap::Parser, Debug)]
+struct ChipArgs {
+    /// The name of the AVR programmer you are using. Run `avrdude "-c?"` for the full list.
+    #[clap(long = "programmer", env = "AVR_PROGRAMMER_NAME")]
+    programmer_name: Option<String>,
+
+    /// The serial port used to connect to the programmer. Autodetected when possible if unspecified.
+    #[clap(long = "programmer-port", env = "AVR_PROGRAMMER_PORT", value_parser)]
+    programmer_port: Option<std::path::PathBuf>,
+
+    /// The baudrate used to connect to the programmer. Autodetected when possible if unspecified.
+    #[clap(long = "programmer-baudrate", env = "AVR_PROGRAMMER_BAUDRATE")]
+    programmer_baudrate: Option<NonZero<u32>>,
+
+    /// If set, erase the target before flashing.
+    #[clap(
+        long = "erase-target",
+        env = "AVR_PROGRAMMER_ERASE_TARGET",
+        default_value_t = true
+    )]
+    erase_target: bool,
+
+    /// Serial connection mode, used to connect to the chip after flashing the binary
+    #[clap(
+        long = "console-mode",
+        env = "AVR_CONSOLE_MODE",
+        default_value_t = ConsoleMode::None
+    )]
+    console_mode: ConsoleMode,
+
+    /// The serial port used to connect to the chip after flashing, if different from the programmer serial port.
+    #[clap(long = "console-port", env = "AVR_CONSOLE_PORT", value_parser)]
+    console_port: Option<std::path::PathBuf>,
+
+    /// The baudrate used to connect to the chip after flashing, if different from the programmer baudrate.
+    #[clap(short = 'b', long = "console-baudrate", env = "AVR_CONSOLE_BAUDRATE")]
+    console_baudrate: Option<NonZero<u32>>,
+
+    /// Print verbose information
+    #[clap(short = 'v', long = "verbose")]
+    verbose: bool,
+
+    #[clap(value_parser)]
+    /// The binary to be flashed.
+    binary: std::path::PathBuf,
+}
+
+impl BoardArgs {
     /// Get the board name for legacy configurations.
     /// `None` if the configuration isn't a legacy configuration or the board name doesn't exist.
     fn legacy_board_name(&self) -> Option<String> {
@@ -216,8 +310,27 @@ fn find_manifest() -> anyhow::Result<Option<std::path::PathBuf>> {
 }
 
 fn ravedude() -> anyhow::Result<()> {
-    let args: Args = clap::Parser::parse();
+    let mut args: Args = match Args::try_parse() {
+        Ok(args) => args,
+        Err(_) => {
+            // If no command is specified, try parsing as just `BoardArgs`
+            match BoardArgs::try_parse() {
+                Ok(boardArgs) => Args {
+                    subcommand: Subcommand::Board(boardArgs),
+                },
+                // If `BoardArgs` parsing doesn't work either, go back to parsing as `Args` to force the default help to be printed
+                Err(_) => Args::parse(),
+            }
+        }
+    };
 
+    match &mut args.subcommand {
+        Subcommand::Board(args) => ravedude_board(args),
+        Subcommand::Chip(ref mut args) => ravedude_chip(args),
+    }
+}
+
+fn ravedude_board(args: &BoardArgs) -> anyhow::Result<()> {
     let manifest_path = find_manifest()?;
 
     let mut ravedude_config = match (manifest_path.as_deref(), args.legacy_board_name()) {
@@ -343,6 +456,69 @@ fn ravedude() -> anyhow::Result<()> {
     } else if args.bin.is_none() && port.is_some() {
         warning!("you probably meant to add -c/--open-console?");
     }
+
+    Ok(())
+}
+
+fn ravedude_chip(args: &mut ChipArgs) -> anyhow::Result<()> {
+    avrdude::Avrdude::require_min_ver(MIN_VERSION_AVRDUDE)?;
+
+    // Some programmers require an explicit port, and we could hardcode that here for a better error message.
+    if let Some(port) = args.programmer_port.as_ref() {
+        task_message!(
+            "Programming",
+            "{} {} {}",
+            args.binary.display(),
+            "=>".blue().bold(),
+            port.display()
+        );
+    } else {
+        task_message!("Programming", "{}", args.binary.display(),);
+    }
+
+    let target = target_detect::target_name_from_binary(&args.binary)?;
+
+    let avrdude_options = config::BoardAvrdudeOptions {
+        programmer: args.programmer_name.clone(),
+        partno: Some(target),
+        baudrate: Some(args.programmer_baudrate),
+        do_chip_erase: Some(args.erase_target),
+    };
+
+    let mut avrdude = avrdude::Avrdude::run(
+        &avrdude_options,
+        args.programmer_port.as_ref(),
+        &args.binary,
+        args.verbose,
+    )?;
+    avrdude.wait()?;
+
+    task_message!("Programmed", "{}", args.binary.display());
+
+    match args.console_mode {
+        ConsoleMode::None => Ok(()),
+        ConsoleMode::Plain => {
+            let port = args.console_port.take().or(args.programmer_port.take());
+            let baudrate = args
+                .console_baudrate
+                .take()
+                .or(args.programmer_baudrate.take());
+
+            match (port, baudrate) {
+                (Some(port), Some(baudrate)) => {
+                    task_message!("Console", "{} at {} baud", port.display(), baudrate);
+                    task_message!("", "{}", "CTRL+C to exit.".dimmed());
+                    // Empty line for visual consistency
+                    eprintln!();
+                    console::open(&port, baudrate.get())
+                }
+
+                _ => Err(anyhow::anyhow!(
+                    "Console port and baudrate have to be specified."
+                )),
+            }
+        }
+    }?;
 
     Ok(())
 }

--- a/ravedude/src/target_detect.rs
+++ b/ravedude/src/target_detect.rs
@@ -1,0 +1,42 @@
+use std::ffi::{c_char, CStr};
+use std::marker::PhantomData;
+use std::mem::offset_of;
+use std::path::Path;
+
+use anyhow::Result;
+
+use goblin::elf::Elf;
+
+#[repr(C, packed)]
+#[derive(Debug)]
+struct AvrDeviceInfoDesc<'a> {
+    flash_start: u32,
+    flash_size: u32,
+    sram_start: u32,
+    sram_size: u32,
+    eeprom_start: u32,
+    eeprom_size: u32,
+    offset_table_size: u32,
+    offset_table: [u32; 1],
+    strtab: PhantomData<&'a [u8]>,
+}
+
+// https://avrdudes.github.io/avr-libc/avr-libc-user-manual/mem_sections.html#sec_dot_note
+pub fn target_name_from_binary(binary: impl AsRef<Path>) -> Result<String> {
+    let file_data = std::fs::read(binary)?;
+    let note = Elf::parse(&file_data)?
+        .iter_note_sections(&file_data, Some(".note.gnu.avr.deviceinfo"))
+        .map(|mut it| it.nth(0))
+        .flatten()
+        .transpose()?
+        .ok_or_else(|| anyhow::anyhow!("AVR device info section not found"))?;
+
+    let device_info_p = note.desc.as_ptr() as *const AvrDeviceInfoDesc;
+    let device_info = unsafe { &*device_info_p };
+    let device_name_offset =
+        offset_of!(AvrDeviceInfoDesc, strtab) as isize + device_info.offset_table[0] as isize;
+    let device_name_p = unsafe { note.desc.as_ptr().offset(device_name_offset) } as *const c_char;
+    let device_name = unsafe { CStr::from_ptr(device_name_p) }.to_str()?;
+
+    Ok(device_name.to_string())
+}


### PR DESCRIPTION
This PR adds a `ravedude chip` command, aimed primarily at anyone doing bare chip development. The behavior of the `ravedude chip` command is as follows:

1. `ravedude chip` can be used as a cargo runner
2. The target MCU is autodetected from the ELF metadata in the binary that is being flashed. See `ravedude/src/target_detect.rs`.
3. The programmer is specified either with command line options or with environment variables. There is no provision for specifying the programmer using a configuration file. The rationale for this is
  * The programmer and its associated settings (port and baud rate) are not a property of the crate, but are configuration parameters specific to a particular developer and their development system. 
  * Any crate that wishes to hardcode programmer settings can do so in `.cargo/config.toml` and doesn't need a separate config file.
  * Any crate that wishes to leave programmer settings up to the individual developer can leave them out of `.cargo/config.toml` and require the developer to configure them with environment variables
  * Any developer that wishes to use a file on disk to configure their environment can use `direnv` or a similar tool. 
4. `ravedude chip` supports opening a serial console after flashing. Serial console settings (port and baud rate) are specified with either command line options or with environment variable. Typically, the baud rate would be specified in `.cargo/config.toml` (because it's a property of the crate) and the port would be specified in an environment variable (because it's a developer-specific configuration parameter).

In summary, the intended use of `ravedude chip` is:

* Set `runner` in `.cargo/config.toml` to `ravedude chip` (for no serial console after flashing) or `ravedude chip --console-mode=serial --console-baudrate=NNN` (for serial console after flashing)
* Set environment variables for `AVR_PROGRAMMER_NAME`, `AVR_PROGRAMMER_PORT` (if not autodetected by`avrdude`), `AVR_PROGRAMMER_BAUDRATE` (if not autodetected by`avrdude`), and `AVR_CONSOLE_PORT` (if different from `AVR_PROGRAMMER_PORT`) using any of the following methods: directly set them in the shell before `cargo run`, set them in the `[env]` section of `.cargo/config.toml`, or use `direnv` or a similar tool.

For consistency, the existing `ravedude` command has been renamed `ravedude board`; if neither `ravedude chip` nor `ravedude board` has been specified, `ravedude board` is implied. That is, the following work:

* `runner = ravedude` — works like before
* `runner = ravedude board` — works same as `ravedude`
* `runner = ravedude chip` — new addition, works as described above.

I am keeping `ravedude chip` out of the main package docs for now because its only imminent use will be internal (for developing inside MCU crates), but I do plan to add more documentation for it in the future (probably when I add examples in MCU crates, which I am working on in a separate branch). 