### PR TITLE
fix ping_device hanging in read mode

### DIFF
--- a/avr-hal-generic/src/i2c.rs
+++ b/avr-hal-generic/src/i2c.rs
@@ -289,6 +289,9 @@ where
     pub fn ping_device(&mut self, address: u8, direction: Direction) -> Result<bool, Error> {
         match self.p.raw_start(address, direction) {
             Ok(_) => {
+                if direction == Direction::Read {
+                    self.p.raw_read(&mut [0], true)?
+                }
                 self.p.raw_stop()?;
                 Ok(true)
             }


### PR DESCRIPTION
This fixes a part of #622 (i2cdetect getting stuck)

It looks like you need to actually read after requesting data, otherwise something breaks in the i2c implementation and the next operation will just get stuck forever