### PR TITLE
Fail loudly when I2C frequency too slow

### DIFF
--- a/avr-hal-generic/src/i2c.rs
+++ b/avr-hal-generic/src/i2c.rs
@@ -478,7 +478,8 @@ macro_rules! impl_i2c_twi {
             fn raw_setup<CLOCK: $crate::clock::Clock>(&mut self, speed: u32) {
                 // Calculate TWBR register value
                 let twbr = ((CLOCK::FREQ / speed) - 16) / 2;
-                self.twbr.write(|w| unsafe { w.bits(twbr as u8) });
+                self.twbr
+                    .write(|w| unsafe { w.bits(twbr.try_into().unwrap()) });
 
                 // Disable prescaler
                 self.twsr.write(|w| w.twps().prescaler_1());


### PR DESCRIPTION
This makes sure that, if the I2C frequency chosen by the user is too slow to be handled without selecting a different prescaler, the issue doesn't get hidden by silent integer overflow.