### PR TITLE
Add new `Ravedude.toml` files for all example crates

### DIFF
--- a/examples/arduino-diecimila/.cargo/config.toml
+++ b/examples/arduino-diecimila/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega168"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude diecimila"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/arduino-diecimila/Ravedude.toml
+++ b/examples/arduino-diecimila/Ravedude.toml
@@ -1,0 +1,7 @@
+[general]
+board = "diecimila"
+serial-baudrate = 57600
+open-console = true
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/arduino-leonardo/.cargo/config.toml
+++ b/examples/arduino-leonardo/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega32u4"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude leonardo"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/arduino-leonardo/Ravedude.toml
+++ b/examples/arduino-leonardo/Ravedude.toml
@@ -1,0 +1,12 @@
+[general]
+board = "leonardo"
+
+# The Arduino Leonardo does not have a UART console like other Arduino boards.
+# Instead, it can emulate a console device over USB, but this is not yet
+# supported in `avr-hal`.  To get console output from an Arduino Leonardo, you
+# need to connect an external usb-serial converter to the TX/RX pins of your
+# board.
+open-console = false
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/arduino-mega1280/.cargo/config.toml
+++ b/examples/arduino-mega1280/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega1280"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude -cb 57600 mega1280"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/arduino-mega1280/Ravedude.toml
+++ b/examples/arduino-mega1280/Ravedude.toml
@@ -1,0 +1,7 @@
+[general]
+board = "mega1280"
+serial-baudrate = 57600
+open-console = true
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/arduino-mega2560/.cargo/config.toml
+++ b/examples/arduino-mega2560/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega2560"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude -cb 57600 mega2560"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/arduino-mega2560/Ravedude.toml
+++ b/examples/arduino-mega2560/Ravedude.toml
@@ -1,0 +1,7 @@
+[general]
+board = "mega2560"
+serial-baudrate = 57600
+open-console = true
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/arduino-nano/.cargo/config.toml
+++ b/examples/arduino-nano/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega328p"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/arduino-nano/Ravedude.toml
+++ b/examples/arduino-nano/Ravedude.toml
@@ -1,0 +1,7 @@
+[general]
+board = "nano"
+serial-baudrate = 57600
+open-console = true
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/arduino-uno/.cargo/config.toml
+++ b/examples/arduino-uno/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega328p"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude uno -cb 57600"
+runner = "ravedude"
 # To run in simulator, replace the line above with this:
 # runner = "simavr -m atmega328p"
 

--- a/examples/arduino-uno/Ravedude.toml
+++ b/examples/arduino-uno/Ravedude.toml
@@ -1,0 +1,7 @@
+[general]
+board = "uno"
+serial-baudrate = 57600
+open-console = true
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/atmega2560/.cargo/config.toml
+++ b/examples/atmega2560/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega2560"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude -cb 57600 mega2560"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/atmega2560/Ravedude.toml
+++ b/examples/atmega2560/Ravedude.toml
@@ -1,0 +1,34 @@
+[general]
+# We're not using a predefined board here, but instead define a custom one.
+# board = "???"
+
+serial-baudrate = 57600
+open-console = true
+
+# Custom Board Definition Below.  Check
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/src/boards.toml for some
+# example board definitions.
+[board]
+name = "Custom ATmega2560 Board"
+
+[board.reset]
+automatic = true
+
+[board.avrdude]
+programmer = "wiring"
+partno = "atmega2560"
+baudrate = 115200
+do-chip-erase = false
+
+[board.usb-info]
+port-ids = [
+    { vid = 0x2341, pid = 0x0010 },
+    { vid = 0x2341, pid = 0x0042 },
+    { vid = 0x2A03, pid = 0x0010 },
+    { vid = 0x2A03, pid = 0x0042 },
+    { vid = 0x2341, pid = 0x0210 },
+    { vid = 0x2341, pid = 0x0242 },
+]
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/nano168/.cargo/config.toml
+++ b/examples/nano168/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega168"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano168 -cb 57600"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/nano168/Ravedude.toml
+++ b/examples/nano168/Ravedude.toml
@@ -1,0 +1,7 @@
+[general]
+board = "nano168"
+serial-baudrate = 57600
+open-console = true
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/sparkfun-promicro/.cargo/config.toml
+++ b/examples/sparkfun-promicro/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega32u4"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude promicro"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/sparkfun-promicro/Ravedude.toml
+++ b/examples/sparkfun-promicro/Ravedude.toml
@@ -1,0 +1,11 @@
+[general]
+board = "promicro"
+
+# The Pro Micro does not have a UART console like other Arduino boards.
+# Instead, it can emulate a console device over USB, but this is not yet
+# supported in `avr-hal`.  To get console output from a Pro Micro, you need to
+# connect an external usb-serial converter to the TX/RX pins of your board.
+open-console = false
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/sparkfun-promini-3v3/.cargo/config.toml
+++ b/examples/sparkfun-promini-3v3/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega328p"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude promini-3v3"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/sparkfun-promini-3v3/Ravedude.toml
+++ b/examples/sparkfun-promini-3v3/Ravedude.toml
@@ -1,0 +1,5 @@
+[general]
+board = "promini-3v3"
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/sparkfun-promini-5v/.cargo/config.toml
+++ b/examples/sparkfun-promini-5v/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega328p"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude promini-5v"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/sparkfun-promini-5v/Ravedude.toml
+++ b/examples/sparkfun-promini-5v/Ravedude.toml
@@ -1,0 +1,5 @@
+[general]
+board = "promini-5v"
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/trinket-pro/.cargo/config.toml
+++ b/examples/trinket-pro/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=atmega328p"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude trinket-pro"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/trinket-pro/Ravedude.toml
+++ b/examples/trinket-pro/Ravedude.toml
@@ -1,0 +1,5 @@
+[general]
+board = "trinket-pro"
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/examples/trinket/.cargo/config.toml
+++ b/examples/trinket/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "avr-none"
 rustflags = ["-C", "target-cpu=attiny85"]
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude trinket"
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/examples/trinket/Ravedude.toml
+++ b/examples/trinket/Ravedude.toml
@@ -1,0 +1,5 @@
+[general]
+board = "trinket"
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format

