### PR TITLE
Nix update and revamp

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+source_up_if_exists
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,145 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1746167999,
+        "narHash": "sha256-18XGHsjk/5H8F0OGUCG56CeeW1u6qQ7tAfQK3azlwWg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "bcbc23a4f3391c1c3657f1847cb693aaea3aed76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722073938,
+        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1746064326,
+        "narHash": "sha256-r7IZkN9NhK/IO9/J6D9ih2P1OXb67nr5HaQ1YAte18w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "91bf6dffa21c7709607c9fdbf9a6acb44e7a0a5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-NxYmSysMkQ+8bUZzRFyN+mqFdZ9bv9Bb9gwgCKQcCZU=",
+        "path": "/nix/store/iqjfrk4wpry4z7vnjq06l4nsbfiqf2kx-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1746093169,
+        "narHash": "sha256-3gmUmzIzfzlgF/b4HXvtoBIP4bKofVeEubX7LcPBYLo=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "298fa81aacda7b06de4db55c377b1aa081906bc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,82 @@
+{
+  description = "AVR HAL development environment";
+
+  inputs.devshell.url = "github:numtide/devshell";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.fenix.url = "github:nix-community/fenix";
+
+  outputs =
+    {
+      self,
+      fenix,
+      flake-utils,
+      devshell,
+      nixpkgs,
+    }:
+    flake-utils.lib.eachDefaultSystem (system: {
+      devShell =
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+
+            overlays = [ devshell.overlays.default fenix.overlays.default ];
+          };
+        in
+        pkgs.devshell.mkShell ({extraModulesPath, ...}: let
+          rust-toolchain = pkgs.fenix.fromToolchainFile {
+            file = ./rust-toolchain.toml;
+            sha256 = "DnyK5MS+xYySA+csnnMogu2gtEfyiy10W0ATmAvmjGg=";
+          };
+          c-compiler = pkgs.pkgsCross.avr.buildPackages.gcc;
+        in {
+          name = "avr-hal";
+
+          imports = [
+            "${extraModulesPath}/language/c.nix"
+          ];
+
+          language.c = {
+            compiler = c-compiler;
+          };
+
+          commands = [
+            {
+              name = "rustc";
+              category = "rust";
+              help = "Rust compiler";
+              package = rust-toolchain;
+            }
+            {
+              name = "cargo";
+              category = "rust";
+              help = "Rust build tool";
+              package = rust-toolchain;
+            }
+            {
+              name = "rustfmt";
+              category = "rust";
+              help = "Rust formatting tool";
+              package = rust-toolchain;
+            }
+            {
+              name = "avrdude";
+              category = "avr";
+              help = "Programmer for AVR chips";
+              package = pkgs.avrdude;
+            }
+            {
+              name = "ravedude";
+              category = "avr";
+              help = "Rust adapter for flashing with avrdude";
+              package = pkgs.ravedude;
+            }
+            {
+              name = "avr-gcc";
+              category = "avr";
+              help = "AVR C/C++ compiler (used for linking)";
+              package = c-compiler;
+            }
+          ];
+        });
+    });
+}

