### PR TITLE
Add option to specify serial port distinct from programming port

### DIFF
--- a/ravedude/src/config.rs
+++ b/ravedude/src/config.rs
@@ -108,6 +108,9 @@ impl RavedudeGeneralConfig {
         if args.open_console {
             self.open_console = true;
         }
+        if let Some(console_port) = args.console_port.clone() {
+            self.console_port = Some(console_port);
+        }
         if let Some(serial_baudrate) = args.baudrate {
             self.serial_baudrate = Some(
                 NonZeroU32::new(serial_baudrate)

--- a/ravedude/src/config.rs
+++ b/ravedude/src/config.rs
@@ -39,6 +39,7 @@ impl RavedudeConfig {
         Ok(Self {
             general_options: RavedudeGeneralConfig {
                 open_console: args.open_console,
+                console_port: args.console_port.clone(),
                 serial_baudrate: match args.baudrate {
                     Some(serial_baudrate) => Some(
                         NonZeroU32::new(serial_baudrate)
@@ -90,6 +91,7 @@ impl RavedudeGeneralConfig {
 pub struct RavedudeGeneralConfig {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub open_console: bool,
+    pub console_port: Option<std::path::PathBuf>,
     pub serial_baudrate: Option<NonZeroU32>,
     pub port: Option<std::path::PathBuf>,
     pub reset_delay: Option<u64>,

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -130,7 +130,12 @@ struct Args {
     #[clap(short = 'c', long = "open-console")]
     open_console: bool,
 
-    #[clap(short = 'C', long = "console-port", value_parser, env = "RAVEDUDE_CONSOLE_PORT")]
+    #[clap(
+        short = 'C',
+        long = "console-port",
+        value_parser,
+        env = "RAVEDUDE_CONSOLE_PORT"
+    )]
     console_port: Option<std::path::PathBuf>,
 
     /// Baudrate which should be used for the serial console.
@@ -346,7 +351,9 @@ fn ravedude() -> anyhow::Result<()> {
                 "-b/--baudrate is needed for the serial console"
             })?;
 
-        let port = console_port.or_else(|| port).context("console can only be opened for devices with USB-to-Serial")?;
+        let port = console_port
+            .or_else(|| port)
+            .context("console can only be opened for devices with USB-to-Serial")?;
         let newline_mode = ravedude_config.general_options.newline_mode()?;
 
         task_message!("Console", "{} at {} baud", port.display(), baudrate);

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -294,8 +294,6 @@ fn ravedude() -> anyhow::Result<()> {
         },
     }?;
 
-    let console_port = ravedude_config.general_options.console_port.clone();
-
     if let Some(bin) = args.bin_or_legacy_bin() {
         if let Some(wait_time) = args.reset_delay {
             if wait_time > 0 {
@@ -351,9 +349,11 @@ fn ravedude() -> anyhow::Result<()> {
                 "-b/--baudrate is needed for the serial console"
             })?;
 
+        let console_port = ravedude_config.general_options.console_port.clone();
         let port = console_port
             .or_else(|| port)
-            .context("console can only be opened for devices with USB-to-Serial")?;
+            .context("no programmer serial port or `console-port` was set")
+            .context("cannot open console without a serial port")?;
         let newline_mode = ravedude_config.general_options.newline_mode()?;
 
         task_message!("Console", "{} at {} baud", port.display(), baudrate);

--- a/ravedude/src/main.rs
+++ b/ravedude/src/main.rs
@@ -130,6 +130,9 @@ struct Args {
     #[clap(short = 'c', long = "open-console")]
     open_console: bool,
 
+    #[clap(short = 'C', long = "console-port", value_parser, env = "RAVEDUDE_CONSOLE_PORT")]
+    console_port: Option<std::path::PathBuf>,
+
     /// Baudrate which should be used for the serial console.
     #[clap(short = 'b', long = "baudrate")]
     baudrate: Option<u32>,
@@ -286,6 +289,8 @@ fn ravedude() -> anyhow::Result<()> {
         },
     }?;
 
+    let console_port = ravedude_config.general_options.console_port.clone();
+
     if let Some(bin) = args.bin_or_legacy_bin() {
         if let Some(wait_time) = args.reset_delay {
             if wait_time > 0 {
@@ -341,7 +346,7 @@ fn ravedude() -> anyhow::Result<()> {
                 "-b/--baudrate is needed for the serial console"
             })?;
 
-        let port = port.context("console can only be opened for devices with USB-to-Serial")?;
+        let port = console_port.or_else(|| port).context("console can only be opened for devices with USB-to-Serial")?;
         let newline_mode = ravedude_config.general_options.newline_mode()?;
 
         task_message!("Console", "{} at {} baud", port.display(), baudrate);


### PR DESCRIPTION
possibly addresses https://github.com/Rahix/avr-hal/issues/577

usecase: i have an atmel-ice for programming using icsp, but i want to monitor the serial port using a silicon labs cp2102 usb->serial cable

this patch allows specifying the com port for the serial console separately from the programmer which in my case does not provide a serial port