--- a/ravedude/CHANGELOG.md
+++ b/ravedude/CHANGELOG.md
@@ -14,8 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   internals of the tool.  Custom boards can now be defined and settings for
   off-the-shelf boards can be adjusted.
 
-  For documentation, please check [`main.rs`](https://github.com/Rahix/avr-hal/blob/main/ravedude/src/main.rs)
-  for the time being.
+  For documentation, please see [`Ravedude.toml` Format](https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format).
 
   This redesign was implemented in [#522].
 - Updated to clap 3.0 ([#631]).

--- a/ravedude/README.md
+++ b/ravedude/README.md
@@ -7,9 +7,6 @@ target's serial console, similar to the Arduino IDE.
 `ravedude` is meant to be used as a cargo "runner".  This allows you to just use
 `cargo run` for building, deploying, and running your AVR code!
 
-if you get an `Error: no matching serial port found, use -P or set RAVEDUDE_PORT in your environment` , 
-run `cargo run` with set environment variable or adjust `runner = "ravedude {X} -cb {X} -P /dev/ttyUSB{X}"` inside `.cargo/config.toml` (replace {X} with your respective values)
-
 ## Installation
 On Linux systems, you'll need pkg-config and libudev development files
 installed:
@@ -50,8 +47,8 @@ open-console = true
 serial-baudrate = 57600
 ```
 
-(For more info about the `Ravedude.toml` format, please check
-[`main.rs`](https://github.com/Rahix/avr-hal/blob/main/ravedude/src/main.rs)).
+For more info about the configuratiom, please check [`Ravedude.toml`
+Format](#ravedudetoml-format) below.
 
 And that's all, now just call `cargo run` and watch it do its magic:
 
@@ -114,6 +111,60 @@ Read direction test:
 60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 70: -- -- -- -- -- -- -- --
 </pre>
+
+## `Ravedude.toml` Format
+For off-the-shelf AVR boards that are already supported by ravedude, configuration is very
+simple.  Just two lines in `Ravedude.toml` are all that is necessary:
+
+```toml
+[general]
+board = "<board-name-here>"
+```
+
+Depending on your project, you may want to add any of the following additional options:
+
+```toml
+[general]
+# if auto-detection is not working, you can hard-code a specific port here
+# (the port can also be passed via the RAVEDUDE_PORT environment variable)
+port = "/dev/ttyACM0"
+
+# ravedude should open a serial console after flashing
+open-console = true
+
+# baudrate for the serial console (this is **not** the avrdude flashing baudrate)
+serial-baudrate = 57600
+
+# time to wait for the board to be reset (in milliseconds).  this skips the manual prompt for resetting the board.
+reset-delay = 2000
+```
+
+#### Custom Boards
+For boards that are not yet part of _ravedude_, you can specify all relevant options yourself
+in `Ravedude.toml`.  It works like this:
+
+```toml
+[general]
+# port = ...
+# open-console = true
+# serial-baudrate = 57600
+
+[board]
+name = "Custom Arduino Uno"
+
+[board.reset]
+# The board automatically resets when attempting to flash
+automatic = true
+
+[board.avrdude]
+# avrdude configuration
+programmer = "arduino"
+partno = "atmega328p"
+baudrate = -1
+do-chip-erase = true
+```
+
+For reference, take a look at [`boards.toml`](https://github.com/Rahix/avr-hal/blob/main/ravedude/src/boards.toml).
 
 ## License
 *ravedude* is licensed under either of


### PR DESCRIPTION
Now that the [new version of `ravedude`](https://github.com/Rahix/avr-hal/blob/main/ravedude/CHANGELOG.md#020---2025-04-22) has been released, add the necessary `Ravedude.toml` configuration files to all our example crates.

Cc: @Creative0708