--- a/ravedude/flake.lock
+++ b/ravedude/flake.lock
@@ -1,15 +1,34 @@
 {
   "nodes": {
-    "naersk": {
+    "fenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1679567394,
-        "narHash": "sha256-ZvLuzPeARDLiQUt6zSZFGOs+HZmE+3g4QURc8mkBsfM=",
+        "lastModified": 1746167999,
+        "narHash": "sha256-18XGHsjk/5H8F0OGUCG56CeeW1u6qQ7tAfQK3azlwWg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "bcbc23a4f3391c1c3657f1847cb693aaea3aed76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1745925850,
+        "narHash": "sha256-cyAAMal0aPrlb1NgzMxZqeN1mAJ2pJseDhm2m6Um8T0=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "88cd22380154a2c36799fe8098888f0f59861a15",
+        "rev": "38bc60bbc157ae266d4a0c96671c6c742ee17a5f",
         "type": "github"
       },
       "original": {
@@ -20,21 +39,41 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-eOnCn0o3I6LP48fAi8xWFcn49V2rL7oX5jCtJTeN1LI=",
-        "path": "/nix/store/jcb1zr0g47d0cd13jfvg64fwczy2cfd7-source",
-        "type": "path"
+        "lastModified": 1746064326,
+        "narHash": "sha256-r7IZkN9NhK/IO9/J6D9ih2P1OXb67nr5HaQ1YAte18w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "91bf6dffa21c7709607c9fdbf9a6acb44e7a0a5d",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1746152631,
+        "narHash": "sha256-zBuvmL6+CUsk2J8GINpyy8Hs1Zp4PP6iBWSmZ4SCQ/s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "032bc6539bd5f14e9d0c51bd79cfe9a055b094c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 0,
-        "narHash": "sha256-eOnCn0o3I6LP48fAi8xWFcn49V2rL7oX5jCtJTeN1LI=",
-        "path": "/nix/store/jcb1zr0g47d0cd13jfvg64fwczy2cfd7-source",
+        "narHash": "sha256-NxYmSysMkQ+8bUZzRFyN+mqFdZ9bv9Bb9gwgCKQcCZU=",
+        "path": "/nix/store/iqjfrk4wpry4z7vnjq06l4nsbfiqf2kx-source",
         "type": "path"
       },
       "original": {
@@ -44,18 +83,54 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "utils": "utils"
       }
     },
-    "utils": {
+    "rust-analyzer-src": {
+      "flake": false,
       "locked": {
-        "lastModified": 1680776469,
-        "narHash": "sha256-3CXUDK/3q/kieWtdsYpDOBJw3Gw4Af6x+2EiSnIkNQw=",
+        "lastModified": 1746093169,
+        "narHash": "sha256-3gmUmzIzfzlgF/b4HXvtoBIP4bKofVeEubX7LcPBYLo=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "298fa81aacda7b06de4db55c377b1aa081906bc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "411e8764155aa9354dbcd6d5faaeb97e9e3dce24",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/ravedude/flake.nix
+++ b/ravedude/flake.nix
@@ -1,27 +1,28 @@
 {
   inputs = {
-    utils = {
-      url = "github:numtide/flake-utils";
-    };
-
-    naersk = {
-      url = "github:nix-community/naersk";
-    };
+    utils.url = "github:numtide/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+    fenix.url = "github:nix-community/fenix";
   };
 
-  outputs = { self, nixpkgs, utils, naersk }:
+  outputs = { nixpkgs, utils, naersk, fenix, ... }:
     utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
+          overlays = [ fenix.overlays.default ];
         };
-
-        naersk' = pkgs.callPackage naersk {};
-
         lib = pkgs.lib;
 
-      in
-      rec {
+        rust-toolchain = pkgs.fenix.fromToolchainFile {
+          file = ./rust-toolchain.toml;
+          sha256 = "X/4ZBHO3iW0fOenQ3foEvscgAPJYl2abspaBThDOukI=";
+        };
+        naersk' = pkgs.callPackage naersk {
+          cargo = rust-toolchain;
+          rustc = rust-toolchain;
+        };
+      in {
         packages.default = naersk'.buildPackage {
           pname = "ravedude";
           src = ./.;

--- a/ravedude/rust-toolchain.toml
+++ b/ravedude/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "stable-2025-04-03"
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,11 @@
 [toolchain]
 channel = "nightly-2025-04-27"
-components = [ "rust-src" ]
+components = [
+    "rustc",
+    "cargo",
+    "clippy",
+    "rustfmt",
+    "rust-src",
+    "rust-analyzer",
+]
 profile = "minimal"


### PR DESCRIPTION
Fix #632. I asked there if the second commit of this PR would be accepted, but let's move the discussion here.

This PR updates the ravedude flake and revises it to follow `ravedude/rust-toolchain.toml`. It also adds the latest stable date to the toolchain, to avoid silently using the older version if it's not in the locked `fenix` input (also because it is generally good to specify the date).

Beyond that, it adds a Nix development shell to the root, which similarly follows `rust-toolchain.toml` and provides runtime programs like avr-gcc too. It does not build the project, just helps testing it. For convenience, minimal descriptions of each relevant command are printed when the user enters the shell, since it's built-in functionality of `devshell`.